### PR TITLE
Allow additional props and utilise latest gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ SPEC_PATCHED_FILE:=spec/oas3.patched.json
 OPENAPI_CONFIG:=spec/oas3.config.json
 OPENAPI_GENERATED_CLIENT=equinix-openapi-metal/
 
-OPENAPI_CODEGEN_TAG=v6.0.1
+OPENAPI_CODEGEN_TAG=latest
+OPENAPI_CODEGEN_BRANCH=master
 
 # Patches
-
 SPEC_FETCHED_PATCHES=patches/spec.fetched.json
 
 ##
@@ -36,7 +36,7 @@ OPENAPI_GIT_JAR=modules/openapi-generator-cli/target/openapi-generator-cli.jar
 git_run: pre-common clone git_generate post-common
 
 clone:
-	git clone ${OPENAPI_GIT_URL} --branch ${OPENAPI_CODEGEN_TAG} --single-branch
+	git clone ${OPENAPI_GIT_URL} --branch ${OPENAPI_CODEGEN_BRANCH} --single-branch
 	cd ${OPENAPI_GIT_DIR}; mvn clean package
 
 git_generate:

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/ApiClient.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/ApiClient.java
@@ -883,6 +883,8 @@ public class ApiClient {
                 content = null;
             }
             return RequestBody.create(content, MediaType.parse(contentType));
+        } else if (obj instanceof String) {
+            return RequestBody.create(MediaType.parse(contentType), (String) obj);
         } else {
             throw new ApiException("Content type \"" + contentType + "\" is not supported");
         }
@@ -1302,11 +1304,12 @@ public class ApiClient {
                 for (Object item: list) {
                     if (item instanceof File) {
                         addPartToMultiPartBuilder(mpBuilder, param.getKey(), (File) item);
+                    } else {
+                        addPartToMultiPartBuilder(mpBuilder, param.getKey(), param.getValue());
                     }
                 }
             } else {
-                Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + param.getKey() + "\"");
-                mpBuilder.addPart(partHeaders, RequestBody.create(parameterToString(param.getValue()), null));
+                addPartToMultiPartBuilder(mpBuilder, param.getKey(), param.getValue());
             }
         }
         return mpBuilder.build();
@@ -1338,6 +1341,31 @@ public class ApiClient {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
+    }
+
+    /**
+     * Add a Content-Disposition Header for the given key and complex object to the MultipartBody Builder.
+     *
+     * @param mpBuilder MultipartBody.Builder
+     * @param key The key of the Header element
+     * @param obj The complex object to add to the Header
+     */
+    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+        RequestBody requestBody;
+        if (obj instanceof String) {
+            requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
+        } else {
+            String content;
+            if (obj != null) {
+                content = json.serialize(obj);
+            } else {
+                content = null;
+            }
+            requestBody = RequestBody.create(content, MediaType.parse("application/json"));
+        }
+
+        Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"");
+        mpBuilder.addPart(partHeaders, requestBody);
     }
 
     /**
@@ -1440,7 +1468,7 @@ public class ApiClient {
     /**
      * Convert the HTTP request body to a string.
      *
-     * @param request The HTTP request object
+     * @param requestBody The HTTP request object
      * @return The string representation of the HTTP request body
      * @throws com.equinix.openapi.ApiException If fail to serialize the request body object into a string
      */

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Address.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Address.java
@@ -78,7 +78,7 @@ public class Address {
   @SerializedName(SERIALIZED_NAME_ZIP_CODE)
   private String zipCode;
 
-  public Address() { 
+  public Address() {
   }
 
   public Address address(String address) {
@@ -241,6 +241,41 @@ public class Address {
     this.zipCode = zipCode;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Address putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -258,12 +293,13 @@ public class Address {
         Objects.equals(this.coordinates, address.coordinates) &&
         Objects.equals(this.country, address.country) &&
         Objects.equals(this.state, address.state) &&
-        Objects.equals(this.zipCode, address.zipCode);
+        Objects.equals(this.zipCode, address.zipCode)&&
+        Objects.equals(this.additionalProperties, address.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, address2, city, coordinates, country, state, zipCode);
+    return Objects.hash(address, address2, city, coordinates, country, state, zipCode, additionalProperties);
   }
 
   @Override
@@ -277,6 +313,7 @@ public class Address {
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    zipCode: ").append(toIndentedString(zipCode)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -329,40 +366,32 @@ public class Address {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Address.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Address` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : Address.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonPrimitive()) {
+      if ((jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) && !jsonObj.get("address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address").toString()));
       }
-      if (jsonObj.get("address2") != null && !jsonObj.get("address2").isJsonPrimitive()) {
+      if ((jsonObj.get("address2") != null && !jsonObj.get("address2").isJsonNull()) && !jsonObj.get("address2").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address2` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address2").toString()));
       }
-      if (jsonObj.get("city") != null && !jsonObj.get("city").isJsonPrimitive()) {
+      if ((jsonObj.get("city") != null && !jsonObj.get("city").isJsonNull()) && !jsonObj.get("city").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `city` to be a primitive type in the JSON string but got `%s`", jsonObj.get("city").toString()));
       }
       // validate the optional field `coordinates`
-      if (jsonObj.getAsJsonObject("coordinates") != null) {
+      if (jsonObj.get("coordinates") != null && !jsonObj.get("coordinates").isJsonNull()) {
         Coordinates.validateJsonObject(jsonObj.getAsJsonObject("coordinates"));
       }
-      if (jsonObj.get("country") != null && !jsonObj.get("country").isJsonPrimitive()) {
+      if ((jsonObj.get("country") != null && !jsonObj.get("country").isJsonNull()) && !jsonObj.get("country").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country").toString()));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
-      if (jsonObj.get("zip_code") != null && !jsonObj.get("zip_code").isJsonPrimitive()) {
+      if ((jsonObj.get("zip_code") != null && !jsonObj.get("zip_code").isJsonNull()) && !jsonObj.get("zip_code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `zip_code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("zip_code").toString()));
       }
   }
@@ -382,6 +411,23 @@ public class Address {
            @Override
            public void write(JsonWriter out, Address value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -389,7 +435,25 @@ public class Address {
            public Address read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Address instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthToken.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthToken.java
@@ -85,7 +85,7 @@ public class AuthToken {
   @SerializedName(SERIALIZED_NAME_USER)
   private AuthTokenUser user;
 
-  public AuthToken() { 
+  public AuthToken() {
   }
 
   public AuthToken createdAt(OffsetDateTime createdAt) {
@@ -271,6 +271,41 @@ public class AuthToken {
     this.user = user;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public AuthToken putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -289,12 +324,13 @@ public class AuthToken {
         Objects.equals(this.readOnly, authToken.readOnly) &&
         Objects.equals(this.token, authToken.token) &&
         Objects.equals(this.updatedAt, authToken.updatedAt) &&
-        Objects.equals(this.user, authToken.user);
+        Objects.equals(this.user, authToken.user)&&
+        Objects.equals(this.additionalProperties, authToken.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, description, id, project, readOnly, token, updatedAt, user);
+    return Objects.hash(createdAt, description, id, project, readOnly, token, updatedAt, user, additionalProperties);
   }
 
   @Override
@@ -309,6 +345,7 @@ public class AuthToken {
     sb.append("    token: ").append(toIndentedString(token)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    user: ").append(toIndentedString(user)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -358,29 +395,21 @@ public class AuthToken {
           throw new IllegalArgumentException(String.format("The required field(s) %s in AuthToken is not found in the empty JSON string", AuthToken.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!AuthToken.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AuthToken` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         AuthTokenProject.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("token") != null && !jsonObj.get("token").isJsonPrimitive()) {
+      if ((jsonObj.get("token") != null && !jsonObj.get("token").isJsonNull()) && !jsonObj.get("token").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `token` to be a primitive type in the JSON string but got `%s`", jsonObj.get("token").toString()));
       }
       // validate the optional field `user`
-      if (jsonObj.getAsJsonObject("user") != null) {
+      if (jsonObj.get("user") != null && !jsonObj.get("user").isJsonNull()) {
         AuthTokenUser.validateJsonObject(jsonObj.getAsJsonObject("user"));
       }
   }
@@ -400,6 +429,23 @@ public class AuthToken {
            @Override
            public void write(JsonWriter out, AuthToken value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -407,7 +453,25 @@ public class AuthToken {
            public AuthToken read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             AuthToken instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenInput.java
@@ -57,7 +57,7 @@ public class AuthTokenInput {
   @SerializedName(SERIALIZED_NAME_READ_ONLY)
   private Boolean readOnly;
 
-  public AuthTokenInput() { 
+  public AuthTokenInput() {
   }
 
   public AuthTokenInput description(String description) {
@@ -105,6 +105,41 @@ public class AuthTokenInput {
     this.readOnly = readOnly;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public AuthTokenInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -117,12 +152,13 @@ public class AuthTokenInput {
     }
     AuthTokenInput authTokenInput = (AuthTokenInput) o;
     return Objects.equals(this.description, authTokenInput.description) &&
-        Objects.equals(this.readOnly, authTokenInput.readOnly);
+        Objects.equals(this.readOnly, authTokenInput.readOnly)&&
+        Objects.equals(this.additionalProperties, authTokenInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, readOnly);
+    return Objects.hash(description, readOnly, additionalProperties);
   }
 
   @Override
@@ -131,6 +167,7 @@ public class AuthTokenInput {
     sb.append("class AuthTokenInput {\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    readOnly: ").append(toIndentedString(readOnly)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -174,15 +211,7 @@ public class AuthTokenInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in AuthTokenInput is not found in the empty JSON string", AuthTokenInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!AuthTokenInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AuthTokenInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
   }
@@ -202,6 +231,23 @@ public class AuthTokenInput {
            @Override
            public void write(JsonWriter out, AuthTokenInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -209,7 +255,25 @@ public class AuthTokenInput {
            public AuthTokenInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             AuthTokenInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenList.java
@@ -56,7 +56,7 @@ public class AuthTokenList {
   @SerializedName(SERIALIZED_NAME_API_KEYS)
   private List<AuthToken> apiKeys = null;
 
-  public AuthTokenList() { 
+  public AuthTokenList() {
   }
 
   public AuthTokenList apiKeys(List<AuthToken> apiKeys) {
@@ -89,6 +89,41 @@ public class AuthTokenList {
     this.apiKeys = apiKeys;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public AuthTokenList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class AuthTokenList {
       return false;
     }
     AuthTokenList authTokenList = (AuthTokenList) o;
-    return Objects.equals(this.apiKeys, authTokenList.apiKeys);
+    return Objects.equals(this.apiKeys, authTokenList.apiKeys)&&
+        Objects.equals(this.additionalProperties, authTokenList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(apiKeys);
+    return Objects.hash(apiKeys, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class AuthTokenList {
     StringBuilder sb = new StringBuilder();
     sb.append("class AuthTokenList {\n");
     sb.append("    apiKeys: ").append(toIndentedString(apiKeys)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class AuthTokenList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in AuthTokenList is not found in the empty JSON string", AuthTokenList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!AuthTokenList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AuthTokenList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayapiKeys = jsonObj.getAsJsonArray("api_keys");
       if (jsonArrayapiKeys != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class AuthTokenList {
            @Override
            public void write(JsonWriter out, AuthTokenList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class AuthTokenList {
            public AuthTokenList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             AuthTokenList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenProject.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenProject.java
@@ -16,7 +16,6 @@ package com.equinix.openapi.metal.v1.model;
 import java.util.Objects;
 import java.util.Arrays;
 import com.equinix.openapi.metal.v1.model.Href;
-import com.equinix.openapi.metal.v1.model.Project;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -115,7 +114,7 @@ public class AuthTokenProject {
   @SerializedName(SERIALIZED_NAME_VOLUMES)
   private List<Href> volumes = null;
 
-  public AuthTokenProject() { 
+  public AuthTokenProject() {
   }
 
   public AuthTokenProject bgpConfig(Href bgpConfig) {
@@ -510,6 +509,41 @@ public class AuthTokenProject {
     this.volumes = volumes;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public AuthTokenProject putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -535,12 +569,13 @@ public class AuthTokenProject {
         Objects.equals(this.paymentMethod, authTokenProject.paymentMethod) &&
         Objects.equals(this.sshKeys, authTokenProject.sshKeys) &&
         Objects.equals(this.updatedAt, authTokenProject.updatedAt) &&
-        Objects.equals(this.volumes, authTokenProject.volumes);
+        Objects.equals(this.volumes, authTokenProject.volumes)&&
+        Objects.equals(this.additionalProperties, authTokenProject.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bgpConfig, createdAt, customdata, devices, id, invitations, maxDevices, members, memberships, name, networkStatus, paymentMethod, sshKeys, updatedAt, volumes);
+    return Objects.hash(bgpConfig, createdAt, customdata, devices, id, invitations, maxDevices, members, memberships, name, networkStatus, paymentMethod, sshKeys, updatedAt, volumes, additionalProperties);
   }
 
   @Override
@@ -562,6 +597,7 @@ public class AuthTokenProject {
     sb.append("    sshKeys: ").append(toIndentedString(sshKeys)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    volumes: ").append(toIndentedString(volumes)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -618,16 +654,8 @@ public class AuthTokenProject {
           throw new IllegalArgumentException(String.format("The required field(s) %s in AuthTokenProject is not found in the empty JSON string", AuthTokenProject.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!AuthTokenProject.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AuthTokenProject` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `bgp_config`
-      if (jsonObj.getAsJsonObject("bgp_config") != null) {
+      if (jsonObj.get("bgp_config") != null && !jsonObj.get("bgp_config").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("bgp_config"));
       }
       JsonArray jsonArraydevices = jsonObj.getAsJsonArray("devices");
@@ -642,7 +670,7 @@ public class AuthTokenProject {
           Href.validateJsonObject(jsonArraydevices.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       JsonArray jsonArrayinvitations = jsonObj.getAsJsonArray("invitations");
@@ -681,11 +709,11 @@ public class AuthTokenProject {
           Href.validateJsonObject(jsonArraymemberships.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       // validate the optional field `payment_method`
-      if (jsonObj.getAsJsonObject("payment_method") != null) {
+      if (jsonObj.get("payment_method") != null && !jsonObj.get("payment_method").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("payment_method"));
       }
       JsonArray jsonArraysshKeys = jsonObj.getAsJsonArray("ssh_keys");
@@ -729,6 +757,23 @@ public class AuthTokenProject {
            @Override
            public void write(JsonWriter out, AuthTokenProject value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -736,7 +781,25 @@ public class AuthTokenProject {
            public AuthTokenProject read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             AuthTokenProject instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenUser.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenUser.java
@@ -16,7 +16,6 @@ package com.equinix.openapi.metal.v1.model;
 import java.util.Objects;
 import java.util.Arrays;
 import com.equinix.openapi.metal.v1.model.Href;
-import com.equinix.openapi.metal.v1.model.User;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -135,7 +134,7 @@ public class AuthTokenUser {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public AuthTokenUser() { 
+  public AuthTokenUser() {
   }
 
   public AuthTokenUser avatarThumbUrl(String avatarThumbUrl) {
@@ -605,6 +604,41 @@ public class AuthTokenUser {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public AuthTokenUser putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -635,12 +669,13 @@ public class AuthTokenUser {
         Objects.equals(this.shortId, authTokenUser.shortId) &&
         Objects.equals(this.timezone, authTokenUser.timezone) &&
         Objects.equals(this.twoFactorAuth, authTokenUser.twoFactorAuth) &&
-        Objects.equals(this.updatedAt, authTokenUser.updatedAt);
+        Objects.equals(this.updatedAt, authTokenUser.updatedAt)&&
+        Objects.equals(this.additionalProperties, authTokenUser.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(avatarThumbUrl, avatarUrl, createdAt, customdata, email, emails, firstName, fraudScore, fullName, href, id, lastLoginAt, lastName, maxOrganizations, maxProjects, phoneNumber, shortId, timezone, twoFactorAuth, updatedAt);
+    return Objects.hash(avatarThumbUrl, avatarUrl, createdAt, customdata, email, emails, firstName, fraudScore, fullName, href, id, lastLoginAt, lastName, maxOrganizations, maxProjects, phoneNumber, shortId, timezone, twoFactorAuth, updatedAt, additionalProperties);
   }
 
   @Override
@@ -667,6 +702,7 @@ public class AuthTokenUser {
     sb.append("    timezone: ").append(toIndentedString(timezone)).append("\n");
     sb.append("    twoFactorAuth: ").append(toIndentedString(twoFactorAuth)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -728,21 +764,13 @@ public class AuthTokenUser {
           throw new IllegalArgumentException(String.format("The required field(s) %s in AuthTokenUser is not found in the empty JSON string", AuthTokenUser.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!AuthTokenUser.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AuthTokenUser` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
+      if ((jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonNull()) && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `avatar_thumb_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("avatar_thumb_url").toString()));
       }
-      if (jsonObj.get("avatar_url") != null && !jsonObj.get("avatar_url").isJsonPrimitive()) {
+      if ((jsonObj.get("avatar_url") != null && !jsonObj.get("avatar_url").isJsonNull()) && !jsonObj.get("avatar_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `avatar_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("avatar_url").toString()));
       }
-      if (jsonObj.get("email") != null && !jsonObj.get("email").isJsonPrimitive()) {
+      if ((jsonObj.get("email") != null && !jsonObj.get("email").isJsonNull()) && !jsonObj.get("email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
       }
       JsonArray jsonArrayemails = jsonObj.getAsJsonArray("emails");
@@ -757,34 +785,34 @@ public class AuthTokenUser {
           Href.validateJsonObject(jsonArrayemails.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonPrimitive()) {
+      if ((jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonNull()) && !jsonObj.get("first_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `first_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("first_name").toString()));
       }
-      if (jsonObj.get("fraud_score") != null && !jsonObj.get("fraud_score").isJsonPrimitive()) {
+      if ((jsonObj.get("fraud_score") != null && !jsonObj.get("fraud_score").isJsonNull()) && !jsonObj.get("fraud_score").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `fraud_score` to be a primitive type in the JSON string but got `%s`", jsonObj.get("fraud_score").toString()));
       }
-      if (jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonPrimitive()) {
+      if ((jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonNull()) && !jsonObj.get("full_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `full_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("full_name").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonPrimitive()) {
+      if ((jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonNull()) && !jsonObj.get("last_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `last_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("last_name").toString()));
       }
-      if (jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonPrimitive()) {
+      if ((jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonNull()) && !jsonObj.get("phone_number").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `phone_number` to be a primitive type in the JSON string but got `%s`", jsonObj.get("phone_number").toString()));
       }
-      if (jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonPrimitive()) {
+      if ((jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonNull()) && !jsonObj.get("short_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `short_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("short_id").toString()));
       }
-      if (jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonPrimitive()) {
+      if ((jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonNull()) && !jsonObj.get("timezone").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `timezone` to be a primitive type in the JSON string but got `%s`", jsonObj.get("timezone").toString()));
       }
-      if (jsonObj.get("two_factor_auth") != null && !jsonObj.get("two_factor_auth").isJsonPrimitive()) {
+      if ((jsonObj.get("two_factor_auth") != null && !jsonObj.get("two_factor_auth").isJsonNull()) && !jsonObj.get("two_factor_auth").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `two_factor_auth` to be a primitive type in the JSON string but got `%s`", jsonObj.get("two_factor_auth").toString()));
       }
   }
@@ -804,6 +832,23 @@ public class AuthTokenUser {
            @Override
            public void write(JsonWriter out, AuthTokenUser value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -811,7 +856,25 @@ public class AuthTokenUser {
            public AuthTokenUser read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             AuthTokenUser instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BGPSessionInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BGPSessionInput.java
@@ -104,7 +104,7 @@ public class BGPSessionInput {
   @SerializedName(SERIALIZED_NAME_DEFAULT_ROUTE)
   private Boolean defaultRoute = false;
 
-  public BGPSessionInput() { 
+  public BGPSessionInput() {
   }
 
   public BGPSessionInput addressFamily(AddressFamilyEnum addressFamily) {
@@ -152,6 +152,41 @@ public class BGPSessionInput {
     this.defaultRoute = defaultRoute;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BGPSessionInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -164,12 +199,13 @@ public class BGPSessionInput {
     }
     BGPSessionInput bgPSessionInput = (BGPSessionInput) o;
     return Objects.equals(this.addressFamily, bgPSessionInput.addressFamily) &&
-        Objects.equals(this.defaultRoute, bgPSessionInput.defaultRoute);
+        Objects.equals(this.defaultRoute, bgPSessionInput.defaultRoute)&&
+        Objects.equals(this.additionalProperties, bgPSessionInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, defaultRoute);
+    return Objects.hash(addressFamily, defaultRoute, additionalProperties);
   }
 
   @Override
@@ -178,6 +214,7 @@ public class BGPSessionInput {
     sb.append("class BGPSessionInput {\n");
     sb.append("    addressFamily: ").append(toIndentedString(addressFamily)).append("\n");
     sb.append("    defaultRoute: ").append(toIndentedString(defaultRoute)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -221,15 +258,7 @@ public class BGPSessionInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BGPSessionInput is not found in the empty JSON string", BGPSessionInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BGPSessionInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BGPSessionInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("address_family") != null && !jsonObj.get("address_family").isJsonPrimitive()) {
+      if ((jsonObj.get("address_family") != null && !jsonObj.get("address_family").isJsonNull()) && !jsonObj.get("address_family").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address_family` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address_family").toString()));
       }
   }
@@ -249,6 +278,23 @@ public class BGPSessionInput {
            @Override
            public void write(JsonWriter out, BGPSessionInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -256,7 +302,25 @@ public class BGPSessionInput {
            public BGPSessionInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BGPSessionInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Batch.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Batch.java
@@ -86,7 +86,7 @@ public class Batch {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public Batch() { 
+  public Batch() {
   }
 
   public Batch createdAt(OffsetDateTime createdAt) {
@@ -288,6 +288,41 @@ public class Batch {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Batch putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -306,12 +341,13 @@ public class Batch {
         Objects.equals(this.project, batch.project) &&
         Objects.equals(this.quantity, batch.quantity) &&
         Objects.equals(this.state, batch.state) &&
-        Objects.equals(this.updatedAt, batch.updatedAt);
+        Objects.equals(this.updatedAt, batch.updatedAt)&&
+        Objects.equals(this.additionalProperties, batch.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, devices, errorMessages, id, project, quantity, state, updatedAt);
+    return Objects.hash(createdAt, devices, errorMessages, id, project, quantity, state, updatedAt, additionalProperties);
   }
 
   @Override
@@ -326,6 +362,7 @@ public class Batch {
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -375,14 +412,6 @@ public class Batch {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Batch is not found in the empty JSON string", Batch.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Batch.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Batch` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraydevices = jsonObj.getAsJsonArray("devices");
       if (jsonArraydevices != null) {
         // ensure the json data is an array
@@ -396,17 +425,17 @@ public class Batch {
         };
       }
       // ensure the json data is an array
-      if (jsonObj.get("error_messages") != null && !jsonObj.get("error_messages").isJsonArray()) {
+      if ((jsonObj.get("error_messages") != null && !jsonObj.get("error_messages").isJsonNull()) && !jsonObj.get("error_messages").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `error_messages` to be an array in the JSON string but got `%s`", jsonObj.get("error_messages").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
   }
@@ -426,6 +455,23 @@ public class Batch {
            @Override
            public void write(JsonWriter out, Batch value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -433,7 +479,25 @@ public class Batch {
            public Batch read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Batch instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BatchesList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BatchesList.java
@@ -56,7 +56,7 @@ public class BatchesList {
   @SerializedName(SERIALIZED_NAME_BATCHES)
   private List<Batch> batches = null;
 
-  public BatchesList() { 
+  public BatchesList() {
   }
 
   public BatchesList batches(List<Batch> batches) {
@@ -89,6 +89,41 @@ public class BatchesList {
     this.batches = batches;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BatchesList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class BatchesList {
       return false;
     }
     BatchesList batchesList = (BatchesList) o;
-    return Objects.equals(this.batches, batchesList.batches);
+    return Objects.equals(this.batches, batchesList.batches)&&
+        Objects.equals(this.additionalProperties, batchesList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(batches);
+    return Objects.hash(batches, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class BatchesList {
     StringBuilder sb = new StringBuilder();
     sb.append("class BatchesList {\n");
     sb.append("    batches: ").append(toIndentedString(batches)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class BatchesList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BatchesList is not found in the empty JSON string", BatchesList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BatchesList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BatchesList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraybatches = jsonObj.getAsJsonArray("batches");
       if (jsonArraybatches != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class BatchesList {
            @Override
            public void write(JsonWriter out, BatchesList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class BatchesList {
            public BatchesList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BatchesList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfig.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfig.java
@@ -205,7 +205,7 @@ public class BgpConfig {
   @SerializedName(SERIALIZED_NAME_STATUS)
   private StatusEnum status;
 
-  public BgpConfig() { 
+  public BgpConfig() {
   }
 
   public BgpConfig asn(Integer asn) {
@@ -522,6 +522,41 @@ public class BgpConfig {
     this.status = status;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpConfig putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -545,7 +580,8 @@ public class BgpConfig {
         Objects.equals(this.requestedAt, bgpConfig.requestedAt) &&
         Objects.equals(this.routeObject, bgpConfig.routeObject) &&
         Objects.equals(this.sessions, bgpConfig.sessions) &&
-        Objects.equals(this.status, bgpConfig.status);
+        Objects.equals(this.status, bgpConfig.status)&&
+        Objects.equals(this.additionalProperties, bgpConfig.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -554,7 +590,7 @@ public class BgpConfig {
 
   @Override
   public int hashCode() {
-    return Objects.hash(asn, createdAt, deploymentType, href, id, maxPrefix, md5, project, ranges, requestedAt, routeObject, sessions, status);
+    return Objects.hash(asn, createdAt, deploymentType, href, id, maxPrefix, md5, project, ranges, requestedAt, routeObject, sessions, status, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -581,6 +617,7 @@ public class BgpConfig {
     sb.append("    routeObject: ").append(toIndentedString(routeObject)).append("\n");
     sb.append("    sessions: ").append(toIndentedString(sessions)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -635,28 +672,20 @@ public class BgpConfig {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BgpConfig is not found in the empty JSON string", BgpConfig.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpConfig.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpConfig` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("deployment_type") != null && !jsonObj.get("deployment_type").isJsonPrimitive()) {
+      if ((jsonObj.get("deployment_type") != null && !jsonObj.get("deployment_type").isJsonNull()) && !jsonObj.get("deployment_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `deployment_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("deployment_type").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonPrimitive()) {
+      if ((jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonNull()) && !jsonObj.get("md5").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `md5` to be a primitive type in the JSON string but got `%s`", jsonObj.get("md5").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
       JsonArray jsonArrayranges = jsonObj.getAsJsonArray("ranges");
@@ -671,7 +700,7 @@ public class BgpConfig {
           GlobalBgpRange.validateJsonObject(jsonArrayranges.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("route_object") != null && !jsonObj.get("route_object").isJsonPrimitive()) {
+      if ((jsonObj.get("route_object") != null && !jsonObj.get("route_object").isJsonNull()) && !jsonObj.get("route_object").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `route_object` to be a primitive type in the JSON string but got `%s`", jsonObj.get("route_object").toString()));
       }
       JsonArray jsonArraysessions = jsonObj.getAsJsonArray("sessions");
@@ -686,7 +715,7 @@ public class BgpConfig {
           BgpSession.validateJsonObject(jsonArraysessions.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonPrimitive()) {
+      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
   }
@@ -706,6 +735,23 @@ public class BgpConfig {
            @Override
            public void write(JsonWriter out, BgpConfig value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -713,7 +759,25 @@ public class BgpConfig {
            public BgpConfig read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpConfig instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfigRequestInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfigRequestInput.java
@@ -65,7 +65,7 @@ public class BgpConfigRequestInput {
   @SerializedName(SERIALIZED_NAME_USE_CASE)
   private String useCase;
 
-  public BgpConfigRequestInput() { 
+  public BgpConfigRequestInput() {
   }
 
   public BgpConfigRequestInput asn(Integer asn) {
@@ -159,6 +159,41 @@ public class BgpConfigRequestInput {
     this.useCase = useCase;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpConfigRequestInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -173,12 +208,13 @@ public class BgpConfigRequestInput {
     return Objects.equals(this.asn, bgpConfigRequestInput.asn) &&
         Objects.equals(this.deploymentType, bgpConfigRequestInput.deploymentType) &&
         Objects.equals(this.md5, bgpConfigRequestInput.md5) &&
-        Objects.equals(this.useCase, bgpConfigRequestInput.useCase);
+        Objects.equals(this.useCase, bgpConfigRequestInput.useCase)&&
+        Objects.equals(this.additionalProperties, bgpConfigRequestInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(asn, deploymentType, md5, useCase);
+    return Objects.hash(asn, deploymentType, md5, useCase, additionalProperties);
   }
 
   @Override
@@ -189,6 +225,7 @@ public class BgpConfigRequestInput {
     sb.append("    deploymentType: ").append(toIndentedString(deploymentType)).append("\n");
     sb.append("    md5: ").append(toIndentedString(md5)).append("\n");
     sb.append("    useCase: ").append(toIndentedString(useCase)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -237,27 +274,19 @@ public class BgpConfigRequestInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpConfigRequestInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpConfigRequestInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BgpConfigRequestInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("deployment_type") != null && !jsonObj.get("deployment_type").isJsonPrimitive()) {
+      if ((jsonObj.get("deployment_type") != null && !jsonObj.get("deployment_type").isJsonNull()) && !jsonObj.get("deployment_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `deployment_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("deployment_type").toString()));
       }
-      if (jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonPrimitive()) {
+      if ((jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonNull()) && !jsonObj.get("md5").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `md5` to be a primitive type in the JSON string but got `%s`", jsonObj.get("md5").toString()));
       }
-      if (jsonObj.get("use_case") != null && !jsonObj.get("use_case").isJsonPrimitive()) {
+      if ((jsonObj.get("use_case") != null && !jsonObj.get("use_case").isJsonNull()) && !jsonObj.get("use_case").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `use_case` to be a primitive type in the JSON string but got `%s`", jsonObj.get("use_case").toString()));
       }
   }
@@ -277,6 +306,23 @@ public class BgpConfigRequestInput {
            @Override
            public void write(JsonWriter out, BgpConfigRequestInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -284,7 +330,25 @@ public class BgpConfigRequestInput {
            public BgpConfigRequestInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpConfigRequestInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpNeighborData.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpNeighborData.java
@@ -94,7 +94,7 @@ public class BgpNeighborData {
   @SerializedName(SERIALIZED_NAME_ROUTES_OUT)
   private List<BgpNeighborDataRoutesOutInner> routesOut = null;
 
-  public BgpNeighborData() { 
+  public BgpNeighborData() {
   }
 
   public BgpNeighborData addressFamily(BigDecimal addressFamily) {
@@ -350,6 +350,41 @@ public class BgpNeighborData {
     this.routesOut = routesOut;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpNeighborData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -370,12 +405,13 @@ public class BgpNeighborData {
         Objects.equals(this.peerAs, bgpNeighborData.peerAs) &&
         Objects.equals(this.peerIps, bgpNeighborData.peerIps) &&
         Objects.equals(this.routesIn, bgpNeighborData.routesIn) &&
-        Objects.equals(this.routesOut, bgpNeighborData.routesOut);
+        Objects.equals(this.routesOut, bgpNeighborData.routesOut)&&
+        Objects.equals(this.additionalProperties, bgpNeighborData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, customerAs, customerIp, md5Enabled, md5Password, multihop, peerAs, peerIps, routesIn, routesOut);
+    return Objects.hash(addressFamily, customerAs, customerIp, md5Enabled, md5Password, multihop, peerAs, peerIps, routesIn, routesOut, additionalProperties);
   }
 
   @Override
@@ -392,6 +428,7 @@ public class BgpNeighborData {
     sb.append("    peerIps: ").append(toIndentedString(peerIps)).append("\n");
     sb.append("    routesIn: ").append(toIndentedString(routesIn)).append("\n");
     sb.append("    routesOut: ").append(toIndentedString(routesOut)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -443,22 +480,14 @@ public class BgpNeighborData {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BgpNeighborData is not found in the empty JSON string", BgpNeighborData.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpNeighborData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpNeighborData` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("customer_ip") != null && !jsonObj.get("customer_ip").isJsonPrimitive()) {
+      if ((jsonObj.get("customer_ip") != null && !jsonObj.get("customer_ip").isJsonNull()) && !jsonObj.get("customer_ip").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `customer_ip` to be a primitive type in the JSON string but got `%s`", jsonObj.get("customer_ip").toString()));
       }
-      if (jsonObj.get("md5_password") != null && !jsonObj.get("md5_password").isJsonPrimitive()) {
+      if ((jsonObj.get("md5_password") != null && !jsonObj.get("md5_password").isJsonNull()) && !jsonObj.get("md5_password").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `md5_password` to be a primitive type in the JSON string but got `%s`", jsonObj.get("md5_password").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("peer_ips") != null && !jsonObj.get("peer_ips").isJsonArray()) {
+      if ((jsonObj.get("peer_ips") != null && !jsonObj.get("peer_ips").isJsonNull()) && !jsonObj.get("peer_ips").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `peer_ips` to be an array in the JSON string but got `%s`", jsonObj.get("peer_ips").toString()));
       }
       JsonArray jsonArrayroutesIn = jsonObj.getAsJsonArray("routes_in");
@@ -502,6 +531,23 @@ public class BgpNeighborData {
            @Override
            public void write(JsonWriter out, BgpNeighborData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -509,7 +555,25 @@ public class BgpNeighborData {
            public BgpNeighborData read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpNeighborData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpNeighborDataRoutesInInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpNeighborDataRoutesInInner.java
@@ -57,7 +57,7 @@ public class BgpNeighborDataRoutesInInner {
   @SerializedName(SERIALIZED_NAME_ROUTE)
   private String route;
 
-  public BgpNeighborDataRoutesInInner() { 
+  public BgpNeighborDataRoutesInInner() {
   }
 
   public BgpNeighborDataRoutesInInner exact(Boolean exact) {
@@ -105,6 +105,41 @@ public class BgpNeighborDataRoutesInInner {
     this.route = route;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpNeighborDataRoutesInInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -117,12 +152,13 @@ public class BgpNeighborDataRoutesInInner {
     }
     BgpNeighborDataRoutesInInner bgpNeighborDataRoutesInInner = (BgpNeighborDataRoutesInInner) o;
     return Objects.equals(this.exact, bgpNeighborDataRoutesInInner.exact) &&
-        Objects.equals(this.route, bgpNeighborDataRoutesInInner.route);
+        Objects.equals(this.route, bgpNeighborDataRoutesInInner.route)&&
+        Objects.equals(this.additionalProperties, bgpNeighborDataRoutesInInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(exact, route);
+    return Objects.hash(exact, route, additionalProperties);
   }
 
   @Override
@@ -131,6 +167,7 @@ public class BgpNeighborDataRoutesInInner {
     sb.append("class BgpNeighborDataRoutesInInner {\n");
     sb.append("    exact: ").append(toIndentedString(exact)).append("\n");
     sb.append("    route: ").append(toIndentedString(route)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -174,15 +211,7 @@ public class BgpNeighborDataRoutesInInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BgpNeighborDataRoutesInInner is not found in the empty JSON string", BgpNeighborDataRoutesInInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpNeighborDataRoutesInInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpNeighborDataRoutesInInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("route") != null && !jsonObj.get("route").isJsonPrimitive()) {
+      if ((jsonObj.get("route") != null && !jsonObj.get("route").isJsonNull()) && !jsonObj.get("route").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `route` to be a primitive type in the JSON string but got `%s`", jsonObj.get("route").toString()));
       }
   }
@@ -202,6 +231,23 @@ public class BgpNeighborDataRoutesInInner {
            @Override
            public void write(JsonWriter out, BgpNeighborDataRoutesInInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -209,7 +255,25 @@ public class BgpNeighborDataRoutesInInner {
            public BgpNeighborDataRoutesInInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpNeighborDataRoutesInInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpNeighborDataRoutesOutInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpNeighborDataRoutesOutInner.java
@@ -57,7 +57,7 @@ public class BgpNeighborDataRoutesOutInner {
   @SerializedName(SERIALIZED_NAME_ROUTE)
   private String route;
 
-  public BgpNeighborDataRoutesOutInner() { 
+  public BgpNeighborDataRoutesOutInner() {
   }
 
   public BgpNeighborDataRoutesOutInner exact(Boolean exact) {
@@ -105,6 +105,41 @@ public class BgpNeighborDataRoutesOutInner {
     this.route = route;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpNeighborDataRoutesOutInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -117,12 +152,13 @@ public class BgpNeighborDataRoutesOutInner {
     }
     BgpNeighborDataRoutesOutInner bgpNeighborDataRoutesOutInner = (BgpNeighborDataRoutesOutInner) o;
     return Objects.equals(this.exact, bgpNeighborDataRoutesOutInner.exact) &&
-        Objects.equals(this.route, bgpNeighborDataRoutesOutInner.route);
+        Objects.equals(this.route, bgpNeighborDataRoutesOutInner.route)&&
+        Objects.equals(this.additionalProperties, bgpNeighborDataRoutesOutInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(exact, route);
+    return Objects.hash(exact, route, additionalProperties);
   }
 
   @Override
@@ -131,6 +167,7 @@ public class BgpNeighborDataRoutesOutInner {
     sb.append("class BgpNeighborDataRoutesOutInner {\n");
     sb.append("    exact: ").append(toIndentedString(exact)).append("\n");
     sb.append("    route: ").append(toIndentedString(route)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -174,15 +211,7 @@ public class BgpNeighborDataRoutesOutInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BgpNeighborDataRoutesOutInner is not found in the empty JSON string", BgpNeighborDataRoutesOutInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpNeighborDataRoutesOutInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpNeighborDataRoutesOutInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("route") != null && !jsonObj.get("route").isJsonPrimitive()) {
+      if ((jsonObj.get("route") != null && !jsonObj.get("route").isJsonNull()) && !jsonObj.get("route").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `route` to be a primitive type in the JSON string but got `%s`", jsonObj.get("route").toString()));
       }
   }
@@ -202,6 +231,23 @@ public class BgpNeighborDataRoutesOutInner {
            @Override
            public void write(JsonWriter out, BgpNeighborDataRoutesOutInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -209,7 +255,25 @@ public class BgpNeighborDataRoutesOutInner {
            public BgpNeighborDataRoutesOutInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpNeighborDataRoutesOutInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSession.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSession.java
@@ -186,7 +186,7 @@ public class BgpSession {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public BgpSession() { 
+  public BgpSession() {
   }
 
   public BgpSession addressFamily(AddressFamilyEnum addressFamily) {
@@ -403,6 +403,41 @@ public class BgpSession {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpSession putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -422,12 +457,13 @@ public class BgpSession {
         Objects.equals(this.id, bgpSession.id) &&
         Objects.equals(this.learnedRoutes, bgpSession.learnedRoutes) &&
         Objects.equals(this.status, bgpSession.status) &&
-        Objects.equals(this.updatedAt, bgpSession.updatedAt);
+        Objects.equals(this.updatedAt, bgpSession.updatedAt)&&
+        Objects.equals(this.additionalProperties, bgpSession.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, createdAt, defaultRoute, device, href, id, learnedRoutes, status, updatedAt);
+    return Objects.hash(addressFamily, createdAt, defaultRoute, device, href, id, learnedRoutes, status, updatedAt, additionalProperties);
   }
 
   @Override
@@ -443,6 +479,7 @@ public class BgpSession {
     sb.append("    learnedRoutes: ").append(toIndentedString(learnedRoutes)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -495,38 +532,30 @@ public class BgpSession {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpSession.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpSession` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BgpSession.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("address_family") != null && !jsonObj.get("address_family").isJsonPrimitive()) {
+      if ((jsonObj.get("address_family") != null && !jsonObj.get("address_family").isJsonNull()) && !jsonObj.get("address_family").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address_family` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address_family").toString()));
       }
       // validate the optional field `device`
-      if (jsonObj.getAsJsonObject("device") != null) {
+      if (jsonObj.get("device") != null && !jsonObj.get("device").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("device"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("learned_routes") != null && !jsonObj.get("learned_routes").isJsonArray()) {
+      if ((jsonObj.get("learned_routes") != null && !jsonObj.get("learned_routes").isJsonNull()) && !jsonObj.get("learned_routes").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `learned_routes` to be an array in the JSON string but got `%s`", jsonObj.get("learned_routes").toString()));
       }
-      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonPrimitive()) {
+      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
   }
@@ -546,6 +575,23 @@ public class BgpSession {
            @Override
            public void write(JsonWriter out, BgpSession value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -553,7 +599,25 @@ public class BgpSession {
            public BgpSession read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpSession instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSessionList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSessionList.java
@@ -56,7 +56,7 @@ public class BgpSessionList {
   @SerializedName(SERIALIZED_NAME_BGP_SESSIONS)
   private List<BgpSession> bgpSessions = null;
 
-  public BgpSessionList() { 
+  public BgpSessionList() {
   }
 
   public BgpSessionList bgpSessions(List<BgpSession> bgpSessions) {
@@ -89,6 +89,41 @@ public class BgpSessionList {
     this.bgpSessions = bgpSessions;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpSessionList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class BgpSessionList {
       return false;
     }
     BgpSessionList bgpSessionList = (BgpSessionList) o;
-    return Objects.equals(this.bgpSessions, bgpSessionList.bgpSessions);
+    return Objects.equals(this.bgpSessions, bgpSessionList.bgpSessions)&&
+        Objects.equals(this.additionalProperties, bgpSessionList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bgpSessions);
+    return Objects.hash(bgpSessions, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class BgpSessionList {
     StringBuilder sb = new StringBuilder();
     sb.append("class BgpSessionList {\n");
     sb.append("    bgpSessions: ").append(toIndentedString(bgpSessions)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class BgpSessionList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BgpSessionList is not found in the empty JSON string", BgpSessionList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpSessionList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpSessionList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraybgpSessions = jsonObj.getAsJsonArray("bgp_sessions");
       if (jsonArraybgpSessions != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class BgpSessionList {
            @Override
            public void write(JsonWriter out, BgpSessionList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class BgpSessionList {
            public BgpSessionList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpSessionList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSessionNeighbors.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSessionNeighbors.java
@@ -56,7 +56,7 @@ public class BgpSessionNeighbors {
   @SerializedName(SERIALIZED_NAME_BGP_NEIGHBORS)
   private List<BgpNeighborData> bgpNeighbors = null;
 
-  public BgpSessionNeighbors() { 
+  public BgpSessionNeighbors() {
   }
 
   public BgpSessionNeighbors bgpNeighbors(List<BgpNeighborData> bgpNeighbors) {
@@ -89,6 +89,41 @@ public class BgpSessionNeighbors {
     this.bgpNeighbors = bgpNeighbors;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public BgpSessionNeighbors putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class BgpSessionNeighbors {
       return false;
     }
     BgpSessionNeighbors bgpSessionNeighbors = (BgpSessionNeighbors) o;
-    return Objects.equals(this.bgpNeighbors, bgpSessionNeighbors.bgpNeighbors);
+    return Objects.equals(this.bgpNeighbors, bgpSessionNeighbors.bgpNeighbors)&&
+        Objects.equals(this.additionalProperties, bgpSessionNeighbors.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bgpNeighbors);
+    return Objects.hash(bgpNeighbors, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class BgpSessionNeighbors {
     StringBuilder sb = new StringBuilder();
     sb.append("class BgpSessionNeighbors {\n");
     sb.append("    bgpNeighbors: ").append(toIndentedString(bgpNeighbors)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class BgpSessionNeighbors {
           throw new IllegalArgumentException(String.format("The required field(s) %s in BgpSessionNeighbors is not found in the empty JSON string", BgpSessionNeighbors.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!BgpSessionNeighbors.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BgpSessionNeighbors` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraybgpNeighbors = jsonObj.getAsJsonArray("bgp_neighbors");
       if (jsonArraybgpNeighbors != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class BgpSessionNeighbors {
            @Override
            public void write(JsonWriter out, BgpSessionNeighbors value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class BgpSessionNeighbors {
            public BgpSessionNeighbors read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             BgpSessionNeighbors instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerFacilityInfo.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerFacilityInfo.java
@@ -65,7 +65,7 @@ public class CapacityCheckPerFacilityInfo {
   @SerializedName(SERIALIZED_NAME_QUANTITY)
   private String quantity;
 
-  public CapacityCheckPerFacilityInfo() { 
+  public CapacityCheckPerFacilityInfo() {
   }
 
   public CapacityCheckPerFacilityInfo available(Boolean available) {
@@ -159,6 +159,41 @@ public class CapacityCheckPerFacilityInfo {
     this.quantity = quantity;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityCheckPerFacilityInfo putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -173,12 +208,13 @@ public class CapacityCheckPerFacilityInfo {
     return Objects.equals(this.available, capacityCheckPerFacilityInfo.available) &&
         Objects.equals(this.facility, capacityCheckPerFacilityInfo.facility) &&
         Objects.equals(this.plan, capacityCheckPerFacilityInfo.plan) &&
-        Objects.equals(this.quantity, capacityCheckPerFacilityInfo.quantity);
+        Objects.equals(this.quantity, capacityCheckPerFacilityInfo.quantity)&&
+        Objects.equals(this.additionalProperties, capacityCheckPerFacilityInfo.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(available, facility, plan, quantity);
+    return Objects.hash(available, facility, plan, quantity, additionalProperties);
   }
 
   @Override
@@ -189,6 +225,7 @@ public class CapacityCheckPerFacilityInfo {
     sb.append("    facility: ").append(toIndentedString(facility)).append("\n");
     sb.append("    plan: ").append(toIndentedString(plan)).append("\n");
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -234,21 +271,13 @@ public class CapacityCheckPerFacilityInfo {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityCheckPerFacilityInfo is not found in the empty JSON string", CapacityCheckPerFacilityInfo.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityCheckPerFacilityInfo.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityCheckPerFacilityInfo` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonPrimitive()) {
+      if ((jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) && !jsonObj.get("facility").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `facility` to be a primitive type in the JSON string but got `%s`", jsonObj.get("facility").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
-      if (jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonPrimitive()) {
+      if ((jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonNull()) && !jsonObj.get("quantity").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `quantity` to be a primitive type in the JSON string but got `%s`", jsonObj.get("quantity").toString()));
       }
   }
@@ -268,6 +297,23 @@ public class CapacityCheckPerFacilityInfo {
            @Override
            public void write(JsonWriter out, CapacityCheckPerFacilityInfo value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -275,7 +321,25 @@ public class CapacityCheckPerFacilityInfo {
            public CapacityCheckPerFacilityInfo read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityCheckPerFacilityInfo instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerFacilityList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerFacilityList.java
@@ -56,7 +56,7 @@ public class CapacityCheckPerFacilityList {
   @SerializedName(SERIALIZED_NAME_SERVERS)
   private List<CapacityCheckPerFacilityInfo> servers = null;
 
-  public CapacityCheckPerFacilityList() { 
+  public CapacityCheckPerFacilityList() {
   }
 
   public CapacityCheckPerFacilityList servers(List<CapacityCheckPerFacilityInfo> servers) {
@@ -89,6 +89,41 @@ public class CapacityCheckPerFacilityList {
     this.servers = servers;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityCheckPerFacilityList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class CapacityCheckPerFacilityList {
       return false;
     }
     CapacityCheckPerFacilityList capacityCheckPerFacilityList = (CapacityCheckPerFacilityList) o;
-    return Objects.equals(this.servers, capacityCheckPerFacilityList.servers);
+    return Objects.equals(this.servers, capacityCheckPerFacilityList.servers)&&
+        Objects.equals(this.additionalProperties, capacityCheckPerFacilityList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(servers);
+    return Objects.hash(servers, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class CapacityCheckPerFacilityList {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapacityCheckPerFacilityList {\n");
     sb.append("    servers: ").append(toIndentedString(servers)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class CapacityCheckPerFacilityList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityCheckPerFacilityList is not found in the empty JSON string", CapacityCheckPerFacilityList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityCheckPerFacilityList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityCheckPerFacilityList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayservers = jsonObj.getAsJsonArray("servers");
       if (jsonArrayservers != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class CapacityCheckPerFacilityList {
            @Override
            public void write(JsonWriter out, CapacityCheckPerFacilityList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class CapacityCheckPerFacilityList {
            public CapacityCheckPerFacilityList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityCheckPerFacilityList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerMetroInfo.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerMetroInfo.java
@@ -65,7 +65,7 @@ public class CapacityCheckPerMetroInfo {
   @SerializedName(SERIALIZED_NAME_QUANTITY)
   private String quantity;
 
-  public CapacityCheckPerMetroInfo() { 
+  public CapacityCheckPerMetroInfo() {
   }
 
   public CapacityCheckPerMetroInfo available(Boolean available) {
@@ -159,6 +159,41 @@ public class CapacityCheckPerMetroInfo {
     this.quantity = quantity;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityCheckPerMetroInfo putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -173,12 +208,13 @@ public class CapacityCheckPerMetroInfo {
     return Objects.equals(this.available, capacityCheckPerMetroInfo.available) &&
         Objects.equals(this.metro, capacityCheckPerMetroInfo.metro) &&
         Objects.equals(this.plan, capacityCheckPerMetroInfo.plan) &&
-        Objects.equals(this.quantity, capacityCheckPerMetroInfo.quantity);
+        Objects.equals(this.quantity, capacityCheckPerMetroInfo.quantity)&&
+        Objects.equals(this.additionalProperties, capacityCheckPerMetroInfo.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(available, metro, plan, quantity);
+    return Objects.hash(available, metro, plan, quantity, additionalProperties);
   }
 
   @Override
@@ -189,6 +225,7 @@ public class CapacityCheckPerMetroInfo {
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    plan: ").append(toIndentedString(plan)).append("\n");
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -234,21 +271,13 @@ public class CapacityCheckPerMetroInfo {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityCheckPerMetroInfo is not found in the empty JSON string", CapacityCheckPerMetroInfo.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityCheckPerMetroInfo.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityCheckPerMetroInfo` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
-      if (jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonPrimitive()) {
+      if ((jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonNull()) && !jsonObj.get("quantity").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `quantity` to be a primitive type in the JSON string but got `%s`", jsonObj.get("quantity").toString()));
       }
   }
@@ -268,6 +297,23 @@ public class CapacityCheckPerMetroInfo {
            @Override
            public void write(JsonWriter out, CapacityCheckPerMetroInfo value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -275,7 +321,25 @@ public class CapacityCheckPerMetroInfo {
            public CapacityCheckPerMetroInfo read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityCheckPerMetroInfo instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerMetroList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityCheckPerMetroList.java
@@ -56,7 +56,7 @@ public class CapacityCheckPerMetroList {
   @SerializedName(SERIALIZED_NAME_SERVERS)
   private List<CapacityCheckPerMetroInfo> servers = null;
 
-  public CapacityCheckPerMetroList() { 
+  public CapacityCheckPerMetroList() {
   }
 
   public CapacityCheckPerMetroList servers(List<CapacityCheckPerMetroInfo> servers) {
@@ -89,6 +89,41 @@ public class CapacityCheckPerMetroList {
     this.servers = servers;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityCheckPerMetroList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class CapacityCheckPerMetroList {
       return false;
     }
     CapacityCheckPerMetroList capacityCheckPerMetroList = (CapacityCheckPerMetroList) o;
-    return Objects.equals(this.servers, capacityCheckPerMetroList.servers);
+    return Objects.equals(this.servers, capacityCheckPerMetroList.servers)&&
+        Objects.equals(this.additionalProperties, capacityCheckPerMetroList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(servers);
+    return Objects.hash(servers, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class CapacityCheckPerMetroList {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapacityCheckPerMetroList {\n");
     sb.append("    servers: ").append(toIndentedString(servers)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class CapacityCheckPerMetroList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityCheckPerMetroList is not found in the empty JSON string", CapacityCheckPerMetroList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityCheckPerMetroList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityCheckPerMetroList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayservers = jsonObj.getAsJsonArray("servers");
       if (jsonArrayservers != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class CapacityCheckPerMetroList {
            @Override
            public void write(JsonWriter out, CapacityCheckPerMetroList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class CapacityCheckPerMetroList {
            public CapacityCheckPerMetroList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityCheckPerMetroList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityInput.java
@@ -56,7 +56,7 @@ public class CapacityInput {
   @SerializedName(SERIALIZED_NAME_SERVERS)
   private List<ServerInfo> servers = null;
 
-  public CapacityInput() { 
+  public CapacityInput() {
   }
 
   public CapacityInput servers(List<ServerInfo> servers) {
@@ -89,6 +89,41 @@ public class CapacityInput {
     this.servers = servers;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class CapacityInput {
       return false;
     }
     CapacityInput capacityInput = (CapacityInput) o;
-    return Objects.equals(this.servers, capacityInput.servers);
+    return Objects.equals(this.servers, capacityInput.servers)&&
+        Objects.equals(this.additionalProperties, capacityInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(servers);
+    return Objects.hash(servers, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class CapacityInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapacityInput {\n");
     sb.append("    servers: ").append(toIndentedString(servers)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class CapacityInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityInput is not found in the empty JSON string", CapacityInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayservers = jsonObj.getAsJsonArray("servers");
       if (jsonArrayservers != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class CapacityInput {
            @Override
            public void write(JsonWriter out, CapacityInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class CapacityInput {
            public CapacityInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityLevelPerBaremetal.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityLevelPerBaremetal.java
@@ -53,7 +53,7 @@ public class CapacityLevelPerBaremetal {
   @SerializedName(SERIALIZED_NAME_LEVEL)
   private String level;
 
-  public CapacityLevelPerBaremetal() { 
+  public CapacityLevelPerBaremetal() {
   }
 
   public CapacityLevelPerBaremetal level(String level) {
@@ -78,6 +78,41 @@ public class CapacityLevelPerBaremetal {
     this.level = level;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityLevelPerBaremetal putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -89,12 +124,13 @@ public class CapacityLevelPerBaremetal {
       return false;
     }
     CapacityLevelPerBaremetal capacityLevelPerBaremetal = (CapacityLevelPerBaremetal) o;
-    return Objects.equals(this.level, capacityLevelPerBaremetal.level);
+    return Objects.equals(this.level, capacityLevelPerBaremetal.level)&&
+        Objects.equals(this.additionalProperties, capacityLevelPerBaremetal.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(level);
+    return Objects.hash(level, additionalProperties);
   }
 
   @Override
@@ -102,6 +138,7 @@ public class CapacityLevelPerBaremetal {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapacityLevelPerBaremetal {\n");
     sb.append("    level: ").append(toIndentedString(level)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -144,15 +181,7 @@ public class CapacityLevelPerBaremetal {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityLevelPerBaremetal is not found in the empty JSON string", CapacityLevelPerBaremetal.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityLevelPerBaremetal.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityLevelPerBaremetal` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("level") != null && !jsonObj.get("level").isJsonPrimitive()) {
+      if ((jsonObj.get("level") != null && !jsonObj.get("level").isJsonNull()) && !jsonObj.get("level").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `level` to be a primitive type in the JSON string but got `%s`", jsonObj.get("level").toString()));
       }
   }
@@ -172,6 +201,23 @@ public class CapacityLevelPerBaremetal {
            @Override
            public void write(JsonWriter out, CapacityLevelPerBaremetal value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -179,7 +225,25 @@ public class CapacityLevelPerBaremetal {
            public CapacityLevelPerBaremetal read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityLevelPerBaremetal instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityList.java
@@ -54,7 +54,7 @@ public class CapacityList {
   @SerializedName(SERIALIZED_NAME_CAPACITY)
   private CapacityReport capacity;
 
-  public CapacityList() { 
+  public CapacityList() {
   }
 
   public CapacityList capacity(CapacityReport capacity) {
@@ -79,6 +79,41 @@ public class CapacityList {
     this.capacity = capacity;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class CapacityList {
       return false;
     }
     CapacityList capacityList = (CapacityList) o;
-    return Objects.equals(this.capacity, capacityList.capacity);
+    return Objects.equals(this.capacity, capacityList.capacity)&&
+        Objects.equals(this.additionalProperties, capacityList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(capacity);
+    return Objects.hash(capacity, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class CapacityList {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapacityList {\n");
     sb.append("    capacity: ").append(toIndentedString(capacity)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,16 +182,8 @@ public class CapacityList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityList is not found in the empty JSON string", CapacityList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `capacity`
-      if (jsonObj.getAsJsonObject("capacity") != null) {
+      if (jsonObj.get("capacity") != null && !jsonObj.get("capacity").isJsonNull()) {
         CapacityReport.validateJsonObject(jsonObj.getAsJsonObject("capacity"));
       }
   }
@@ -174,6 +203,23 @@ public class CapacityList {
            @Override
            public void write(JsonWriter out, CapacityList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -181,7 +227,25 @@ public class CapacityList {
            public CapacityList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityPerFacility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityPerFacility.java
@@ -86,7 +86,7 @@ public class CapacityPerFacility {
   @SerializedName(SERIALIZED_NAME_M2_XLARGE_X86)
   private CapacityLevelPerBaremetal m2XlargeX86;
 
-  public CapacityPerFacility() { 
+  public CapacityPerFacility() {
   }
 
   public CapacityPerFacility baremetal0(CapacityLevelPerBaremetal baremetal0) {
@@ -295,6 +295,41 @@ public class CapacityPerFacility {
     this.m2XlargeX86 = m2XlargeX86;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityPerFacility putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -314,12 +349,13 @@ public class CapacityPerFacility {
         Objects.equals(this.baremetal3, capacityPerFacility.baremetal3) &&
         Objects.equals(this.baremetalS, capacityPerFacility.baremetalS) &&
         Objects.equals(this.c2MediumX86, capacityPerFacility.c2MediumX86) &&
-        Objects.equals(this.m2XlargeX86, capacityPerFacility.m2XlargeX86);
+        Objects.equals(this.m2XlargeX86, capacityPerFacility.m2XlargeX86)&&
+        Objects.equals(this.additionalProperties, capacityPerFacility.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baremetal0, baremetal1, baremetal2, baremetal2a, baremetal2a2, baremetal3, baremetalS, c2MediumX86, m2XlargeX86);
+    return Objects.hash(baremetal0, baremetal1, baremetal2, baremetal2a, baremetal2a2, baremetal3, baremetalS, c2MediumX86, m2XlargeX86, additionalProperties);
   }
 
   @Override
@@ -335,6 +371,7 @@ public class CapacityPerFacility {
     sb.append("    baremetalS: ").append(toIndentedString(baremetalS)).append("\n");
     sb.append("    c2MediumX86: ").append(toIndentedString(c2MediumX86)).append("\n");
     sb.append("    m2XlargeX86: ").append(toIndentedString(m2XlargeX86)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -385,48 +422,40 @@ public class CapacityPerFacility {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityPerFacility is not found in the empty JSON string", CapacityPerFacility.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityPerFacility.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityPerFacility` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `baremetal_0`
-      if (jsonObj.getAsJsonObject("baremetal_0") != null) {
+      if (jsonObj.get("baremetal_0") != null && !jsonObj.get("baremetal_0").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_0"));
       }
       // validate the optional field `baremetal_1`
-      if (jsonObj.getAsJsonObject("baremetal_1") != null) {
+      if (jsonObj.get("baremetal_1") != null && !jsonObj.get("baremetal_1").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_1"));
       }
       // validate the optional field `baremetal_2`
-      if (jsonObj.getAsJsonObject("baremetal_2") != null) {
+      if (jsonObj.get("baremetal_2") != null && !jsonObj.get("baremetal_2").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_2"));
       }
       // validate the optional field `baremetal_2a`
-      if (jsonObj.getAsJsonObject("baremetal_2a") != null) {
+      if (jsonObj.get("baremetal_2a") != null && !jsonObj.get("baremetal_2a").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_2a"));
       }
       // validate the optional field `baremetal_2a2`
-      if (jsonObj.getAsJsonObject("baremetal_2a2") != null) {
+      if (jsonObj.get("baremetal_2a2") != null && !jsonObj.get("baremetal_2a2").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_2a2"));
       }
       // validate the optional field `baremetal_3`
-      if (jsonObj.getAsJsonObject("baremetal_3") != null) {
+      if (jsonObj.get("baremetal_3") != null && !jsonObj.get("baremetal_3").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_3"));
       }
       // validate the optional field `baremetal_s`
-      if (jsonObj.getAsJsonObject("baremetal_s") != null) {
+      if (jsonObj.get("baremetal_s") != null && !jsonObj.get("baremetal_s").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_s"));
       }
       // validate the optional field `c2.medium.x86`
-      if (jsonObj.getAsJsonObject("c2.medium.x86") != null) {
+      if (jsonObj.get("c2.medium.x86") != null && !jsonObj.get("c2.medium.x86").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("c2.medium.x86"));
       }
       // validate the optional field `m2.xlarge.x86`
-      if (jsonObj.getAsJsonObject("m2.xlarge.x86") != null) {
+      if (jsonObj.get("m2.xlarge.x86") != null && !jsonObj.get("m2.xlarge.x86").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("m2.xlarge.x86"));
       }
   }
@@ -446,6 +475,23 @@ public class CapacityPerFacility {
            @Override
            public void write(JsonWriter out, CapacityPerFacility value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -453,7 +499,25 @@ public class CapacityPerFacility {
            public CapacityPerFacility read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityPerFacility instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityPerMetroInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityPerMetroInput.java
@@ -56,7 +56,7 @@ public class CapacityPerMetroInput {
   @SerializedName(SERIALIZED_NAME_SERVERS)
   private List<MetroServerInfo> servers = null;
 
-  public CapacityPerMetroInput() { 
+  public CapacityPerMetroInput() {
   }
 
   public CapacityPerMetroInput servers(List<MetroServerInfo> servers) {
@@ -89,6 +89,41 @@ public class CapacityPerMetroInput {
     this.servers = servers;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityPerMetroInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class CapacityPerMetroInput {
       return false;
     }
     CapacityPerMetroInput capacityPerMetroInput = (CapacityPerMetroInput) o;
-    return Objects.equals(this.servers, capacityPerMetroInput.servers);
+    return Objects.equals(this.servers, capacityPerMetroInput.servers)&&
+        Objects.equals(this.additionalProperties, capacityPerMetroInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(servers);
+    return Objects.hash(servers, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class CapacityPerMetroInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapacityPerMetroInput {\n");
     sb.append("    servers: ").append(toIndentedString(servers)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class CapacityPerMetroInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityPerMetroInput is not found in the empty JSON string", CapacityPerMetroInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityPerMetroInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityPerMetroInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayservers = jsonObj.getAsJsonArray("servers");
       if (jsonArrayservers != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class CapacityPerMetroInput {
            @Override
            public void write(JsonWriter out, CapacityPerMetroInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class CapacityPerMetroInput {
            public CapacityPerMetroInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityPerMetroInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityPerNewFacility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityPerNewFacility.java
@@ -54,7 +54,7 @@ public class CapacityPerNewFacility {
   @SerializedName(SERIALIZED_NAME_BAREMETAL1E)
   private CapacityLevelPerBaremetal baremetal1e;
 
-  public CapacityPerNewFacility() { 
+  public CapacityPerNewFacility() {
   }
 
   public CapacityPerNewFacility baremetal1e(CapacityLevelPerBaremetal baremetal1e) {
@@ -79,6 +79,41 @@ public class CapacityPerNewFacility {
     this.baremetal1e = baremetal1e;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityPerNewFacility putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class CapacityPerNewFacility {
       return false;
     }
     CapacityPerNewFacility capacityPerNewFacility = (CapacityPerNewFacility) o;
-    return Objects.equals(this.baremetal1e, capacityPerNewFacility.baremetal1e);
+    return Objects.equals(this.baremetal1e, capacityPerNewFacility.baremetal1e)&&
+        Objects.equals(this.additionalProperties, capacityPerNewFacility.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baremetal1e);
+    return Objects.hash(baremetal1e, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class CapacityPerNewFacility {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapacityPerNewFacility {\n");
     sb.append("    baremetal1e: ").append(toIndentedString(baremetal1e)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,16 +182,8 @@ public class CapacityPerNewFacility {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityPerNewFacility is not found in the empty JSON string", CapacityPerNewFacility.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityPerNewFacility.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityPerNewFacility` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `baremetal_1e`
-      if (jsonObj.getAsJsonObject("baremetal_1e") != null) {
+      if (jsonObj.get("baremetal_1e") != null && !jsonObj.get("baremetal_1e").isJsonNull()) {
         CapacityLevelPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_1e"));
       }
   }
@@ -174,6 +203,23 @@ public class CapacityPerNewFacility {
            @Override
            public void write(JsonWriter out, CapacityPerNewFacility value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -181,7 +227,25 @@ public class CapacityPerNewFacility {
            public CapacityPerNewFacility read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityPerNewFacility instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityReport.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CapacityReport.java
@@ -107,7 +107,7 @@ public class CapacityReport {
   @SerializedName(SERIALIZED_NAME_YYZ1)
   private CapacityPerNewFacility yyz1;
 
-  public CapacityReport() { 
+  public CapacityReport() {
   }
 
   public CapacityReport ams1(CapacityPerFacility ams1) {
@@ -431,6 +431,41 @@ public class CapacityReport {
     this.yyz1 = yyz1;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CapacityReport putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -455,12 +490,13 @@ public class CapacityReport {
         Objects.equals(this.sin1, capacityReport.sin1) &&
         Objects.equals(this.sjc1, capacityReport.sjc1) &&
         Objects.equals(this.syd1, capacityReport.syd1) &&
-        Objects.equals(this.yyz1, capacityReport.yyz1);
+        Objects.equals(this.yyz1, capacityReport.yyz1)&&
+        Objects.equals(this.additionalProperties, capacityReport.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ams1, atl1, dfw1, ewr1, fra1, iad1, lax1, nrt1, ord1, sea1, sin1, sjc1, syd1, yyz1);
+    return Objects.hash(ams1, atl1, dfw1, ewr1, fra1, iad1, lax1, nrt1, ord1, sea1, sin1, sjc1, syd1, yyz1, additionalProperties);
   }
 
   @Override
@@ -481,6 +517,7 @@ public class CapacityReport {
     sb.append("    sjc1: ").append(toIndentedString(sjc1)).append("\n");
     sb.append("    syd1: ").append(toIndentedString(syd1)).append("\n");
     sb.append("    yyz1: ").append(toIndentedString(yyz1)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -536,68 +573,60 @@ public class CapacityReport {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CapacityReport is not found in the empty JSON string", CapacityReport.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CapacityReport.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CapacityReport` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `ams1`
-      if (jsonObj.getAsJsonObject("ams1") != null) {
+      if (jsonObj.get("ams1") != null && !jsonObj.get("ams1").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ams1"));
       }
       // validate the optional field `atl1`
-      if (jsonObj.getAsJsonObject("atl1") != null) {
+      if (jsonObj.get("atl1") != null && !jsonObj.get("atl1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("atl1"));
       }
       // validate the optional field `dfw1`
-      if (jsonObj.getAsJsonObject("dfw1") != null) {
+      if (jsonObj.get("dfw1") != null && !jsonObj.get("dfw1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("dfw1"));
       }
       // validate the optional field `ewr1`
-      if (jsonObj.getAsJsonObject("ewr1") != null) {
+      if (jsonObj.get("ewr1") != null && !jsonObj.get("ewr1").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ewr1"));
       }
       // validate the optional field `fra1`
-      if (jsonObj.getAsJsonObject("fra1") != null) {
+      if (jsonObj.get("fra1") != null && !jsonObj.get("fra1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("fra1"));
       }
       // validate the optional field `iad1`
-      if (jsonObj.getAsJsonObject("iad1") != null) {
+      if (jsonObj.get("iad1") != null && !jsonObj.get("iad1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("iad1"));
       }
       // validate the optional field `lax1`
-      if (jsonObj.getAsJsonObject("lax1") != null) {
+      if (jsonObj.get("lax1") != null && !jsonObj.get("lax1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("lax1"));
       }
       // validate the optional field `nrt1`
-      if (jsonObj.getAsJsonObject("nrt1") != null) {
+      if (jsonObj.get("nrt1") != null && !jsonObj.get("nrt1").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("nrt1"));
       }
       // validate the optional field `ord1`
-      if (jsonObj.getAsJsonObject("ord1") != null) {
+      if (jsonObj.get("ord1") != null && !jsonObj.get("ord1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("ord1"));
       }
       // validate the optional field `sea1`
-      if (jsonObj.getAsJsonObject("sea1") != null) {
+      if (jsonObj.get("sea1") != null && !jsonObj.get("sea1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("sea1"));
       }
       // validate the optional field `sin1`
-      if (jsonObj.getAsJsonObject("sin1") != null) {
+      if (jsonObj.get("sin1") != null && !jsonObj.get("sin1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("sin1"));
       }
       // validate the optional field `sjc1`
-      if (jsonObj.getAsJsonObject("sjc1") != null) {
+      if (jsonObj.get("sjc1") != null && !jsonObj.get("sjc1").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sjc1"));
       }
       // validate the optional field `syd1`
-      if (jsonObj.getAsJsonObject("syd1") != null) {
+      if (jsonObj.get("syd1") != null && !jsonObj.get("syd1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("syd1"));
       }
       // validate the optional field `yyz1`
-      if (jsonObj.getAsJsonObject("yyz1") != null) {
+      if (jsonObj.get("yyz1") != null && !jsonObj.get("yyz1").isJsonNull()) {
         CapacityPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("yyz1"));
       }
   }
@@ -617,6 +646,23 @@ public class CapacityReport {
            @Override
            public void write(JsonWriter out, CapacityReport value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -624,7 +670,25 @@ public class CapacityReport {
            public CapacityReport read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CapacityReport instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Coordinates.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Coordinates.java
@@ -57,7 +57,7 @@ public class Coordinates {
   @SerializedName(SERIALIZED_NAME_LONGITUDE)
   private String longitude;
 
-  public Coordinates() { 
+  public Coordinates() {
   }
 
   public Coordinates latitude(String latitude) {
@@ -105,6 +105,41 @@ public class Coordinates {
     this.longitude = longitude;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Coordinates putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -117,12 +152,13 @@ public class Coordinates {
     }
     Coordinates coordinates = (Coordinates) o;
     return Objects.equals(this.latitude, coordinates.latitude) &&
-        Objects.equals(this.longitude, coordinates.longitude);
+        Objects.equals(this.longitude, coordinates.longitude)&&
+        Objects.equals(this.additionalProperties, coordinates.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(latitude, longitude);
+    return Objects.hash(latitude, longitude, additionalProperties);
   }
 
   @Override
@@ -131,6 +167,7 @@ public class Coordinates {
     sb.append("class Coordinates {\n");
     sb.append("    latitude: ").append(toIndentedString(latitude)).append("\n");
     sb.append("    longitude: ").append(toIndentedString(longitude)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -174,18 +211,10 @@ public class Coordinates {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Coordinates is not found in the empty JSON string", Coordinates.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Coordinates.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Coordinates` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("latitude") != null && !jsonObj.get("latitude").isJsonPrimitive()) {
+      if ((jsonObj.get("latitude") != null && !jsonObj.get("latitude").isJsonNull()) && !jsonObj.get("latitude").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `latitude` to be a primitive type in the JSON string but got `%s`", jsonObj.get("latitude").toString()));
       }
-      if (jsonObj.get("longitude") != null && !jsonObj.get("longitude").isJsonPrimitive()) {
+      if ((jsonObj.get("longitude") != null && !jsonObj.get("longitude").isJsonNull()) && !jsonObj.get("longitude").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `longitude` to be a primitive type in the JSON string but got `%s`", jsonObj.get("longitude").toString()));
       }
   }
@@ -205,6 +234,23 @@ public class Coordinates {
            @Override
            public void write(JsonWriter out, Coordinates value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -212,7 +258,25 @@ public class Coordinates {
            public Coordinates read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Coordinates instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateEmailInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateEmailInput.java
@@ -53,7 +53,7 @@ public class CreateEmailInput {
   @SerializedName(SERIALIZED_NAME_ADDRESS)
   private String address;
 
-  public CreateEmailInput() { 
+  public CreateEmailInput() {
   }
 
   public CreateEmailInput address(String address) {
@@ -78,6 +78,41 @@ public class CreateEmailInput {
     this.address = address;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CreateEmailInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -89,12 +124,13 @@ public class CreateEmailInput {
       return false;
     }
     CreateEmailInput createEmailInput = (CreateEmailInput) o;
-    return Objects.equals(this.address, createEmailInput.address);
+    return Objects.equals(this.address, createEmailInput.address)&&
+        Objects.equals(this.additionalProperties, createEmailInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address);
+    return Objects.hash(address, additionalProperties);
   }
 
   @Override
@@ -102,6 +138,7 @@ public class CreateEmailInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class CreateEmailInput {\n");
     sb.append("    address: ").append(toIndentedString(address)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -146,21 +183,13 @@ public class CreateEmailInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CreateEmailInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateEmailInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateEmailInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonPrimitive()) {
+      if ((jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) && !jsonObj.get("address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address").toString()));
       }
   }
@@ -180,6 +209,23 @@ public class CreateEmailInput {
            @Override
            public void write(JsonWriter out, CreateEmailInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -187,7 +233,25 @@ public class CreateEmailInput {
            public CreateEmailInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CreateEmailInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateSelfServiceReservationRequest.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateSelfServiceReservationRequest.java
@@ -70,7 +70,7 @@ public class CreateSelfServiceReservationRequest {
   @SerializedName(SERIALIZED_NAME_START_DATE)
   private OffsetDateTime startDate;
 
-  public CreateSelfServiceReservationRequest() { 
+  public CreateSelfServiceReservationRequest() {
   }
 
   public CreateSelfServiceReservationRequest item(List<SelfServiceReservationItemRequest> item) {
@@ -172,6 +172,41 @@ public class CreateSelfServiceReservationRequest {
     this.startDate = startDate;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CreateSelfServiceReservationRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -186,12 +221,13 @@ public class CreateSelfServiceReservationRequest {
     return Objects.equals(this.item, createSelfServiceReservationRequest.item) &&
         Objects.equals(this.notes, createSelfServiceReservationRequest.notes) &&
         Objects.equals(this.period, createSelfServiceReservationRequest.period) &&
-        Objects.equals(this.startDate, createSelfServiceReservationRequest.startDate);
+        Objects.equals(this.startDate, createSelfServiceReservationRequest.startDate)&&
+        Objects.equals(this.additionalProperties, createSelfServiceReservationRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(item, notes, period, startDate);
+    return Objects.hash(item, notes, period, startDate, additionalProperties);
   }
 
   @Override
@@ -202,6 +238,7 @@ public class CreateSelfServiceReservationRequest {
     sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
     sb.append("    period: ").append(toIndentedString(period)).append("\n");
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -247,14 +284,6 @@ public class CreateSelfServiceReservationRequest {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CreateSelfServiceReservationRequest is not found in the empty JSON string", CreateSelfServiceReservationRequest.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CreateSelfServiceReservationRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateSelfServiceReservationRequest` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayitem = jsonObj.getAsJsonArray("item");
       if (jsonArrayitem != null) {
         // ensure the json data is an array
@@ -267,11 +296,11 @@ public class CreateSelfServiceReservationRequest {
           SelfServiceReservationItemRequest.validateJsonObject(jsonArrayitem.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("notes") != null && !jsonObj.get("notes").isJsonPrimitive()) {
+      if ((jsonObj.get("notes") != null && !jsonObj.get("notes").isJsonNull()) && !jsonObj.get("notes").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `notes` to be a primitive type in the JSON string but got `%s`", jsonObj.get("notes").toString()));
       }
       // validate the optional field `period`
-      if (jsonObj.getAsJsonObject("period") != null) {
+      if (jsonObj.get("period") != null && !jsonObj.get("period").isJsonNull()) {
         CreateSelfServiceReservationRequestPeriod.validateJsonObject(jsonObj.getAsJsonObject("period"));
       }
   }
@@ -291,6 +320,23 @@ public class CreateSelfServiceReservationRequest {
            @Override
            public void write(JsonWriter out, CreateSelfServiceReservationRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -298,7 +344,25 @@ public class CreateSelfServiceReservationRequest {
            public CreateSelfServiceReservationRequest read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CreateSelfServiceReservationRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateSelfServiceReservationRequestPeriod.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateSelfServiceReservationRequestPeriod.java
@@ -150,7 +150,7 @@ public class CreateSelfServiceReservationRequestPeriod {
   @SerializedName(SERIALIZED_NAME_UNIT)
   private UnitEnum unit;
 
-  public CreateSelfServiceReservationRequestPeriod() { 
+  public CreateSelfServiceReservationRequestPeriod() {
   }
 
   public CreateSelfServiceReservationRequestPeriod count(CountEnum count) {
@@ -198,6 +198,41 @@ public class CreateSelfServiceReservationRequestPeriod {
     this.unit = unit;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CreateSelfServiceReservationRequestPeriod putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -210,12 +245,13 @@ public class CreateSelfServiceReservationRequestPeriod {
     }
     CreateSelfServiceReservationRequestPeriod createSelfServiceReservationRequestPeriod = (CreateSelfServiceReservationRequestPeriod) o;
     return Objects.equals(this.count, createSelfServiceReservationRequestPeriod.count) &&
-        Objects.equals(this.unit, createSelfServiceReservationRequestPeriod.unit);
+        Objects.equals(this.unit, createSelfServiceReservationRequestPeriod.unit)&&
+        Objects.equals(this.additionalProperties, createSelfServiceReservationRequestPeriod.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(count, unit);
+    return Objects.hash(count, unit, additionalProperties);
   }
 
   @Override
@@ -224,6 +260,7 @@ public class CreateSelfServiceReservationRequestPeriod {
     sb.append("class CreateSelfServiceReservationRequestPeriod {\n");
     sb.append("    count: ").append(toIndentedString(count)).append("\n");
     sb.append("    unit: ").append(toIndentedString(unit)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -267,15 +304,7 @@ public class CreateSelfServiceReservationRequestPeriod {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CreateSelfServiceReservationRequestPeriod is not found in the empty JSON string", CreateSelfServiceReservationRequestPeriod.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CreateSelfServiceReservationRequestPeriod.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateSelfServiceReservationRequestPeriod` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonPrimitive()) {
+      if ((jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonNull()) && !jsonObj.get("unit").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `unit` to be a primitive type in the JSON string but got `%s`", jsonObj.get("unit").toString()));
       }
   }
@@ -295,6 +324,23 @@ public class CreateSelfServiceReservationRequestPeriod {
            @Override
            public void write(JsonWriter out, CreateSelfServiceReservationRequestPeriod value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -302,7 +348,25 @@ public class CreateSelfServiceReservationRequestPeriod {
            public CreateSelfServiceReservationRequestPeriod read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CreateSelfServiceReservationRequestPeriod instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateVrfRequest.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateVrfRequest.java
@@ -76,7 +76,7 @@ public class CreateVrfRequest {
   @SerializedName(SERIALIZED_NAME_PROJECT_ID)
   private UUID projectId;
 
-  public CreateVrfRequest() { 
+  public CreateVrfRequest() {
   }
 
   public CreateVrfRequest description(String description) {
@@ -224,6 +224,41 @@ public class CreateVrfRequest {
     this.projectId = projectId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public CreateVrfRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -240,12 +275,13 @@ public class CreateVrfRequest {
         Objects.equals(this.localAsn, createVrfRequest.localAsn) &&
         Objects.equals(this.metro, createVrfRequest.metro) &&
         Objects.equals(this.name, createVrfRequest.name) &&
-        Objects.equals(this.projectId, createVrfRequest.projectId);
+        Objects.equals(this.projectId, createVrfRequest.projectId)&&
+        Objects.equals(this.additionalProperties, createVrfRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, ipRanges, localAsn, metro, name, projectId);
+    return Objects.hash(description, ipRanges, localAsn, metro, name, projectId, additionalProperties);
   }
 
   @Override
@@ -258,6 +294,7 @@ public class CreateVrfRequest {
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    projectId: ").append(toIndentedString(projectId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -309,34 +346,26 @@ public class CreateVrfRequest {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!CreateVrfRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateVrfRequest` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateVrfRequest.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonArray()) {
+      if ((jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonNull()) && !jsonObj.get("ip_ranges").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_ranges` to be an array in the JSON string but got `%s`", jsonObj.get("ip_ranges").toString()));
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonPrimitive()) {
+      if ((jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonNull()) && !jsonObj.get("project_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project_id").toString()));
       }
   }
@@ -356,6 +385,23 @@ public class CreateVrfRequest {
            @Override
            public void write(JsonWriter out, CreateVrfRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -363,7 +409,25 @@ public class CreateVrfRequest {
            public CreateVrfRequest read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             CreateVrfRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Device.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Device.java
@@ -216,7 +216,7 @@ public class Device {
   @SerializedName(SERIALIZED_NAME_VOLUMES)
   private List<Href> volumes = null;
 
-  public Device() { 
+  public Device() {
   }
 
   public Device alwaysPxe(Boolean alwaysPxe) {
@@ -1132,6 +1132,41 @@ public class Device {
     this.volumes = volumes;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Device putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -1180,12 +1215,13 @@ public class Device {
         Objects.equals(this.updatedAt, device.updatedAt) &&
         Objects.equals(this.user, device.user) &&
         Objects.equals(this.userdata, device.userdata) &&
-        Objects.equals(this.volumes, device.volumes);
+        Objects.equals(this.volumes, device.volumes)&&
+        Objects.equals(this.additionalProperties, device.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alwaysPxe, billingCycle, bondingMode, createdAt, createdBy, customdata, description, facility, hardwareReservation, hostname, href, id, imageUrl, ipAddresses, ipxeScriptUrl, iqn, locked, metro, networkPorts, operatingSystem, plan, project, projectLite, provisioningEvents, provisioningPercentage, rootPassword, shortId, spotInstance, spotPriceMax, sshKeys, state, switchUuid, tags, terminationTime, updatedAt, user, userdata, volumes);
+    return Objects.hash(alwaysPxe, billingCycle, bondingMode, createdAt, createdBy, customdata, description, facility, hardwareReservation, hostname, href, id, imageUrl, ipAddresses, ipxeScriptUrl, iqn, locked, metro, networkPorts, operatingSystem, plan, project, projectLite, provisioningEvents, provisioningPercentage, rootPassword, shortId, spotInstance, spotPriceMax, sshKeys, state, switchUuid, tags, terminationTime, updatedAt, user, userdata, volumes, additionalProperties);
   }
 
   @Override
@@ -1230,6 +1266,7 @@ public class Device {
     sb.append("    user: ").append(toIndentedString(user)).append("\n");
     sb.append("    userdata: ").append(toIndentedString(userdata)).append("\n");
     sb.append("    volumes: ").append(toIndentedString(volumes)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -1309,42 +1346,34 @@ public class Device {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Device is not found in the empty JSON string", Device.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Device.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Device` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
+      if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
       }
       // validate the optional field `created_by`
-      if (jsonObj.getAsJsonObject("created_by") != null) {
+      if (jsonObj.get("created_by") != null && !jsonObj.get("created_by").isJsonNull()) {
         DeviceCreatedBy.validateJsonObject(jsonObj.getAsJsonObject("created_by"));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // validate the optional field `facility`
-      if (jsonObj.getAsJsonObject("facility") != null) {
+      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) {
         Facility.validateJsonObject(jsonObj.getAsJsonObject("facility"));
       }
       // validate the optional field `hardware_reservation`
-      if (jsonObj.getAsJsonObject("hardware_reservation") != null) {
+      if (jsonObj.get("hardware_reservation") != null && !jsonObj.get("hardware_reservation").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("hardware_reservation"));
       }
-      if (jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonPrimitive()) {
+      if ((jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonNull()) && !jsonObj.get("hostname").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `hostname` to be a primitive type in the JSON string but got `%s`", jsonObj.get("hostname").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("image_url") != null && !jsonObj.get("image_url").isJsonPrimitive()) {
+      if ((jsonObj.get("image_url") != null && !jsonObj.get("image_url").isJsonNull()) && !jsonObj.get("image_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `image_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("image_url").toString()));
       }
       JsonArray jsonArrayipAddresses = jsonObj.getAsJsonArray("ip_addresses");
@@ -1359,34 +1388,34 @@ public class Device {
           IPAssignment.validateJsonObject(jsonArrayipAddresses.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("ipxe_script_url") != null && !jsonObj.get("ipxe_script_url").isJsonPrimitive()) {
+      if ((jsonObj.get("ipxe_script_url") != null && !jsonObj.get("ipxe_script_url").isJsonNull()) && !jsonObj.get("ipxe_script_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `ipxe_script_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("ipxe_script_url").toString()));
       }
-      if (jsonObj.get("iqn") != null && !jsonObj.get("iqn").isJsonPrimitive()) {
+      if ((jsonObj.get("iqn") != null && !jsonObj.get("iqn").isJsonNull()) && !jsonObj.get("iqn").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `iqn` to be a primitive type in the JSON string but got `%s`", jsonObj.get("iqn").toString()));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         DeviceMetro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
       // validate the optional field `network_ports`
-      if (jsonObj.getAsJsonObject("network_ports") != null) {
+      if (jsonObj.get("network_ports") != null && !jsonObj.get("network_ports").isJsonNull()) {
         DeviceNetworkPorts.validateJsonObject(jsonObj.getAsJsonObject("network_ports"));
       }
       // validate the optional field `operating_system`
-      if (jsonObj.getAsJsonObject("operating_system") != null) {
+      if (jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonNull()) {
         OperatingSystem.validateJsonObject(jsonObj.getAsJsonObject("operating_system"));
       }
       // validate the optional field `plan`
-      if (jsonObj.getAsJsonObject("plan") != null) {
+      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) {
         Plan.validateJsonObject(jsonObj.getAsJsonObject("plan"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         DeviceProject.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
       // validate the optional field `project_lite`
-      if (jsonObj.getAsJsonObject("project_lite") != null) {
+      if (jsonObj.get("project_lite") != null && !jsonObj.get("project_lite").isJsonNull()) {
         DeviceProjectLite.validateJsonObject(jsonObj.getAsJsonObject("project_lite"));
       }
       JsonArray jsonArrayprovisioningEvents = jsonObj.getAsJsonArray("provisioning_events");
@@ -1401,10 +1430,10 @@ public class Device {
           Event.validateJsonObject(jsonArrayprovisioningEvents.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("root_password") != null && !jsonObj.get("root_password").isJsonPrimitive()) {
+      if ((jsonObj.get("root_password") != null && !jsonObj.get("root_password").isJsonNull()) && !jsonObj.get("root_password").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `root_password` to be a primitive type in the JSON string but got `%s`", jsonObj.get("root_password").toString()));
       }
-      if (jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonPrimitive()) {
+      if ((jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonNull()) && !jsonObj.get("short_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `short_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("short_id").toString()));
       }
       JsonArray jsonArraysshKeys = jsonObj.getAsJsonArray("ssh_keys");
@@ -1419,20 +1448,20 @@ public class Device {
           Href.validateJsonObject(jsonArraysshKeys.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
-      if (jsonObj.get("switch_uuid") != null && !jsonObj.get("switch_uuid").isJsonPrimitive()) {
+      if ((jsonObj.get("switch_uuid") != null && !jsonObj.get("switch_uuid").isJsonNull()) && !jsonObj.get("switch_uuid").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `switch_uuid` to be a primitive type in the JSON string but got `%s`", jsonObj.get("switch_uuid").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("user") != null && !jsonObj.get("user").isJsonPrimitive()) {
+      if ((jsonObj.get("user") != null && !jsonObj.get("user").isJsonNull()) && !jsonObj.get("user").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `user` to be a primitive type in the JSON string but got `%s`", jsonObj.get("user").toString()));
       }
-      if (jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonPrimitive()) {
+      if ((jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonNull()) && !jsonObj.get("userdata").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `userdata` to be a primitive type in the JSON string but got `%s`", jsonObj.get("userdata").toString()));
       }
       JsonArray jsonArrayvolumes = jsonObj.getAsJsonArray("volumes");
@@ -1464,6 +1493,23 @@ public class Device {
            @Override
            public void write(JsonWriter out, Device value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -1471,7 +1517,25 @@ public class Device {
            public Device read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Device instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInput.java
@@ -208,7 +208,7 @@ public class DeviceCreateInput {
   @SerializedName(SERIALIZED_NAME_USERDATA)
   private String userdata;
 
-  public DeviceCreateInput() { 
+  public DeviceCreateInput() {
   }
 
   public DeviceCreateInput alwaysPxe(Boolean alwaysPxe) {
@@ -841,6 +841,41 @@ public class DeviceCreateInput {
     this.userdata = userdata;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -876,7 +911,8 @@ public class DeviceCreateInput {
         Objects.equals(this.tags, deviceCreateInput.tags) &&
         Objects.equals(this.terminationTime, deviceCreateInput.terminationTime) &&
         Objects.equals(this.userSshKeys, deviceCreateInput.userSshKeys) &&
-        Objects.equals(this.userdata, deviceCreateInput.userdata);
+        Objects.equals(this.userdata, deviceCreateInput.userdata)&&
+        Objects.equals(this.additionalProperties, deviceCreateInput.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -885,7 +921,7 @@ public class DeviceCreateInput {
 
   @Override
   public int hashCode() {
-    return Objects.hash(alwaysPxe, billingCycle, customdata, description, facility, features, hardwareReservationId, hostname, ipAddresses, ipxeScriptUrl, locked, metro, noSshKeys, operatingSystem, plan, privateIpv4SubnetSize, projectSshKeys, publicIpv4SubnetSize, spotInstance, spotPriceMax, sshKeys, tags, terminationTime, userSshKeys, userdata);
+    return Objects.hash(alwaysPxe, billingCycle, customdata, description, facility, features, hardwareReservationId, hostname, ipAddresses, ipxeScriptUrl, locked, metro, noSshKeys, operatingSystem, plan, privateIpv4SubnetSize, projectSshKeys, publicIpv4SubnetSize, spotInstance, spotPriceMax, sshKeys, tags, terminationTime, userSshKeys, userdata, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -924,6 +960,7 @@ public class DeviceCreateInput {
     sb.append("    terminationTime: ").append(toIndentedString(terminationTime)).append("\n");
     sb.append("    userSshKeys: ").append(toIndentedString(userSshKeys)).append("\n");
     sb.append("    userdata: ").append(toIndentedString(userdata)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -993,38 +1030,30 @@ public class DeviceCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : DeviceCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
+      if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonArray()) {
+      if ((jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) && !jsonObj.get("facility").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `facility` to be an array in the JSON string but got `%s`", jsonObj.get("facility").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("features") != null && !jsonObj.get("features").isJsonArray()) {
+      if ((jsonObj.get("features") != null && !jsonObj.get("features").isJsonNull()) && !jsonObj.get("features").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `features` to be an array in the JSON string but got `%s`", jsonObj.get("features").toString()));
       }
-      if (jsonObj.get("hardware_reservation_id") != null && !jsonObj.get("hardware_reservation_id").isJsonPrimitive()) {
+      if ((jsonObj.get("hardware_reservation_id") != null && !jsonObj.get("hardware_reservation_id").isJsonNull()) && !jsonObj.get("hardware_reservation_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `hardware_reservation_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("hardware_reservation_id").toString()));
       }
-      if (jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonPrimitive()) {
+      if ((jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonNull()) && !jsonObj.get("hostname").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `hostname` to be a primitive type in the JSON string but got `%s`", jsonObj.get("hostname").toString()));
       }
       JsonArray jsonArrayipAddresses = jsonObj.getAsJsonArray("ip_addresses");
@@ -1039,20 +1068,20 @@ public class DeviceCreateInput {
           DeviceCreateInputIpAddressesInner.validateJsonObject(jsonArrayipAddresses.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("ipxe_script_url") != null && !jsonObj.get("ipxe_script_url").isJsonPrimitive()) {
+      if ((jsonObj.get("ipxe_script_url") != null && !jsonObj.get("ipxe_script_url").isJsonNull()) && !jsonObj.get("ipxe_script_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `ipxe_script_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("ipxe_script_url").toString()));
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonPrimitive()) {
+      if ((jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonNull()) && !jsonObj.get("operating_system").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `operating_system` to be a primitive type in the JSON string but got `%s`", jsonObj.get("operating_system").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("project_ssh_keys") != null && !jsonObj.get("project_ssh_keys").isJsonArray()) {
+      if ((jsonObj.get("project_ssh_keys") != null && !jsonObj.get("project_ssh_keys").isJsonNull()) && !jsonObj.get("project_ssh_keys").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_ssh_keys` to be an array in the JSON string but got `%s`", jsonObj.get("project_ssh_keys").toString()));
       }
       JsonArray jsonArraysshKeys = jsonObj.getAsJsonArray("ssh_keys");
@@ -1068,14 +1097,14 @@ public class DeviceCreateInput {
         };
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("user_ssh_keys") != null && !jsonObj.get("user_ssh_keys").isJsonArray()) {
+      if ((jsonObj.get("user_ssh_keys") != null && !jsonObj.get("user_ssh_keys").isJsonNull()) && !jsonObj.get("user_ssh_keys").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `user_ssh_keys` to be an array in the JSON string but got `%s`", jsonObj.get("user_ssh_keys").toString()));
       }
-      if (jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonPrimitive()) {
+      if ((jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonNull()) && !jsonObj.get("userdata").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `userdata` to be a primitive type in the JSON string but got `%s`", jsonObj.get("userdata").toString()));
       }
   }
@@ -1095,6 +1124,23 @@ public class DeviceCreateInput {
            @Override
            public void write(JsonWriter out, DeviceCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -1102,7 +1148,25 @@ public class DeviceCreateInput {
            public DeviceCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInputIpAddressesInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInputIpAddressesInner.java
@@ -115,7 +115,7 @@ public class DeviceCreateInputIpAddressesInner {
   @SerializedName(SERIALIZED_NAME_PUBLIC)
   private Boolean _public = true;
 
-  public DeviceCreateInputIpAddressesInner() { 
+  public DeviceCreateInputIpAddressesInner() {
   }
 
   public DeviceCreateInputIpAddressesInner addressFamily(AddressFamilyEnum addressFamily) {
@@ -217,6 +217,41 @@ public class DeviceCreateInputIpAddressesInner {
     this._public = _public;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceCreateInputIpAddressesInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -231,12 +266,13 @@ public class DeviceCreateInputIpAddressesInner {
     return Objects.equals(this.addressFamily, deviceCreateInputIpAddressesInner.addressFamily) &&
         Objects.equals(this.cidr, deviceCreateInputIpAddressesInner.cidr) &&
         Objects.equals(this.ipReservations, deviceCreateInputIpAddressesInner.ipReservations) &&
-        Objects.equals(this._public, deviceCreateInputIpAddressesInner._public);
+        Objects.equals(this._public, deviceCreateInputIpAddressesInner._public)&&
+        Objects.equals(this.additionalProperties, deviceCreateInputIpAddressesInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, cidr, ipReservations, _public);
+    return Objects.hash(addressFamily, cidr, ipReservations, _public, additionalProperties);
   }
 
   @Override
@@ -247,6 +283,7 @@ public class DeviceCreateInputIpAddressesInner {
     sb.append("    cidr: ").append(toIndentedString(cidr)).append("\n");
     sb.append("    ipReservations: ").append(toIndentedString(ipReservations)).append("\n");
     sb.append("    _public: ").append(toIndentedString(_public)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -292,16 +329,8 @@ public class DeviceCreateInputIpAddressesInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in DeviceCreateInputIpAddressesInner is not found in the empty JSON string", DeviceCreateInputIpAddressesInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceCreateInputIpAddressesInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceCreateInputIpAddressesInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("ip_reservations") != null && !jsonObj.get("ip_reservations").isJsonArray()) {
+      if ((jsonObj.get("ip_reservations") != null && !jsonObj.get("ip_reservations").isJsonNull()) && !jsonObj.get("ip_reservations").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_reservations` to be an array in the JSON string but got `%s`", jsonObj.get("ip_reservations").toString()));
       }
   }
@@ -321,6 +350,23 @@ public class DeviceCreateInputIpAddressesInner {
            @Override
            public void write(JsonWriter out, DeviceCreateInputIpAddressesInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -328,7 +374,25 @@ public class DeviceCreateInputIpAddressesInner {
            public DeviceCreateInputIpAddressesInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceCreateInputIpAddressesInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreatedBy.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreatedBy.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.UserLite;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -92,7 +91,7 @@ public class DeviceCreatedBy {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public DeviceCreatedBy() { 
+  public DeviceCreatedBy() {
   }
 
   public DeviceCreatedBy avatarThumbUrl(String avatarThumbUrl) {
@@ -324,6 +323,41 @@ public class DeviceCreatedBy {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceCreatedBy putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -344,12 +378,13 @@ public class DeviceCreatedBy {
         Objects.equals(this.id, deviceCreatedBy.id) &&
         Objects.equals(this.lastName, deviceCreatedBy.lastName) &&
         Objects.equals(this.shortId, deviceCreatedBy.shortId) &&
-        Objects.equals(this.updatedAt, deviceCreatedBy.updatedAt);
+        Objects.equals(this.updatedAt, deviceCreatedBy.updatedAt)&&
+        Objects.equals(this.additionalProperties, deviceCreatedBy.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(avatarThumbUrl, createdAt, email, firstName, fullName, href, id, lastName, shortId, updatedAt);
+    return Objects.hash(avatarThumbUrl, createdAt, email, firstName, fullName, href, id, lastName, shortId, updatedAt, additionalProperties);
   }
 
   @Override
@@ -366,6 +401,7 @@ public class DeviceCreatedBy {
     sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
     sb.append("    shortId: ").append(toIndentedString(shortId)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -420,42 +456,34 @@ public class DeviceCreatedBy {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceCreatedBy.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceCreatedBy` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : DeviceCreatedBy.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
+      if ((jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonNull()) && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `avatar_thumb_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("avatar_thumb_url").toString()));
       }
-      if (jsonObj.get("email") != null && !jsonObj.get("email").isJsonPrimitive()) {
+      if ((jsonObj.get("email") != null && !jsonObj.get("email").isJsonNull()) && !jsonObj.get("email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
       }
-      if (jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonPrimitive()) {
+      if ((jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonNull()) && !jsonObj.get("first_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `first_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("first_name").toString()));
       }
-      if (jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonPrimitive()) {
+      if ((jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonNull()) && !jsonObj.get("full_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `full_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("full_name").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonPrimitive()) {
+      if ((jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonNull()) && !jsonObj.get("last_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `last_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("last_name").toString()));
       }
-      if (jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonPrimitive()) {
+      if ((jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonNull()) && !jsonObj.get("short_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `short_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("short_id").toString()));
       }
   }
@@ -475,6 +503,23 @@ public class DeviceCreatedBy {
            @Override
            public void write(JsonWriter out, DeviceCreatedBy value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -482,7 +527,25 @@ public class DeviceCreatedBy {
            public DeviceCreatedBy read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceCreatedBy instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceList.java
@@ -61,7 +61,7 @@ public class DeviceList {
   @SerializedName(SERIALIZED_NAME_META)
   private Meta meta;
 
-  public DeviceList() { 
+  public DeviceList() {
   }
 
   public DeviceList devices(List<Device> devices) {
@@ -117,6 +117,41 @@ public class DeviceList {
     this.meta = meta;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -129,12 +164,13 @@ public class DeviceList {
     }
     DeviceList deviceList = (DeviceList) o;
     return Objects.equals(this.devices, deviceList.devices) &&
-        Objects.equals(this.meta, deviceList.meta);
+        Objects.equals(this.meta, deviceList.meta)&&
+        Objects.equals(this.additionalProperties, deviceList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(devices, meta);
+    return Objects.hash(devices, meta, additionalProperties);
   }
 
   @Override
@@ -143,6 +179,7 @@ public class DeviceList {
     sb.append("class DeviceList {\n");
     sb.append("    devices: ").append(toIndentedString(devices)).append("\n");
     sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -186,14 +223,6 @@ public class DeviceList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in DeviceList is not found in the empty JSON string", DeviceList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraydevices = jsonObj.getAsJsonArray("devices");
       if (jsonArraydevices != null) {
         // ensure the json data is an array
@@ -207,7 +236,7 @@ public class DeviceList {
         };
       }
       // validate the optional field `meta`
-      if (jsonObj.getAsJsonObject("meta") != null) {
+      if (jsonObj.get("meta") != null && !jsonObj.get("meta").isJsonNull()) {
         Meta.validateJsonObject(jsonObj.getAsJsonObject("meta"));
       }
   }
@@ -227,6 +256,23 @@ public class DeviceList {
            @Override
            public void write(JsonWriter out, DeviceList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -234,7 +280,25 @@ public class DeviceList {
            public DeviceList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceMetro.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceMetro.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -67,7 +66,7 @@ public class DeviceMetro {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public DeviceMetro() { 
+  public DeviceMetro() {
   }
 
   public DeviceMetro code(String code) {
@@ -161,6 +160,41 @@ public class DeviceMetro {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceMetro putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -175,12 +209,13 @@ public class DeviceMetro {
     return Objects.equals(this.code, deviceMetro.code) &&
         Objects.equals(this.country, deviceMetro.country) &&
         Objects.equals(this.id, deviceMetro.id) &&
-        Objects.equals(this.name, deviceMetro.name);
+        Objects.equals(this.name, deviceMetro.name)&&
+        Objects.equals(this.additionalProperties, deviceMetro.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(code, country, id, name);
+    return Objects.hash(code, country, id, name, additionalProperties);
   }
 
   @Override
@@ -191,6 +226,7 @@ public class DeviceMetro {
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -236,24 +272,16 @@ public class DeviceMetro {
           throw new IllegalArgumentException(String.format("The required field(s) %s in DeviceMetro is not found in the empty JSON string", DeviceMetro.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceMetro.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceMetro` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
-      if (jsonObj.get("country") != null && !jsonObj.get("country").isJsonPrimitive()) {
+      if ((jsonObj.get("country") != null && !jsonObj.get("country").isJsonNull()) && !jsonObj.get("country").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -273,6 +301,23 @@ public class DeviceMetro {
            @Override
            public void write(JsonWriter out, DeviceMetro value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -280,7 +325,25 @@ public class DeviceMetro {
            public DeviceMetro read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceMetro instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceNetworkPorts.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceNetworkPorts.java
@@ -16,7 +16,6 @@ package com.equinix.openapi.metal.v1.model;
 import java.util.Objects;
 import java.util.Arrays;
 import com.equinix.openapi.metal.v1.model.Href;
-import com.equinix.openapi.metal.v1.model.Port;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -82,7 +81,7 @@ public class DeviceNetworkPorts {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_NETWORKS)
   private List<Href> virtualNetworks = null;
 
-  public DeviceNetworkPorts() { 
+  public DeviceNetworkPorts() {
   }
 
   public DeviceNetworkPorts data(Object data) {
@@ -253,6 +252,41 @@ public class DeviceNetworkPorts {
     this.virtualNetworks = virtualNetworks;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceNetworkPorts putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -270,12 +304,13 @@ public class DeviceNetworkPorts {
         Objects.equals(this.id, deviceNetworkPorts.id) &&
         Objects.equals(this.name, deviceNetworkPorts.name) &&
         Objects.equals(this.type, deviceNetworkPorts.type) &&
-        Objects.equals(this.virtualNetworks, deviceNetworkPorts.virtualNetworks);
+        Objects.equals(this.virtualNetworks, deviceNetworkPorts.virtualNetworks)&&
+        Objects.equals(this.additionalProperties, deviceNetworkPorts.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(data, disbondOperationSupported, href, id, name, type, virtualNetworks);
+    return Objects.hash(data, disbondOperationSupported, href, id, name, type, virtualNetworks, additionalProperties);
   }
 
   @Override
@@ -289,6 +324,7 @@ public class DeviceNetworkPorts {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    virtualNetworks: ").append(toIndentedString(virtualNetworks)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -337,24 +373,16 @@ public class DeviceNetworkPorts {
           throw new IllegalArgumentException(String.format("The required field(s) %s in DeviceNetworkPorts is not found in the empty JSON string", DeviceNetworkPorts.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceNetworkPorts.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceNetworkPorts` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
       JsonArray jsonArrayvirtualNetworks = jsonObj.getAsJsonArray("virtual_networks");
@@ -386,6 +414,23 @@ public class DeviceNetworkPorts {
            @Override
            public void write(JsonWriter out, DeviceNetworkPorts value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -393,7 +438,25 @@ public class DeviceNetworkPorts {
            public DeviceNetworkPorts read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceNetworkPorts instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceProject.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceProject.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.Href;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -54,7 +53,7 @@ public class DeviceProject {
   @SerializedName(SERIALIZED_NAME_HREF)
   private String href;
 
-  public DeviceProject() { 
+  public DeviceProject() {
   }
 
   public DeviceProject href(String href) {
@@ -79,6 +78,41 @@ public class DeviceProject {
     this.href = href;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceProject putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +124,13 @@ public class DeviceProject {
       return false;
     }
     DeviceProject deviceProject = (DeviceProject) o;
-    return Objects.equals(this.href, deviceProject.href);
+    return Objects.equals(this.href, deviceProject.href)&&
+        Objects.equals(this.additionalProperties, deviceProject.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(href);
+    return Objects.hash(href, additionalProperties);
   }
 
   @Override
@@ -103,6 +138,7 @@ public class DeviceProject {
     StringBuilder sb = new StringBuilder();
     sb.append("class DeviceProject {\n");
     sb.append("    href: ").append(toIndentedString(href)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -147,21 +183,13 @@ public class DeviceProject {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceProject.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceProject` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : DeviceProject.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
   }
@@ -181,6 +209,23 @@ public class DeviceProject {
            @Override
            public void write(JsonWriter out, DeviceProject value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -188,7 +233,25 @@ public class DeviceProject {
            public DeviceProject read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceProject instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceProjectLite.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceProjectLite.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.Href;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -54,7 +53,7 @@ public class DeviceProjectLite {
   @SerializedName(SERIALIZED_NAME_HREF)
   private String href;
 
-  public DeviceProjectLite() { 
+  public DeviceProjectLite() {
   }
 
   public DeviceProjectLite href(String href) {
@@ -79,6 +78,41 @@ public class DeviceProjectLite {
     this.href = href;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceProjectLite putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +124,13 @@ public class DeviceProjectLite {
       return false;
     }
     DeviceProjectLite deviceProjectLite = (DeviceProjectLite) o;
-    return Objects.equals(this.href, deviceProjectLite.href);
+    return Objects.equals(this.href, deviceProjectLite.href)&&
+        Objects.equals(this.additionalProperties, deviceProjectLite.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(href);
+    return Objects.hash(href, additionalProperties);
   }
 
   @Override
@@ -103,6 +138,7 @@ public class DeviceProjectLite {
     StringBuilder sb = new StringBuilder();
     sb.append("class DeviceProjectLite {\n");
     sb.append("    href: ").append(toIndentedString(href)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -147,21 +183,13 @@ public class DeviceProjectLite {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceProjectLite.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceProjectLite` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : DeviceProjectLite.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
   }
@@ -181,6 +209,23 @@ public class DeviceProjectLite {
            @Override
            public void write(JsonWriter out, DeviceProjectLite value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -188,7 +233,25 @@ public class DeviceProjectLite {
            public DeviceProjectLite read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceProjectLite instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceUpdateInput.java
@@ -95,7 +95,7 @@ public class DeviceUpdateInput {
   @SerializedName(SERIALIZED_NAME_USERDATA)
   private String userdata;
 
-  public DeviceUpdateInput() { 
+  public DeviceUpdateInput() {
   }
 
   public DeviceUpdateInput alwaysPxe(Boolean alwaysPxe) {
@@ -358,6 +358,41 @@ public class DeviceUpdateInput {
     this.userdata = userdata;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -379,12 +414,13 @@ public class DeviceUpdateInput {
         Objects.equals(this.networkFrozen, deviceUpdateInput.networkFrozen) &&
         Objects.equals(this.spotInstance, deviceUpdateInput.spotInstance) &&
         Objects.equals(this.tags, deviceUpdateInput.tags) &&
-        Objects.equals(this.userdata, deviceUpdateInput.userdata);
+        Objects.equals(this.userdata, deviceUpdateInput.userdata)&&
+        Objects.equals(this.additionalProperties, deviceUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alwaysPxe, billingCycle, customdata, description, hostname, ipxeScriptUrl, locked, networkFrozen, spotInstance, tags, userdata);
+    return Objects.hash(alwaysPxe, billingCycle, customdata, description, hostname, ipxeScriptUrl, locked, networkFrozen, spotInstance, tags, userdata, additionalProperties);
   }
 
   @Override
@@ -402,6 +438,7 @@ public class DeviceUpdateInput {
     sb.append("    spotInstance: ").append(toIndentedString(spotInstance)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    userdata: ").append(toIndentedString(userdata)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -454,31 +491,23 @@ public class DeviceUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in DeviceUpdateInput is not found in the empty JSON string", DeviceUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
+      if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonPrimitive()) {
+      if ((jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonNull()) && !jsonObj.get("hostname").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `hostname` to be a primitive type in the JSON string but got `%s`", jsonObj.get("hostname").toString()));
       }
-      if (jsonObj.get("ipxe_script_url") != null && !jsonObj.get("ipxe_script_url").isJsonPrimitive()) {
+      if ((jsonObj.get("ipxe_script_url") != null && !jsonObj.get("ipxe_script_url").isJsonNull()) && !jsonObj.get("ipxe_script_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `ipxe_script_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("ipxe_script_url").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonPrimitive()) {
+      if ((jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonNull()) && !jsonObj.get("userdata").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `userdata` to be a primitive type in the JSON string but got `%s`", jsonObj.get("userdata").toString()));
       }
   }
@@ -498,6 +527,23 @@ public class DeviceUpdateInput {
            @Override
            public void write(JsonWriter out, DeviceUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -505,7 +551,25 @@ public class DeviceUpdateInput {
            public DeviceUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceUsage.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceUsage.java
@@ -61,7 +61,7 @@ public class DeviceUsage {
   @SerializedName(SERIALIZED_NAME_UNIT)
   private String unit;
 
-  public DeviceUsage() { 
+  public DeviceUsage() {
   }
 
   public DeviceUsage quantity(String quantity) {
@@ -132,6 +132,41 @@ public class DeviceUsage {
     this.unit = unit;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceUsage putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -145,12 +180,13 @@ public class DeviceUsage {
     DeviceUsage deviceUsage = (DeviceUsage) o;
     return Objects.equals(this.quantity, deviceUsage.quantity) &&
         Objects.equals(this.total, deviceUsage.total) &&
-        Objects.equals(this.unit, deviceUsage.unit);
+        Objects.equals(this.unit, deviceUsage.unit)&&
+        Objects.equals(this.additionalProperties, deviceUsage.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(quantity, total, unit);
+    return Objects.hash(quantity, total, unit, additionalProperties);
   }
 
   @Override
@@ -160,6 +196,7 @@ public class DeviceUsage {
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
     sb.append("    total: ").append(toIndentedString(total)).append("\n");
     sb.append("    unit: ").append(toIndentedString(unit)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -204,21 +241,13 @@ public class DeviceUsage {
           throw new IllegalArgumentException(String.format("The required field(s) %s in DeviceUsage is not found in the empty JSON string", DeviceUsage.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceUsage.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceUsage` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonPrimitive()) {
+      if ((jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonNull()) && !jsonObj.get("quantity").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `quantity` to be a primitive type in the JSON string but got `%s`", jsonObj.get("quantity").toString()));
       }
-      if (jsonObj.get("total") != null && !jsonObj.get("total").isJsonPrimitive()) {
+      if ((jsonObj.get("total") != null && !jsonObj.get("total").isJsonNull()) && !jsonObj.get("total").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `total` to be a primitive type in the JSON string but got `%s`", jsonObj.get("total").toString()));
       }
-      if (jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonPrimitive()) {
+      if ((jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonNull()) && !jsonObj.get("unit").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `unit` to be a primitive type in the JSON string but got `%s`", jsonObj.get("unit").toString()));
       }
   }
@@ -238,6 +267,23 @@ public class DeviceUsage {
            @Override
            public void write(JsonWriter out, DeviceUsage value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -245,7 +291,25 @@ public class DeviceUsage {
            public DeviceUsage read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceUsage instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceUsageList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceUsageList.java
@@ -56,7 +56,7 @@ public class DeviceUsageList {
   @SerializedName(SERIALIZED_NAME_USAGES)
   private List<DeviceUsage> usages = null;
 
-  public DeviceUsageList() { 
+  public DeviceUsageList() {
   }
 
   public DeviceUsageList usages(List<DeviceUsage> usages) {
@@ -89,6 +89,41 @@ public class DeviceUsageList {
     this.usages = usages;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public DeviceUsageList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class DeviceUsageList {
       return false;
     }
     DeviceUsageList deviceUsageList = (DeviceUsageList) o;
-    return Objects.equals(this.usages, deviceUsageList.usages);
+    return Objects.equals(this.usages, deviceUsageList.usages)&&
+        Objects.equals(this.additionalProperties, deviceUsageList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(usages);
+    return Objects.hash(usages, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class DeviceUsageList {
     StringBuilder sb = new StringBuilder();
     sb.append("class DeviceUsageList {\n");
     sb.append("    usages: ").append(toIndentedString(usages)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class DeviceUsageList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in DeviceUsageList is not found in the empty JSON string", DeviceUsageList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!DeviceUsageList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DeviceUsageList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayusages = jsonObj.getAsJsonArray("usages");
       if (jsonArrayusages != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class DeviceUsageList {
            @Override
            public void write(JsonWriter out, DeviceUsageList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class DeviceUsageList {
            public DeviceUsageList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             DeviceUsageList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Email.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Email.java
@@ -70,7 +70,7 @@ public class Email {
   @SerializedName(SERIALIZED_NAME_VERIFIED)
   private Boolean verified;
 
-  public Email() { 
+  public Email() {
   }
 
   public Email address(String address) {
@@ -187,6 +187,41 @@ public class Email {
     this.verified = verified;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Email putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -202,12 +237,13 @@ public class Email {
         Objects.equals(this._default, email._default) &&
         Objects.equals(this.href, email.href) &&
         Objects.equals(this.id, email.id) &&
-        Objects.equals(this.verified, email.verified);
+        Objects.equals(this.verified, email.verified)&&
+        Objects.equals(this.additionalProperties, email.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, _default, href, id, verified);
+    return Objects.hash(address, _default, href, id, verified, additionalProperties);
   }
 
   @Override
@@ -219,6 +255,7 @@ public class Email {
     sb.append("    href: ").append(toIndentedString(href)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    verified: ").append(toIndentedString(verified)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -265,21 +302,13 @@ public class Email {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Email is not found in the empty JSON string", Email.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Email.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Email` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonPrimitive()) {
+      if ((jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) && !jsonObj.get("address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
   }
@@ -299,6 +328,23 @@ public class Email {
            @Override
            public void write(JsonWriter out, Email value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -306,7 +352,25 @@ public class Email {
            public Email read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Email instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/EmailInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/EmailInput.java
@@ -57,7 +57,7 @@ public class EmailInput {
   @SerializedName(SERIALIZED_NAME_DEFAULT)
   private Boolean _default;
 
-  public EmailInput() { 
+  public EmailInput() {
   }
 
   public EmailInput address(String address) {
@@ -105,6 +105,41 @@ public class EmailInput {
     this._default = _default;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public EmailInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -117,12 +152,13 @@ public class EmailInput {
     }
     EmailInput emailInput = (EmailInput) o;
     return Objects.equals(this.address, emailInput.address) &&
-        Objects.equals(this._default, emailInput._default);
+        Objects.equals(this._default, emailInput._default)&&
+        Objects.equals(this.additionalProperties, emailInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, _default);
+    return Objects.hash(address, _default, additionalProperties);
   }
 
   @Override
@@ -131,6 +167,7 @@ public class EmailInput {
     sb.append("class EmailInput {\n");
     sb.append("    address: ").append(toIndentedString(address)).append("\n");
     sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -176,21 +213,13 @@ public class EmailInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!EmailInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `EmailInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : EmailInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonPrimitive()) {
+      if ((jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) && !jsonObj.get("address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address").toString()));
       }
   }
@@ -210,6 +239,23 @@ public class EmailInput {
            @Override
            public void write(JsonWriter out, EmailInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -217,7 +263,25 @@ public class EmailInput {
            public EmailInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             EmailInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Entitlement.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Entitlement.java
@@ -98,7 +98,7 @@ public class Entitlement {
   @SerializedName(SERIALIZED_NAME_WEIGHT)
   private Integer weight;
 
-  public Entitlement() { 
+  public Entitlement() {
   }
 
   public Entitlement description(String description) {
@@ -376,6 +376,41 @@ public class Entitlement {
     this.weight = weight;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Entitlement putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -398,12 +433,13 @@ public class Entitlement {
         Objects.equals(this.slug, entitlement.slug) &&
         Objects.equals(this.volumeLimits, entitlement.volumeLimits) &&
         Objects.equals(this.volumeQuota, entitlement.volumeQuota) &&
-        Objects.equals(this.weight, entitlement.weight);
+        Objects.equals(this.weight, entitlement.weight)&&
+        Objects.equals(this.additionalProperties, entitlement.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, featureAccess, href, id, instanceQuota, ipQuota, name, projectQuota, slug, volumeLimits, volumeQuota, weight);
+    return Objects.hash(description, featureAccess, href, id, instanceQuota, ipQuota, name, projectQuota, slug, volumeLimits, volumeQuota, weight, additionalProperties);
   }
 
   @Override
@@ -422,6 +458,7 @@ public class Entitlement {
     sb.append("    volumeLimits: ").append(toIndentedString(volumeLimits)).append("\n");
     sb.append("    volumeQuota: ").append(toIndentedString(volumeQuota)).append("\n");
     sb.append("    weight: ").append(toIndentedString(weight)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -479,33 +516,25 @@ public class Entitlement {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Entitlement.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Entitlement` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : Entitlement.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("slug") != null && !jsonObj.get("slug").isJsonPrimitive()) {
+      if ((jsonObj.get("slug") != null && !jsonObj.get("slug").isJsonNull()) && !jsonObj.get("slug").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `slug` to be a primitive type in the JSON string but got `%s`", jsonObj.get("slug").toString()));
       }
   }
@@ -525,6 +554,23 @@ public class Entitlement {
            @Override
            public void write(JsonWriter out, Entitlement value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -532,7 +578,25 @@ public class Entitlement {
            public Entitlement read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Entitlement instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Error.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Error.java
@@ -60,7 +60,7 @@ public class Error {
   @SerializedName(SERIALIZED_NAME_ERRORS)
   private List<String> errors = null;
 
-  public Error() { 
+  public Error() {
   }
 
   public Error error(String error) {
@@ -116,6 +116,41 @@ public class Error {
     this.errors = errors;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Error putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -128,12 +163,13 @@ public class Error {
     }
     Error error = (Error) o;
     return Objects.equals(this.error, error.error) &&
-        Objects.equals(this.errors, error.errors);
+        Objects.equals(this.errors, error.errors)&&
+        Objects.equals(this.additionalProperties, error.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(error, errors);
+    return Objects.hash(error, errors, additionalProperties);
   }
 
   @Override
@@ -142,6 +178,7 @@ public class Error {
     sb.append("class Error {\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    errors: ").append(toIndentedString(errors)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -185,19 +222,11 @@ public class Error {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Error is not found in the empty JSON string", Error.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Error.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Error` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("error") != null && !jsonObj.get("error").isJsonPrimitive()) {
+      if ((jsonObj.get("error") != null && !jsonObj.get("error").isJsonNull()) && !jsonObj.get("error").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `error` to be a primitive type in the JSON string but got `%s`", jsonObj.get("error").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("errors") != null && !jsonObj.get("errors").isJsonArray()) {
+      if ((jsonObj.get("errors") != null && !jsonObj.get("errors").isJsonNull()) && !jsonObj.get("errors").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `errors` to be an array in the JSON string but got `%s`", jsonObj.get("errors").toString()));
       }
   }
@@ -217,6 +246,23 @@ public class Error {
            @Override
            public void write(JsonWriter out, Error value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -224,7 +270,25 @@ public class Error {
            public Error read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Error instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Event.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Event.java
@@ -86,7 +86,7 @@ public class Event {
   @SerializedName(SERIALIZED_NAME_TYPE)
   private String type;
 
-  public Event() { 
+  public Event() {
   }
 
   public Event body(String body) {
@@ -280,6 +280,41 @@ public class Event {
     this.type = type;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Event putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -298,12 +333,13 @@ public class Event {
         Objects.equals(this.interpolated, event.interpolated) &&
         Objects.equals(this.relationships, event.relationships) &&
         Objects.equals(this.state, event.state) &&
-        Objects.equals(this.type, event.type);
+        Objects.equals(this.type, event.type)&&
+        Objects.equals(this.additionalProperties, event.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(body, createdAt, href, id, interpolated, relationships, state, type);
+    return Objects.hash(body, createdAt, href, id, interpolated, relationships, state, type, additionalProperties);
   }
 
   @Override
@@ -318,6 +354,7 @@ public class Event {
     sb.append("    relationships: ").append(toIndentedString(relationships)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -367,24 +404,16 @@ public class Event {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Event is not found in the empty JSON string", Event.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Event.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Event` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("body") != null && !jsonObj.get("body").isJsonPrimitive()) {
+      if ((jsonObj.get("body") != null && !jsonObj.get("body").isJsonNull()) && !jsonObj.get("body").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `body` to be a primitive type in the JSON string but got `%s`", jsonObj.get("body").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("interpolated") != null && !jsonObj.get("interpolated").isJsonPrimitive()) {
+      if ((jsonObj.get("interpolated") != null && !jsonObj.get("interpolated").isJsonNull()) && !jsonObj.get("interpolated").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `interpolated` to be a primitive type in the JSON string but got `%s`", jsonObj.get("interpolated").toString()));
       }
       JsonArray jsonArrayrelationships = jsonObj.getAsJsonArray("relationships");
@@ -399,10 +428,10 @@ public class Event {
           Href.validateJsonObject(jsonArrayrelationships.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
   }
@@ -422,6 +451,23 @@ public class Event {
            @Override
            public void write(JsonWriter out, Event value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -429,7 +475,25 @@ public class Event {
            public Event read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Event instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/EventList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/EventList.java
@@ -61,7 +61,7 @@ public class EventList {
   @SerializedName(SERIALIZED_NAME_META)
   private Meta meta;
 
-  public EventList() { 
+  public EventList() {
   }
 
   public EventList events(List<Event> events) {
@@ -117,6 +117,41 @@ public class EventList {
     this.meta = meta;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public EventList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -129,12 +164,13 @@ public class EventList {
     }
     EventList eventList = (EventList) o;
     return Objects.equals(this.events, eventList.events) &&
-        Objects.equals(this.meta, eventList.meta);
+        Objects.equals(this.meta, eventList.meta)&&
+        Objects.equals(this.additionalProperties, eventList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(events, meta);
+    return Objects.hash(events, meta, additionalProperties);
   }
 
   @Override
@@ -143,6 +179,7 @@ public class EventList {
     sb.append("class EventList {\n");
     sb.append("    events: ").append(toIndentedString(events)).append("\n");
     sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -186,14 +223,6 @@ public class EventList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in EventList is not found in the empty JSON string", EventList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!EventList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `EventList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayevents = jsonObj.getAsJsonArray("events");
       if (jsonArrayevents != null) {
         // ensure the json data is an array
@@ -207,7 +236,7 @@ public class EventList {
         };
       }
       // validate the optional field `meta`
-      if (jsonObj.getAsJsonObject("meta") != null) {
+      if (jsonObj.get("meta") != null && !jsonObj.get("meta").isJsonNull()) {
         Meta.validateJsonObject(jsonObj.getAsJsonObject("meta"));
       }
   }
@@ -227,6 +256,23 @@ public class EventList {
            @Override
            public void write(JsonWriter out, EventList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -234,7 +280,25 @@ public class EventList {
            public EventList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             EventList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/FabricServiceToken.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/FabricServiceToken.java
@@ -216,7 +216,7 @@ public class FabricServiceToken {
   @SerializedName(SERIALIZED_NAME_STATE)
   private StateEnum state;
 
-  public FabricServiceToken() { 
+  public FabricServiceToken() {
   }
 
   public FabricServiceToken expiresAt(OffsetDateTime expiresAt) {
@@ -356,6 +356,41 @@ public class FabricServiceToken {
     this.state = state;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public FabricServiceToken putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -372,12 +407,13 @@ public class FabricServiceToken {
         Objects.equals(this.maxAllowedSpeed, fabricServiceToken.maxAllowedSpeed) &&
         Objects.equals(this.role, fabricServiceToken.role) &&
         Objects.equals(this.serviceTokenType, fabricServiceToken.serviceTokenType) &&
-        Objects.equals(this.state, fabricServiceToken.state);
+        Objects.equals(this.state, fabricServiceToken.state)&&
+        Objects.equals(this.additionalProperties, fabricServiceToken.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(expiresAt, id, maxAllowedSpeed, role, serviceTokenType, state);
+    return Objects.hash(expiresAt, id, maxAllowedSpeed, role, serviceTokenType, state, additionalProperties);
   }
 
   @Override
@@ -390,6 +426,7 @@ public class FabricServiceToken {
     sb.append("    role: ").append(toIndentedString(role)).append("\n");
     sb.append("    serviceTokenType: ").append(toIndentedString(serviceTokenType)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -437,27 +474,19 @@ public class FabricServiceToken {
           throw new IllegalArgumentException(String.format("The required field(s) %s in FabricServiceToken is not found in the empty JSON string", FabricServiceToken.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!FabricServiceToken.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `FabricServiceToken` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("max_allowed_speed") != null && !jsonObj.get("max_allowed_speed").isJsonPrimitive()) {
+      if ((jsonObj.get("max_allowed_speed") != null && !jsonObj.get("max_allowed_speed").isJsonNull()) && !jsonObj.get("max_allowed_speed").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `max_allowed_speed` to be a primitive type in the JSON string but got `%s`", jsonObj.get("max_allowed_speed").toString()));
       }
-      if (jsonObj.get("role") != null && !jsonObj.get("role").isJsonPrimitive()) {
+      if ((jsonObj.get("role") != null && !jsonObj.get("role").isJsonNull()) && !jsonObj.get("role").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `role` to be a primitive type in the JSON string but got `%s`", jsonObj.get("role").toString()));
       }
-      if (jsonObj.get("service_token_type") != null && !jsonObj.get("service_token_type").isJsonPrimitive()) {
+      if ((jsonObj.get("service_token_type") != null && !jsonObj.get("service_token_type").isJsonNull()) && !jsonObj.get("service_token_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `service_token_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("service_token_type").toString()));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
   }
@@ -477,6 +506,23 @@ public class FabricServiceToken {
            @Override
            public void write(JsonWriter out, FabricServiceToken value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -484,7 +530,25 @@ public class FabricServiceToken {
            public FabricServiceToken read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             FabricServiceToken instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Facility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Facility.java
@@ -135,7 +135,7 @@ public class Facility {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public Facility() { 
+  public Facility() {
   }
 
   public Facility address(Address address) {
@@ -314,6 +314,41 @@ public class Facility {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Facility putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -331,12 +366,13 @@ public class Facility {
         Objects.equals(this.id, facility.id) &&
         Objects.equals(this.ipRanges, facility.ipRanges) &&
         Objects.equals(this.metro, facility.metro) &&
-        Objects.equals(this.name, facility.name);
+        Objects.equals(this.name, facility.name)&&
+        Objects.equals(this.additionalProperties, facility.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, code, features, id, ipRanges, metro, name);
+    return Objects.hash(address, code, features, id, ipRanges, metro, name, additionalProperties);
   }
 
   @Override
@@ -350,6 +386,7 @@ public class Facility {
     sb.append("    ipRanges: ").append(toIndentedString(ipRanges)).append("\n");
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -398,37 +435,29 @@ public class Facility {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Facility is not found in the empty JSON string", Facility.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Facility.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Facility` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `address`
-      if (jsonObj.getAsJsonObject("address") != null) {
+      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) {
         Address.validateJsonObject(jsonObj.getAsJsonObject("address"));
       }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("features") != null && !jsonObj.get("features").isJsonArray()) {
+      if ((jsonObj.get("features") != null && !jsonObj.get("features").isJsonNull()) && !jsonObj.get("features").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `features` to be an array in the JSON string but got `%s`", jsonObj.get("features").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonArray()) {
+      if ((jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonNull()) && !jsonObj.get("ip_ranges").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_ranges` to be an array in the JSON string but got `%s`", jsonObj.get("ip_ranges").toString()));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         DeviceMetro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -448,6 +477,23 @@ public class Facility {
            @Override
            public void write(JsonWriter out, Facility value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -455,7 +501,25 @@ public class Facility {
            public Facility read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Facility instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/FacilityList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/FacilityList.java
@@ -56,7 +56,7 @@ public class FacilityList {
   @SerializedName(SERIALIZED_NAME_FACILITIES)
   private List<Facility> facilities = null;
 
-  public FacilityList() { 
+  public FacilityList() {
   }
 
   public FacilityList facilities(List<Facility> facilities) {
@@ -89,6 +89,41 @@ public class FacilityList {
     this.facilities = facilities;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public FacilityList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class FacilityList {
       return false;
     }
     FacilityList facilityList = (FacilityList) o;
-    return Objects.equals(this.facilities, facilityList.facilities);
+    return Objects.equals(this.facilities, facilityList.facilities)&&
+        Objects.equals(this.additionalProperties, facilityList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(facilities);
+    return Objects.hash(facilities, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class FacilityList {
     StringBuilder sb = new StringBuilder();
     sb.append("class FacilityList {\n");
     sb.append("    facilities: ").append(toIndentedString(facilities)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class FacilityList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in FacilityList is not found in the empty JSON string", FacilityList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!FacilityList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `FacilityList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayfacilities = jsonObj.getAsJsonArray("facilities");
       if (jsonArrayfacilities != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class FacilityList {
            @Override
            public void write(JsonWriter out, FacilityList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class FacilityList {
            public FacilityList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             FacilityList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/GlobalBgpRange.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/GlobalBgpRange.java
@@ -71,7 +71,7 @@ public class GlobalBgpRange {
   @SerializedName(SERIALIZED_NAME_RANGE)
   private String range;
 
-  public GlobalBgpRange() { 
+  public GlobalBgpRange() {
   }
 
   public GlobalBgpRange addressFamily(Integer addressFamily) {
@@ -188,6 +188,41 @@ public class GlobalBgpRange {
     this.range = range;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public GlobalBgpRange putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -203,12 +238,13 @@ public class GlobalBgpRange {
         Objects.equals(this.href, globalBgpRange.href) &&
         Objects.equals(this.id, globalBgpRange.id) &&
         Objects.equals(this.project, globalBgpRange.project) &&
-        Objects.equals(this.range, globalBgpRange.range);
+        Objects.equals(this.range, globalBgpRange.range)&&
+        Objects.equals(this.additionalProperties, globalBgpRange.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, href, id, project, range);
+    return Objects.hash(addressFamily, href, id, project, range, additionalProperties);
   }
 
   @Override
@@ -220,6 +256,7 @@ public class GlobalBgpRange {
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    project: ").append(toIndentedString(project)).append("\n");
     sb.append("    range: ").append(toIndentedString(range)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -266,25 +303,17 @@ public class GlobalBgpRange {
           throw new IllegalArgumentException(String.format("The required field(s) %s in GlobalBgpRange is not found in the empty JSON string", GlobalBgpRange.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!GlobalBgpRange.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GlobalBgpRange` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("range") != null && !jsonObj.get("range").isJsonPrimitive()) {
+      if ((jsonObj.get("range") != null && !jsonObj.get("range").isJsonNull()) && !jsonObj.get("range").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `range` to be a primitive type in the JSON string but got `%s`", jsonObj.get("range").toString()));
       }
   }
@@ -304,6 +333,23 @@ public class GlobalBgpRange {
            @Override
            public void write(JsonWriter out, GlobalBgpRange value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -311,7 +357,25 @@ public class GlobalBgpRange {
            public GlobalBgpRange read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             GlobalBgpRange instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/GlobalBgpRangeList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/GlobalBgpRangeList.java
@@ -56,7 +56,7 @@ public class GlobalBgpRangeList {
   @SerializedName(SERIALIZED_NAME_GLOBAL_BGP_RANGES)
   private List<GlobalBgpRange> globalBgpRanges = null;
 
-  public GlobalBgpRangeList() { 
+  public GlobalBgpRangeList() {
   }
 
   public GlobalBgpRangeList globalBgpRanges(List<GlobalBgpRange> globalBgpRanges) {
@@ -89,6 +89,41 @@ public class GlobalBgpRangeList {
     this.globalBgpRanges = globalBgpRanges;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public GlobalBgpRangeList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class GlobalBgpRangeList {
       return false;
     }
     GlobalBgpRangeList globalBgpRangeList = (GlobalBgpRangeList) o;
-    return Objects.equals(this.globalBgpRanges, globalBgpRangeList.globalBgpRanges);
+    return Objects.equals(this.globalBgpRanges, globalBgpRangeList.globalBgpRanges)&&
+        Objects.equals(this.additionalProperties, globalBgpRangeList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(globalBgpRanges);
+    return Objects.hash(globalBgpRanges, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class GlobalBgpRangeList {
     StringBuilder sb = new StringBuilder();
     sb.append("class GlobalBgpRangeList {\n");
     sb.append("    globalBgpRanges: ").append(toIndentedString(globalBgpRanges)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class GlobalBgpRangeList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in GlobalBgpRangeList is not found in the empty JSON string", GlobalBgpRangeList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!GlobalBgpRangeList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GlobalBgpRangeList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayglobalBgpRanges = jsonObj.getAsJsonArray("global_bgp_ranges");
       if (jsonArrayglobalBgpRanges != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class GlobalBgpRangeList {
            @Override
            public void write(JsonWriter out, GlobalBgpRangeList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class GlobalBgpRangeList {
            public GlobalBgpRangeList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             GlobalBgpRangeList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/HardwareReservation.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/HardwareReservation.java
@@ -107,7 +107,7 @@ public class HardwareReservation {
   @SerializedName(SERIALIZED_NAME_SWITCH_UUID)
   private String switchUuid;
 
-  public HardwareReservation() { 
+  public HardwareReservation() {
   }
 
   public HardwareReservation createdAt(OffsetDateTime createdAt) {
@@ -408,6 +408,41 @@ public class HardwareReservation {
     this.switchUuid = switchUuid;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public HardwareReservation putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -431,12 +466,13 @@ public class HardwareReservation {
         Objects.equals(this.provisionable, hardwareReservation.provisionable) &&
         Objects.equals(this.shortId, hardwareReservation.shortId) &&
         Objects.equals(this.spare, hardwareReservation.spare) &&
-        Objects.equals(this.switchUuid, hardwareReservation.switchUuid);
+        Objects.equals(this.switchUuid, hardwareReservation.switchUuid)&&
+        Objects.equals(this.additionalProperties, hardwareReservation.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, customRate, device, facility, href, id, needOfService, plan, project, provisionable, shortId, spare, switchUuid);
+    return Objects.hash(createdAt, customRate, device, facility, href, id, needOfService, plan, project, provisionable, shortId, spare, switchUuid, additionalProperties);
   }
 
   @Override
@@ -456,6 +492,7 @@ public class HardwareReservation {
     sb.append("    shortId: ").append(toIndentedString(shortId)).append("\n");
     sb.append("    spare: ").append(toIndentedString(spare)).append("\n");
     sb.append("    switchUuid: ").append(toIndentedString(switchUuid)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -510,40 +547,32 @@ public class HardwareReservation {
           throw new IllegalArgumentException(String.format("The required field(s) %s in HardwareReservation is not found in the empty JSON string", HardwareReservation.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!HardwareReservation.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `HardwareReservation` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `device`
-      if (jsonObj.getAsJsonObject("device") != null) {
+      if (jsonObj.get("device") != null && !jsonObj.get("device").isJsonNull()) {
         Device.validateJsonObject(jsonObj.getAsJsonObject("device"));
       }
       // validate the optional field `facility`
-      if (jsonObj.getAsJsonObject("facility") != null) {
+      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) {
         Facility.validateJsonObject(jsonObj.getAsJsonObject("facility"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `plan`
-      if (jsonObj.getAsJsonObject("plan") != null) {
+      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) {
         Plan.validateJsonObject(jsonObj.getAsJsonObject("plan"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Project.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonPrimitive()) {
+      if ((jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonNull()) && !jsonObj.get("short_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `short_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("short_id").toString()));
       }
-      if (jsonObj.get("switch_uuid") != null && !jsonObj.get("switch_uuid").isJsonPrimitive()) {
+      if ((jsonObj.get("switch_uuid") != null && !jsonObj.get("switch_uuid").isJsonNull()) && !jsonObj.get("switch_uuid").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `switch_uuid` to be a primitive type in the JSON string but got `%s`", jsonObj.get("switch_uuid").toString()));
       }
   }
@@ -563,6 +592,23 @@ public class HardwareReservation {
            @Override
            public void write(JsonWriter out, HardwareReservation value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -570,7 +616,25 @@ public class HardwareReservation {
            public HardwareReservation read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             HardwareReservation instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/HardwareReservationList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/HardwareReservationList.java
@@ -61,7 +61,7 @@ public class HardwareReservationList {
   @SerializedName(SERIALIZED_NAME_META)
   private Meta meta;
 
-  public HardwareReservationList() { 
+  public HardwareReservationList() {
   }
 
   public HardwareReservationList hardwareReservations(List<HardwareReservation> hardwareReservations) {
@@ -117,6 +117,41 @@ public class HardwareReservationList {
     this.meta = meta;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public HardwareReservationList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -129,12 +164,13 @@ public class HardwareReservationList {
     }
     HardwareReservationList hardwareReservationList = (HardwareReservationList) o;
     return Objects.equals(this.hardwareReservations, hardwareReservationList.hardwareReservations) &&
-        Objects.equals(this.meta, hardwareReservationList.meta);
+        Objects.equals(this.meta, hardwareReservationList.meta)&&
+        Objects.equals(this.additionalProperties, hardwareReservationList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(hardwareReservations, meta);
+    return Objects.hash(hardwareReservations, meta, additionalProperties);
   }
 
   @Override
@@ -143,6 +179,7 @@ public class HardwareReservationList {
     sb.append("class HardwareReservationList {\n");
     sb.append("    hardwareReservations: ").append(toIndentedString(hardwareReservations)).append("\n");
     sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -186,14 +223,6 @@ public class HardwareReservationList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in HardwareReservationList is not found in the empty JSON string", HardwareReservationList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!HardwareReservationList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `HardwareReservationList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayhardwareReservations = jsonObj.getAsJsonArray("hardware_reservations");
       if (jsonArrayhardwareReservations != null) {
         // ensure the json data is an array
@@ -207,7 +236,7 @@ public class HardwareReservationList {
         };
       }
       // validate the optional field `meta`
-      if (jsonObj.getAsJsonObject("meta") != null) {
+      if (jsonObj.get("meta") != null && !jsonObj.get("meta").isJsonNull()) {
         Meta.validateJsonObject(jsonObj.getAsJsonObject("meta"));
       }
   }
@@ -227,6 +256,23 @@ public class HardwareReservationList {
            @Override
            public void write(JsonWriter out, HardwareReservationList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -234,7 +280,25 @@ public class HardwareReservationList {
            public HardwareReservationList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             HardwareReservationList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Href.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Href.java
@@ -53,7 +53,7 @@ public class Href {
   @SerializedName(SERIALIZED_NAME_HREF)
   private String href;
 
-  public Href() { 
+  public Href() {
   }
 
   public Href href(String href) {
@@ -78,6 +78,41 @@ public class Href {
     this.href = href;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Href putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -89,12 +124,13 @@ public class Href {
       return false;
     }
     Href href = (Href) o;
-    return Objects.equals(this.href, href.href);
+    return Objects.equals(this.href, href.href)&&
+        Objects.equals(this.additionalProperties, href.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(href);
+    return Objects.hash(href, additionalProperties);
   }
 
   @Override
@@ -102,6 +138,7 @@ public class Href {
     StringBuilder sb = new StringBuilder();
     sb.append("class Href {\n");
     sb.append("    href: ").append(toIndentedString(href)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -146,21 +183,13 @@ public class Href {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Href.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Href` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : Href.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
   }
@@ -180,6 +209,23 @@ public class Href {
            @Override
            public void write(JsonWriter out, Href value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -187,7 +233,25 @@ public class Href {
            public Href read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Href instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignment.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignment.java
@@ -122,7 +122,7 @@ public class IPAssignment {
   @SerializedName(SERIALIZED_NAME_PUBLIC)
   private Boolean _public;
 
-  public IPAssignment() { 
+  public IPAssignment() {
   }
 
   public IPAssignment address(String address) {
@@ -515,6 +515,41 @@ public class IPAssignment {
     this._public = _public;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPAssignment putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -542,12 +577,13 @@ public class IPAssignment {
         Objects.equals(this.netmask, ipAssignment.netmask) &&
         Objects.equals(this.network, ipAssignment.network) &&
         Objects.equals(this.parentBlock, ipAssignment.parentBlock) &&
-        Objects.equals(this._public, ipAssignment._public);
+        Objects.equals(this._public, ipAssignment._public)&&
+        Objects.equals(this.additionalProperties, ipAssignment.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, addressFamily, assignedTo, cidr, createdAt, enabled, gateway, globalIp, href, id, manageable, management, metro, netmask, network, parentBlock, _public);
+    return Objects.hash(address, addressFamily, assignedTo, cidr, createdAt, enabled, gateway, globalIp, href, id, manageable, management, metro, netmask, network, parentBlock, _public, additionalProperties);
   }
 
   @Override
@@ -571,6 +607,7 @@ public class IPAssignment {
     sb.append("    network: ").append(toIndentedString(network)).append("\n");
     sb.append("    parentBlock: ").append(toIndentedString(parentBlock)).append("\n");
     sb.append("    _public: ").append(toIndentedString(_public)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -629,42 +666,34 @@ public class IPAssignment {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPAssignment is not found in the empty JSON string", IPAssignment.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPAssignment.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPAssignment` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonPrimitive()) {
+      if ((jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) && !jsonObj.get("address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address").toString()));
       }
       // validate the optional field `assigned_to`
-      if (jsonObj.getAsJsonObject("assigned_to") != null) {
+      if (jsonObj.get("assigned_to") != null && !jsonObj.get("assigned_to").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("assigned_to"));
       }
-      if (jsonObj.get("gateway") != null && !jsonObj.get("gateway").isJsonPrimitive()) {
+      if ((jsonObj.get("gateway") != null && !jsonObj.get("gateway").isJsonNull()) && !jsonObj.get("gateway").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `gateway` to be a primitive type in the JSON string but got `%s`", jsonObj.get("gateway").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         IPAssignmentMetro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
-      if (jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonPrimitive()) {
+      if ((jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonNull()) && !jsonObj.get("netmask").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `netmask` to be a primitive type in the JSON string but got `%s`", jsonObj.get("netmask").toString()));
       }
-      if (jsonObj.get("network") != null && !jsonObj.get("network").isJsonPrimitive()) {
+      if ((jsonObj.get("network") != null && !jsonObj.get("network").isJsonNull()) && !jsonObj.get("network").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `network` to be a primitive type in the JSON string but got `%s`", jsonObj.get("network").toString()));
       }
       // validate the optional field `parent_block`
-      if (jsonObj.getAsJsonObject("parent_block") != null) {
+      if (jsonObj.get("parent_block") != null && !jsonObj.get("parent_block").isJsonNull()) {
         ParentBlock.validateJsonObject(jsonObj.getAsJsonObject("parent_block"));
       }
   }
@@ -684,6 +713,23 @@ public class IPAssignment {
            @Override
            public void write(JsonWriter out, IPAssignment value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -691,7 +737,25 @@ public class IPAssignment {
            public IPAssignment read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPAssignment instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignmentInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignmentInput.java
@@ -61,7 +61,7 @@ public class IPAssignmentInput {
   @SerializedName(SERIALIZED_NAME_MANAGEABLE)
   private Boolean manageable;
 
-  public IPAssignmentInput() { 
+  public IPAssignmentInput() {
   }
 
   public IPAssignmentInput address(String address) {
@@ -132,6 +132,41 @@ public class IPAssignmentInput {
     this.manageable = manageable;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPAssignmentInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -145,12 +180,13 @@ public class IPAssignmentInput {
     IPAssignmentInput ipAssignmentInput = (IPAssignmentInput) o;
     return Objects.equals(this.address, ipAssignmentInput.address) &&
         Objects.equals(this.customdata, ipAssignmentInput.customdata) &&
-        Objects.equals(this.manageable, ipAssignmentInput.manageable);
+        Objects.equals(this.manageable, ipAssignmentInput.manageable)&&
+        Objects.equals(this.additionalProperties, ipAssignmentInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, customdata, manageable);
+    return Objects.hash(address, customdata, manageable, additionalProperties);
   }
 
   @Override
@@ -160,6 +196,7 @@ public class IPAssignmentInput {
     sb.append("    address: ").append(toIndentedString(address)).append("\n");
     sb.append("    customdata: ").append(toIndentedString(customdata)).append("\n");
     sb.append("    manageable: ").append(toIndentedString(manageable)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -206,21 +243,13 @@ public class IPAssignmentInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPAssignmentInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPAssignmentInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IPAssignmentInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonPrimitive()) {
+      if ((jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) && !jsonObj.get("address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address").toString()));
       }
   }
@@ -240,6 +269,23 @@ public class IPAssignmentInput {
            @Override
            public void write(JsonWriter out, IPAssignmentInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -247,7 +293,25 @@ public class IPAssignmentInput {
            public IPAssignmentInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPAssignmentInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignmentList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignmentList.java
@@ -56,7 +56,7 @@ public class IPAssignmentList {
   @SerializedName(SERIALIZED_NAME_IP_ADDRESSES)
   private List<IPAssignment> ipAddresses = null;
 
-  public IPAssignmentList() { 
+  public IPAssignmentList() {
   }
 
   public IPAssignmentList ipAddresses(List<IPAssignment> ipAddresses) {
@@ -89,6 +89,41 @@ public class IPAssignmentList {
     this.ipAddresses = ipAddresses;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPAssignmentList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class IPAssignmentList {
       return false;
     }
     IPAssignmentList ipAssignmentList = (IPAssignmentList) o;
-    return Objects.equals(this.ipAddresses, ipAssignmentList.ipAddresses);
+    return Objects.equals(this.ipAddresses, ipAssignmentList.ipAddresses)&&
+        Objects.equals(this.additionalProperties, ipAssignmentList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ipAddresses);
+    return Objects.hash(ipAddresses, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class IPAssignmentList {
     StringBuilder sb = new StringBuilder();
     sb.append("class IPAssignmentList {\n");
     sb.append("    ipAddresses: ").append(toIndentedString(ipAddresses)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class IPAssignmentList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPAssignmentList is not found in the empty JSON string", IPAssignmentList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPAssignmentList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPAssignmentList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayipAddresses = jsonObj.getAsJsonArray("ip_addresses");
       if (jsonArrayipAddresses != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class IPAssignmentList {
            @Override
            public void write(JsonWriter out, IPAssignmentList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class IPAssignmentList {
            public IPAssignmentList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPAssignmentList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignmentMetro.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignmentMetro.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -67,7 +66,7 @@ public class IPAssignmentMetro {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public IPAssignmentMetro() { 
+  public IPAssignmentMetro() {
   }
 
   public IPAssignmentMetro code(String code) {
@@ -161,6 +160,41 @@ public class IPAssignmentMetro {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPAssignmentMetro putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -175,12 +209,13 @@ public class IPAssignmentMetro {
     return Objects.equals(this.code, ipAssignmentMetro.code) &&
         Objects.equals(this.country, ipAssignmentMetro.country) &&
         Objects.equals(this.id, ipAssignmentMetro.id) &&
-        Objects.equals(this.name, ipAssignmentMetro.name);
+        Objects.equals(this.name, ipAssignmentMetro.name)&&
+        Objects.equals(this.additionalProperties, ipAssignmentMetro.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(code, country, id, name);
+    return Objects.hash(code, country, id, name, additionalProperties);
   }
 
   @Override
@@ -191,6 +226,7 @@ public class IPAssignmentMetro {
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -236,24 +272,16 @@ public class IPAssignmentMetro {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPAssignmentMetro is not found in the empty JSON string", IPAssignmentMetro.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPAssignmentMetro.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPAssignmentMetro` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
-      if (jsonObj.get("country") != null && !jsonObj.get("country").isJsonPrimitive()) {
+      if ((jsonObj.get("country") != null && !jsonObj.get("country").isJsonNull()) && !jsonObj.get("country").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -273,6 +301,23 @@ public class IPAssignmentMetro {
            @Override
            public void write(JsonWriter out, IPAssignmentMetro value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -280,7 +325,25 @@ public class IPAssignmentMetro {
            public IPAssignmentMetro read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPAssignmentMetro instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAvailabilitiesList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAvailabilitiesList.java
@@ -55,7 +55,7 @@ public class IPAvailabilitiesList {
   @SerializedName(SERIALIZED_NAME_AVAILABLE)
   private List<String> available = null;
 
-  public IPAvailabilitiesList() { 
+  public IPAvailabilitiesList() {
   }
 
   public IPAvailabilitiesList available(List<String> available) {
@@ -88,6 +88,41 @@ public class IPAvailabilitiesList {
     this.available = available;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPAvailabilitiesList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -99,12 +134,13 @@ public class IPAvailabilitiesList {
       return false;
     }
     IPAvailabilitiesList ipAvailabilitiesList = (IPAvailabilitiesList) o;
-    return Objects.equals(this.available, ipAvailabilitiesList.available);
+    return Objects.equals(this.available, ipAvailabilitiesList.available)&&
+        Objects.equals(this.additionalProperties, ipAvailabilitiesList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(available);
+    return Objects.hash(available, additionalProperties);
   }
 
   @Override
@@ -112,6 +148,7 @@ public class IPAvailabilitiesList {
     StringBuilder sb = new StringBuilder();
     sb.append("class IPAvailabilitiesList {\n");
     sb.append("    available: ").append(toIndentedString(available)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -154,16 +191,8 @@ public class IPAvailabilitiesList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPAvailabilitiesList is not found in the empty JSON string", IPAvailabilitiesList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPAvailabilitiesList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPAvailabilitiesList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("available") != null && !jsonObj.get("available").isJsonArray()) {
+      if ((jsonObj.get("available") != null && !jsonObj.get("available").isJsonNull()) && !jsonObj.get("available").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `available` to be an array in the JSON string but got `%s`", jsonObj.get("available").toString()));
       }
   }
@@ -183,6 +212,23 @@ public class IPAvailabilitiesList {
            @Override
            public void write(JsonWriter out, IPAvailabilitiesList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -190,7 +236,25 @@ public class IPAvailabilitiesList {
            public IPAvailabilitiesList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPAvailabilitiesList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservation.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservation.java
@@ -137,7 +137,7 @@ public class IPReservation {
   @SerializedName(SERIALIZED_NAME_TAGS)
   private List<String> tags = null;
 
-  public IPReservation() { 
+  public IPReservation() {
   }
 
   public IPReservation addon(Boolean addon) {
@@ -615,6 +615,41 @@ public class IPReservation {
     this.tags = tags;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPReservation putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -645,12 +680,13 @@ public class IPReservation {
         Objects.equals(this.network, ipReservation.network) &&
         Objects.equals(this._public, ipReservation._public) &&
         Objects.equals(this.state, ipReservation.state) &&
-        Objects.equals(this.tags, ipReservation.tags);
+        Objects.equals(this.tags, ipReservation.tags)&&
+        Objects.equals(this.additionalProperties, ipReservation.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addon, addressFamily, assignments, bill, cidr, createdAt, enabled, facility, globalIp, href, id, manageable, management, metalGateway, metro, netmask, network, _public, state, tags);
+    return Objects.hash(addon, addressFamily, assignments, bill, cidr, createdAt, enabled, facility, globalIp, href, id, manageable, management, metalGateway, metro, netmask, network, _public, state, tags, additionalProperties);
   }
 
   @Override
@@ -677,6 +713,7 @@ public class IPReservation {
     sb.append("    _public: ").append(toIndentedString(_public)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -738,14 +775,6 @@ public class IPReservation {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPReservation is not found in the empty JSON string", IPReservation.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPReservation.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPReservation` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayassignments = jsonObj.getAsJsonArray("assignments");
       if (jsonArrayassignments != null) {
         // ensure the json data is an array
@@ -759,34 +788,34 @@ public class IPReservation {
         };
       }
       // validate the optional field `facility`
-      if (jsonObj.getAsJsonObject("facility") != null) {
+      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) {
         IPReservationFacility.validateJsonObject(jsonObj.getAsJsonObject("facility"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `metal_gateway`
-      if (jsonObj.getAsJsonObject("metal_gateway") != null) {
+      if (jsonObj.get("metal_gateway") != null && !jsonObj.get("metal_gateway").isJsonNull()) {
         MetalGatewayLite.validateJsonObject(jsonObj.getAsJsonObject("metal_gateway"));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         IPReservationMetro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
-      if (jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonPrimitive()) {
+      if ((jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonNull()) && !jsonObj.get("netmask").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `netmask` to be a primitive type in the JSON string but got `%s`", jsonObj.get("netmask").toString()));
       }
-      if (jsonObj.get("network") != null && !jsonObj.get("network").isJsonPrimitive()) {
+      if ((jsonObj.get("network") != null && !jsonObj.get("network").isJsonNull()) && !jsonObj.get("network").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `network` to be a primitive type in the JSON string but got `%s`", jsonObj.get("network").toString()));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
   }
@@ -806,6 +835,23 @@ public class IPReservation {
            @Override
            public void write(JsonWriter out, IPReservation value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -813,7 +859,25 @@ public class IPReservation {
            public IPReservation read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPReservation instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationFacility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationFacility.java
@@ -17,7 +17,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import com.equinix.openapi.metal.v1.model.Address;
 import com.equinix.openapi.metal.v1.model.DeviceMetro;
-import com.equinix.openapi.metal.v1.model.Facility;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -136,7 +135,7 @@ public class IPReservationFacility {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public IPReservationFacility() { 
+  public IPReservationFacility() {
   }
 
   public IPReservationFacility address(Address address) {
@@ -315,6 +314,41 @@ public class IPReservationFacility {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPReservationFacility putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -332,12 +366,13 @@ public class IPReservationFacility {
         Objects.equals(this.id, ipReservationFacility.id) &&
         Objects.equals(this.ipRanges, ipReservationFacility.ipRanges) &&
         Objects.equals(this.metro, ipReservationFacility.metro) &&
-        Objects.equals(this.name, ipReservationFacility.name);
+        Objects.equals(this.name, ipReservationFacility.name)&&
+        Objects.equals(this.additionalProperties, ipReservationFacility.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, code, features, id, ipRanges, metro, name);
+    return Objects.hash(address, code, features, id, ipRanges, metro, name, additionalProperties);
   }
 
   @Override
@@ -351,6 +386,7 @@ public class IPReservationFacility {
     sb.append("    ipRanges: ").append(toIndentedString(ipRanges)).append("\n");
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -399,37 +435,29 @@ public class IPReservationFacility {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPReservationFacility is not found in the empty JSON string", IPReservationFacility.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPReservationFacility.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPReservationFacility` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `address`
-      if (jsonObj.getAsJsonObject("address") != null) {
+      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) {
         Address.validateJsonObject(jsonObj.getAsJsonObject("address"));
       }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("features") != null && !jsonObj.get("features").isJsonArray()) {
+      if ((jsonObj.get("features") != null && !jsonObj.get("features").isJsonNull()) && !jsonObj.get("features").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `features` to be an array in the JSON string but got `%s`", jsonObj.get("features").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonArray()) {
+      if ((jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonNull()) && !jsonObj.get("ip_ranges").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_ranges` to be an array in the JSON string but got `%s`", jsonObj.get("ip_ranges").toString()));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         DeviceMetro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -449,6 +477,23 @@ public class IPReservationFacility {
            @Override
            public void write(JsonWriter out, IPReservationFacility value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -456,7 +501,25 @@ public class IPReservationFacility {
            public IPReservationFacility read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPReservationFacility instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationList.java
@@ -56,7 +56,7 @@ public class IPReservationList {
   @SerializedName(SERIALIZED_NAME_IP_ADDRESSES)
   private List<IPReservationListIpAddressesInner> ipAddresses = null;
 
-  public IPReservationList() { 
+  public IPReservationList() {
   }
 
   public IPReservationList ipAddresses(List<IPReservationListIpAddressesInner> ipAddresses) {
@@ -89,6 +89,41 @@ public class IPReservationList {
     this.ipAddresses = ipAddresses;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPReservationList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class IPReservationList {
       return false;
     }
     IPReservationList ipReservationList = (IPReservationList) o;
-    return Objects.equals(this.ipAddresses, ipReservationList.ipAddresses);
+    return Objects.equals(this.ipAddresses, ipReservationList.ipAddresses)&&
+        Objects.equals(this.additionalProperties, ipReservationList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ipAddresses);
+    return Objects.hash(ipAddresses, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class IPReservationList {
     StringBuilder sb = new StringBuilder();
     sb.append("class IPReservationList {\n");
     sb.append("    ipAddresses: ").append(toIndentedString(ipAddresses)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class IPReservationList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPReservationList is not found in the empty JSON string", IPReservationList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPReservationList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPReservationList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayipAddresses = jsonObj.getAsJsonArray("ip_addresses");
       if (jsonArrayipAddresses != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class IPReservationList {
            @Override
            public void write(JsonWriter out, IPReservationList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class IPReservationList {
            public IPReservationList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPReservationList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationMetro.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationMetro.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -67,7 +66,7 @@ public class IPReservationMetro {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public IPReservationMetro() { 
+  public IPReservationMetro() {
   }
 
   public IPReservationMetro code(String code) {
@@ -161,6 +160,41 @@ public class IPReservationMetro {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPReservationMetro putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -175,12 +209,13 @@ public class IPReservationMetro {
     return Objects.equals(this.code, ipReservationMetro.code) &&
         Objects.equals(this.country, ipReservationMetro.country) &&
         Objects.equals(this.id, ipReservationMetro.id) &&
-        Objects.equals(this.name, ipReservationMetro.name);
+        Objects.equals(this.name, ipReservationMetro.name)&&
+        Objects.equals(this.additionalProperties, ipReservationMetro.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(code, country, id, name);
+    return Objects.hash(code, country, id, name, additionalProperties);
   }
 
   @Override
@@ -191,6 +226,7 @@ public class IPReservationMetro {
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -236,24 +272,16 @@ public class IPReservationMetro {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IPReservationMetro is not found in the empty JSON string", IPReservationMetro.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPReservationMetro.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPReservationMetro` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
-      if (jsonObj.get("country") != null && !jsonObj.get("country").isJsonPrimitive()) {
+      if ((jsonObj.get("country") != null && !jsonObj.get("country").isJsonNull()) && !jsonObj.get("country").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -273,6 +301,23 @@ public class IPReservationMetro {
            @Override
            public void write(JsonWriter out, IPReservationMetro value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -280,7 +325,25 @@ public class IPReservationMetro {
            public IPReservationMetro read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPReservationMetro instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationRequestInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationRequestInput.java
@@ -87,7 +87,7 @@ public class IPReservationRequestInput {
   @SerializedName(SERIALIZED_NAME_TYPE)
   private String type;
 
-  public IPReservationRequestInput() { 
+  public IPReservationRequestInput() {
   }
 
   public IPReservationRequestInput comments(String comments) {
@@ -304,6 +304,41 @@ public class IPReservationRequestInput {
     this.type = type;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public IPReservationRequestInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -323,12 +358,13 @@ public class IPReservationRequestInput {
         Objects.equals(this.metro, ipReservationRequestInput.metro) &&
         Objects.equals(this.quantity, ipReservationRequestInput.quantity) &&
         Objects.equals(this.tags, ipReservationRequestInput.tags) &&
-        Objects.equals(this.type, ipReservationRequestInput.type);
+        Objects.equals(this.type, ipReservationRequestInput.type)&&
+        Objects.equals(this.additionalProperties, ipReservationRequestInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(comments, customdata, details, facility, failOnApprovalRequired, metro, quantity, tags, type);
+    return Objects.hash(comments, customdata, details, facility, failOnApprovalRequired, metro, quantity, tags, type, additionalProperties);
   }
 
   @Override
@@ -344,6 +380,7 @@ public class IPReservationRequestInput {
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -397,37 +434,29 @@ public class IPReservationRequestInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!IPReservationRequestInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IPReservationRequestInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IPReservationRequestInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("comments") != null && !jsonObj.get("comments").isJsonPrimitive()) {
+      if ((jsonObj.get("comments") != null && !jsonObj.get("comments").isJsonNull()) && !jsonObj.get("comments").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `comments` to be a primitive type in the JSON string but got `%s`", jsonObj.get("comments").toString()));
       }
-      if (jsonObj.get("details") != null && !jsonObj.get("details").isJsonPrimitive()) {
+      if ((jsonObj.get("details") != null && !jsonObj.get("details").isJsonNull()) && !jsonObj.get("details").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `details` to be a primitive type in the JSON string but got `%s`", jsonObj.get("details").toString()));
       }
-      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonPrimitive()) {
+      if ((jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) && !jsonObj.get("facility").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `facility` to be a primitive type in the JSON string but got `%s`", jsonObj.get("facility").toString()));
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
   }
@@ -447,6 +476,23 @@ public class IPReservationRequestInput {
            @Override
            public void write(JsonWriter out, IPReservationRequestInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -454,7 +500,25 @@ public class IPReservationRequestInput {
            public IPReservationRequestInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             IPReservationRequestInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInput.java
@@ -56,7 +56,7 @@ public class InstancesBatchCreateInput {
   @SerializedName(SERIALIZED_NAME_BATCHES)
   private List<InstancesBatchCreateInputBatchesInner> batches = null;
 
-  public InstancesBatchCreateInput() { 
+  public InstancesBatchCreateInput() {
   }
 
   public InstancesBatchCreateInput batches(List<InstancesBatchCreateInputBatchesInner> batches) {
@@ -89,6 +89,41 @@ public class InstancesBatchCreateInput {
     this.batches = batches;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InstancesBatchCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class InstancesBatchCreateInput {
       return false;
     }
     InstancesBatchCreateInput instancesBatchCreateInput = (InstancesBatchCreateInput) o;
-    return Objects.equals(this.batches, instancesBatchCreateInput.batches);
+    return Objects.equals(this.batches, instancesBatchCreateInput.batches)&&
+        Objects.equals(this.additionalProperties, instancesBatchCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(batches);
+    return Objects.hash(batches, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class InstancesBatchCreateInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class InstancesBatchCreateInput {\n");
     sb.append("    batches: ").append(toIndentedString(batches)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class InstancesBatchCreateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InstancesBatchCreateInput is not found in the empty JSON string", InstancesBatchCreateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InstancesBatchCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InstancesBatchCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraybatches = jsonObj.getAsJsonArray("batches");
       if (jsonArraybatches != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class InstancesBatchCreateInput {
            @Override
            public void write(JsonWriter out, InstancesBatchCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class InstancesBatchCreateInput {
            public InstancesBatchCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InstancesBatchCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInputBatchesInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInputBatchesInner.java
@@ -130,7 +130,7 @@ public class InstancesBatchCreateInputBatchesInner {
   @SerializedName(SERIALIZED_NAME_USERDATA)
   private String userdata;
 
-  public InstancesBatchCreateInputBatchesInner() { 
+  public InstancesBatchCreateInputBatchesInner() {
   }
 
   public InstancesBatchCreateInputBatchesInner alwaysPxe(Boolean alwaysPxe) {
@@ -625,6 +625,41 @@ public class InstancesBatchCreateInputBatchesInner {
     this.userdata = userdata;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InstancesBatchCreateInputBatchesInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -654,12 +689,13 @@ public class InstancesBatchCreateInputBatchesInner {
         Objects.equals(this.tags, instancesBatchCreateInputBatchesInner.tags) &&
         Objects.equals(this.terminationTime, instancesBatchCreateInputBatchesInner.terminationTime) &&
         Objects.equals(this.userSshKeys, instancesBatchCreateInputBatchesInner.userSshKeys) &&
-        Objects.equals(this.userdata, instancesBatchCreateInputBatchesInner.userdata);
+        Objects.equals(this.userdata, instancesBatchCreateInputBatchesInner.userdata)&&
+        Objects.equals(this.additionalProperties, instancesBatchCreateInputBatchesInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alwaysPxe, billingCycle, customdata, description, facility, features, hostname, hostnames, ipAddresses, locked, metro, noSshKeys, operatingSystem, plan, projectSshKeys, tags, terminationTime, userSshKeys, userdata);
+    return Objects.hash(alwaysPxe, billingCycle, customdata, description, facility, features, hostname, hostnames, ipAddresses, locked, metro, noSshKeys, operatingSystem, plan, projectSshKeys, tags, terminationTime, userSshKeys, userdata, additionalProperties);
   }
 
   @Override
@@ -685,6 +721,7 @@ public class InstancesBatchCreateInputBatchesInner {
     sb.append("    terminationTime: ").append(toIndentedString(terminationTime)).append("\n");
     sb.append("    userSshKeys: ").append(toIndentedString(userSshKeys)).append("\n");
     sb.append("    userdata: ").append(toIndentedString(userdata)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -745,33 +782,25 @@ public class InstancesBatchCreateInputBatchesInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InstancesBatchCreateInputBatchesInner is not found in the empty JSON string", InstancesBatchCreateInputBatchesInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InstancesBatchCreateInputBatchesInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InstancesBatchCreateInputBatchesInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
+      if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonArray()) {
+      if ((jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) && !jsonObj.get("facility").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `facility` to be an array in the JSON string but got `%s`", jsonObj.get("facility").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("features") != null && !jsonObj.get("features").isJsonArray()) {
+      if ((jsonObj.get("features") != null && !jsonObj.get("features").isJsonNull()) && !jsonObj.get("features").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `features` to be an array in the JSON string but got `%s`", jsonObj.get("features").toString()));
       }
-      if (jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonPrimitive()) {
+      if ((jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonNull()) && !jsonObj.get("hostname").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `hostname` to be a primitive type in the JSON string but got `%s`", jsonObj.get("hostname").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("hostnames") != null && !jsonObj.get("hostnames").isJsonArray()) {
+      if ((jsonObj.get("hostnames") != null && !jsonObj.get("hostnames").isJsonNull()) && !jsonObj.get("hostnames").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `hostnames` to be an array in the JSON string but got `%s`", jsonObj.get("hostnames").toString()));
       }
       JsonArray jsonArrayipAddresses = jsonObj.getAsJsonArray("ip_addresses");
@@ -786,28 +815,28 @@ public class InstancesBatchCreateInputBatchesInner {
           InstancesBatchCreateInputBatchesInnerIpAddressesInner.validateJsonObject(jsonArrayipAddresses.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonPrimitive()) {
+      if ((jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonNull()) && !jsonObj.get("operating_system").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `operating_system` to be a primitive type in the JSON string but got `%s`", jsonObj.get("operating_system").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("project_ssh_keys") != null && !jsonObj.get("project_ssh_keys").isJsonArray()) {
+      if ((jsonObj.get("project_ssh_keys") != null && !jsonObj.get("project_ssh_keys").isJsonNull()) && !jsonObj.get("project_ssh_keys").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_ssh_keys` to be an array in the JSON string but got `%s`", jsonObj.get("project_ssh_keys").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("user_ssh_keys") != null && !jsonObj.get("user_ssh_keys").isJsonArray()) {
+      if ((jsonObj.get("user_ssh_keys") != null && !jsonObj.get("user_ssh_keys").isJsonNull()) && !jsonObj.get("user_ssh_keys").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `user_ssh_keys` to be an array in the JSON string but got `%s`", jsonObj.get("user_ssh_keys").toString()));
       }
-      if (jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonPrimitive()) {
+      if ((jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonNull()) && !jsonObj.get("userdata").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `userdata` to be a primitive type in the JSON string but got `%s`", jsonObj.get("userdata").toString()));
       }
   }
@@ -827,6 +856,23 @@ public class InstancesBatchCreateInputBatchesInner {
            @Override
            public void write(JsonWriter out, InstancesBatchCreateInputBatchesInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -834,7 +880,25 @@ public class InstancesBatchCreateInputBatchesInner {
            public InstancesBatchCreateInputBatchesInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InstancesBatchCreateInputBatchesInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInputBatchesInnerIpAddressesInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInputBatchesInnerIpAddressesInner.java
@@ -115,7 +115,7 @@ public class InstancesBatchCreateInputBatchesInnerIpAddressesInner {
   @SerializedName(SERIALIZED_NAME_PUBLIC)
   private Boolean _public = true;
 
-  public InstancesBatchCreateInputBatchesInnerIpAddressesInner() { 
+  public InstancesBatchCreateInputBatchesInnerIpAddressesInner() {
   }
 
   public InstancesBatchCreateInputBatchesInnerIpAddressesInner addressFamily(AddressFamilyEnum addressFamily) {
@@ -217,6 +217,41 @@ public class InstancesBatchCreateInputBatchesInnerIpAddressesInner {
     this._public = _public;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InstancesBatchCreateInputBatchesInnerIpAddressesInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -231,12 +266,13 @@ public class InstancesBatchCreateInputBatchesInnerIpAddressesInner {
     return Objects.equals(this.addressFamily, instancesBatchCreateInputBatchesInnerIpAddressesInner.addressFamily) &&
         Objects.equals(this.cidr, instancesBatchCreateInputBatchesInnerIpAddressesInner.cidr) &&
         Objects.equals(this.ipReservations, instancesBatchCreateInputBatchesInnerIpAddressesInner.ipReservations) &&
-        Objects.equals(this._public, instancesBatchCreateInputBatchesInnerIpAddressesInner._public);
+        Objects.equals(this._public, instancesBatchCreateInputBatchesInnerIpAddressesInner._public)&&
+        Objects.equals(this.additionalProperties, instancesBatchCreateInputBatchesInnerIpAddressesInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, cidr, ipReservations, _public);
+    return Objects.hash(addressFamily, cidr, ipReservations, _public, additionalProperties);
   }
 
   @Override
@@ -247,6 +283,7 @@ public class InstancesBatchCreateInputBatchesInnerIpAddressesInner {
     sb.append("    cidr: ").append(toIndentedString(cidr)).append("\n");
     sb.append("    ipReservations: ").append(toIndentedString(ipReservations)).append("\n");
     sb.append("    _public: ").append(toIndentedString(_public)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -292,16 +329,8 @@ public class InstancesBatchCreateInputBatchesInnerIpAddressesInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InstancesBatchCreateInputBatchesInnerIpAddressesInner is not found in the empty JSON string", InstancesBatchCreateInputBatchesInnerIpAddressesInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InstancesBatchCreateInputBatchesInnerIpAddressesInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InstancesBatchCreateInputBatchesInnerIpAddressesInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("ip_reservations") != null && !jsonObj.get("ip_reservations").isJsonArray()) {
+      if ((jsonObj.get("ip_reservations") != null && !jsonObj.get("ip_reservations").isJsonNull()) && !jsonObj.get("ip_reservations").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_reservations` to be an array in the JSON string but got `%s`", jsonObj.get("ip_reservations").toString()));
       }
   }
@@ -321,6 +350,23 @@ public class InstancesBatchCreateInputBatchesInnerIpAddressesInner {
            @Override
            public void write(JsonWriter out, InstancesBatchCreateInputBatchesInnerIpAddressesInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -328,7 +374,25 @@ public class InstancesBatchCreateInputBatchesInnerIpAddressesInner {
            public InstancesBatchCreateInputBatchesInnerIpAddressesInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InstancesBatchCreateInputBatchesInnerIpAddressesInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Interconnection.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Interconnection.java
@@ -163,7 +163,7 @@ public class Interconnection {
   @SerializedName(SERIALIZED_NAME_TYPE)
   private String type;
 
-  public Interconnection() { 
+  public Interconnection() {
   }
 
   public Interconnection contactEmail(String contactEmail) {
@@ -534,6 +534,41 @@ public class Interconnection {
     this.type = type;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Interconnection putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -559,12 +594,13 @@ public class Interconnection {
         Objects.equals(this.speed, interconnection.speed) &&
         Objects.equals(this.status, interconnection.status) &&
         Objects.equals(this.tags, interconnection.tags) &&
-        Objects.equals(this.type, interconnection.type);
+        Objects.equals(this.type, interconnection.type)&&
+        Objects.equals(this.additionalProperties, interconnection.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(contactEmail, description, facility, id, metro, mode, name, organization, ports, redundancy, serviceTokens, speed, status, tags, type);
+    return Objects.hash(contactEmail, description, facility, id, metro, mode, name, organization, ports, redundancy, serviceTokens, speed, status, tags, type, additionalProperties);
   }
 
   @Override
@@ -586,6 +622,7 @@ public class Interconnection {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -642,39 +679,31 @@ public class Interconnection {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Interconnection is not found in the empty JSON string", Interconnection.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Interconnection.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Interconnection` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("contact_email") != null && !jsonObj.get("contact_email").isJsonPrimitive()) {
+      if ((jsonObj.get("contact_email") != null && !jsonObj.get("contact_email").isJsonNull()) && !jsonObj.get("contact_email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `contact_email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("contact_email").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // validate the optional field `facility`
-      if (jsonObj.getAsJsonObject("facility") != null) {
+      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("facility"));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         InterconnectionMetro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
-      if (jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonPrimitive()) {
+      if ((jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) && !jsonObj.get("mode").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `mode` to be a primitive type in the JSON string but got `%s`", jsonObj.get("mode").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       // validate the optional field `organization`
-      if (jsonObj.getAsJsonObject("organization") != null) {
+      if (jsonObj.get("organization") != null && !jsonObj.get("organization").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("organization"));
       }
       JsonArray jsonArrayports = jsonObj.getAsJsonArray("ports");
@@ -689,7 +718,7 @@ public class Interconnection {
           InterconnectionPort.validateJsonObject(jsonArrayports.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonPrimitive()) {
+      if ((jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonNull()) && !jsonObj.get("redundancy").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `redundancy` to be a primitive type in the JSON string but got `%s`", jsonObj.get("redundancy").toString()));
       }
       JsonArray jsonArrayserviceTokens = jsonObj.getAsJsonArray("service_tokens");
@@ -704,14 +733,14 @@ public class Interconnection {
           FabricServiceToken.validateJsonObject(jsonArrayserviceTokens.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonPrimitive()) {
+      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
   }
@@ -731,6 +760,23 @@ public class Interconnection {
            @Override
            public void write(JsonWriter out, Interconnection value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -738,7 +784,25 @@ public class Interconnection {
            public Interconnection read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Interconnection instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionCreateInput.java
@@ -191,7 +191,7 @@ public class InterconnectionCreateInput {
   @SerializedName(SERIALIZED_NAME_VLANS)
   private List<Integer> vlans = null;
 
-  public InterconnectionCreateInput() { 
+  public InterconnectionCreateInput() {
   }
 
   public InterconnectionCreateInput contactEmail(String contactEmail) {
@@ -485,6 +485,41 @@ public class InterconnectionCreateInput {
     this.vlans = vlans;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InterconnectionCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -507,12 +542,13 @@ public class InterconnectionCreateInput {
         Objects.equals(this.speed, interconnectionCreateInput.speed) &&
         Objects.equals(this.tags, interconnectionCreateInput.tags) &&
         Objects.equals(this.type, interconnectionCreateInput.type) &&
-        Objects.equals(this.vlans, interconnectionCreateInput.vlans);
+        Objects.equals(this.vlans, interconnectionCreateInput.vlans)&&
+        Objects.equals(this.additionalProperties, interconnectionCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(contactEmail, description, metro, mode, name, project, redundancy, serviceTokenType, speed, tags, type, vlans);
+    return Objects.hash(contactEmail, description, metro, mode, name, project, redundancy, serviceTokenType, speed, tags, type, vlans, additionalProperties);
   }
 
   @Override
@@ -531,6 +567,7 @@ public class InterconnectionCreateInput {
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    vlans: ").append(toIndentedString(vlans)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -589,56 +626,48 @@ public class InterconnectionCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InterconnectionCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InterconnectionCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InterconnectionCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("contact_email") != null && !jsonObj.get("contact_email").isJsonPrimitive()) {
+      if ((jsonObj.get("contact_email") != null && !jsonObj.get("contact_email").isJsonNull()) && !jsonObj.get("contact_email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `contact_email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("contact_email").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonPrimitive()) {
+      if ((jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) && !jsonObj.get("mode").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `mode` to be a primitive type in the JSON string but got `%s`", jsonObj.get("mode").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonPrimitive()) {
+      if ((jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) && !jsonObj.get("project").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project").toString()));
       }
-      if (jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonPrimitive()) {
+      if ((jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonNull()) && !jsonObj.get("redundancy").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `redundancy` to be a primitive type in the JSON string but got `%s`", jsonObj.get("redundancy").toString()));
       }
-      if (jsonObj.get("service_token_type") != null && !jsonObj.get("service_token_type").isJsonPrimitive()) {
+      if ((jsonObj.get("service_token_type") != null && !jsonObj.get("service_token_type").isJsonNull()) && !jsonObj.get("service_token_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `service_token_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("service_token_type").toString()));
       }
-      if (jsonObj.get("speed") != null && !jsonObj.get("speed").isJsonPrimitive()) {
+      if ((jsonObj.get("speed") != null && !jsonObj.get("speed").isJsonNull()) && !jsonObj.get("speed").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `speed` to be a primitive type in the JSON string but got `%s`", jsonObj.get("speed").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("vlans") != null && !jsonObj.get("vlans").isJsonArray()) {
+      if ((jsonObj.get("vlans") != null && !jsonObj.get("vlans").isJsonNull()) && !jsonObj.get("vlans").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `vlans` to be an array in the JSON string but got `%s`", jsonObj.get("vlans").toString()));
       }
   }
@@ -658,6 +687,23 @@ public class InterconnectionCreateInput {
            @Override
            public void write(JsonWriter out, InterconnectionCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -665,7 +711,25 @@ public class InterconnectionCreateInput {
            public InterconnectionCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InterconnectionCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionList.java
@@ -56,7 +56,7 @@ public class InterconnectionList {
   @SerializedName(SERIALIZED_NAME_INTERCONNECTIONS)
   private List<Interconnection> interconnections = null;
 
-  public InterconnectionList() { 
+  public InterconnectionList() {
   }
 
   public InterconnectionList interconnections(List<Interconnection> interconnections) {
@@ -89,6 +89,41 @@ public class InterconnectionList {
     this.interconnections = interconnections;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InterconnectionList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class InterconnectionList {
       return false;
     }
     InterconnectionList interconnectionList = (InterconnectionList) o;
-    return Objects.equals(this.interconnections, interconnectionList.interconnections);
+    return Objects.equals(this.interconnections, interconnectionList.interconnections)&&
+        Objects.equals(this.additionalProperties, interconnectionList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(interconnections);
+    return Objects.hash(interconnections, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class InterconnectionList {
     StringBuilder sb = new StringBuilder();
     sb.append("class InterconnectionList {\n");
     sb.append("    interconnections: ").append(toIndentedString(interconnections)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class InterconnectionList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InterconnectionList is not found in the empty JSON string", InterconnectionList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InterconnectionList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InterconnectionList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayinterconnections = jsonObj.getAsJsonArray("interconnections");
       if (jsonArrayinterconnections != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class InterconnectionList {
            @Override
            public void write(JsonWriter out, InterconnectionList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class InterconnectionList {
            public InterconnectionList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InterconnectionList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionMetro.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionMetro.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -67,7 +66,7 @@ public class InterconnectionMetro {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public InterconnectionMetro() { 
+  public InterconnectionMetro() {
   }
 
   public InterconnectionMetro code(String code) {
@@ -161,6 +160,41 @@ public class InterconnectionMetro {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InterconnectionMetro putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -175,12 +209,13 @@ public class InterconnectionMetro {
     return Objects.equals(this.code, interconnectionMetro.code) &&
         Objects.equals(this.country, interconnectionMetro.country) &&
         Objects.equals(this.id, interconnectionMetro.id) &&
-        Objects.equals(this.name, interconnectionMetro.name);
+        Objects.equals(this.name, interconnectionMetro.name)&&
+        Objects.equals(this.additionalProperties, interconnectionMetro.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(code, country, id, name);
+    return Objects.hash(code, country, id, name, additionalProperties);
   }
 
   @Override
@@ -191,6 +226,7 @@ public class InterconnectionMetro {
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -236,24 +272,16 @@ public class InterconnectionMetro {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InterconnectionMetro is not found in the empty JSON string", InterconnectionMetro.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InterconnectionMetro.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InterconnectionMetro` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
-      if (jsonObj.get("country") != null && !jsonObj.get("country").isJsonPrimitive()) {
+      if ((jsonObj.get("country") != null && !jsonObj.get("country").isJsonNull()) && !jsonObj.get("country").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -273,6 +301,23 @@ public class InterconnectionMetro {
            @Override
            public void write(JsonWriter out, InterconnectionMetro value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -280,7 +325,25 @@ public class InterconnectionMetro {
            public InterconnectionMetro read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InterconnectionMetro instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPort.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPort.java
@@ -76,7 +76,7 @@ public class InterconnectionPort {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_CIRCUITS)
   private VirtualCircuitList virtualCircuits;
 
-  public InterconnectionPort() { 
+  public InterconnectionPort() {
   }
 
   public InterconnectionPort id(UUID id) {
@@ -216,6 +216,41 @@ public class InterconnectionPort {
     this.virtualCircuits = virtualCircuits;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InterconnectionPort putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -232,12 +267,13 @@ public class InterconnectionPort {
         Objects.equals(this.role, interconnectionPort.role) &&
         Objects.equals(this.status, interconnectionPort.status) &&
         Objects.equals(this.switchId, interconnectionPort.switchId) &&
-        Objects.equals(this.virtualCircuits, interconnectionPort.virtualCircuits);
+        Objects.equals(this.virtualCircuits, interconnectionPort.virtualCircuits)&&
+        Objects.equals(this.additionalProperties, interconnectionPort.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organization, role, status, switchId, virtualCircuits);
+    return Objects.hash(id, organization, role, status, switchId, virtualCircuits, additionalProperties);
   }
 
   @Override
@@ -250,6 +286,7 @@ public class InterconnectionPort {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    switchId: ").append(toIndentedString(switchId)).append("\n");
     sb.append("    virtualCircuits: ").append(toIndentedString(virtualCircuits)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -297,32 +334,24 @@ public class InterconnectionPort {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InterconnectionPort is not found in the empty JSON string", InterconnectionPort.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InterconnectionPort.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InterconnectionPort` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `organization`
-      if (jsonObj.getAsJsonObject("organization") != null) {
+      if (jsonObj.get("organization") != null && !jsonObj.get("organization").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("organization"));
       }
-      if (jsonObj.get("role") != null && !jsonObj.get("role").isJsonPrimitive()) {
+      if ((jsonObj.get("role") != null && !jsonObj.get("role").isJsonNull()) && !jsonObj.get("role").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `role` to be a primitive type in the JSON string but got `%s`", jsonObj.get("role").toString()));
       }
-      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonPrimitive()) {
+      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
-      if (jsonObj.get("switch_id") != null && !jsonObj.get("switch_id").isJsonPrimitive()) {
+      if ((jsonObj.get("switch_id") != null && !jsonObj.get("switch_id").isJsonNull()) && !jsonObj.get("switch_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `switch_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("switch_id").toString()));
       }
       // validate the optional field `virtual_circuits`
-      if (jsonObj.getAsJsonObject("virtual_circuits") != null) {
+      if (jsonObj.get("virtual_circuits") != null && !jsonObj.get("virtual_circuits").isJsonNull()) {
         VirtualCircuitList.validateJsonObject(jsonObj.getAsJsonObject("virtual_circuits"));
       }
   }
@@ -342,6 +371,23 @@ public class InterconnectionPort {
            @Override
            public void write(JsonWriter out, InterconnectionPort value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -349,7 +395,25 @@ public class InterconnectionPort {
            public InterconnectionPort read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InterconnectionPort instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPortList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPortList.java
@@ -56,7 +56,7 @@ public class InterconnectionPortList {
   @SerializedName(SERIALIZED_NAME_PORTS)
   private List<InterconnectionPort> ports = null;
 
-  public InterconnectionPortList() { 
+  public InterconnectionPortList() {
   }
 
   public InterconnectionPortList ports(List<InterconnectionPort> ports) {
@@ -89,6 +89,41 @@ public class InterconnectionPortList {
     this.ports = ports;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InterconnectionPortList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class InterconnectionPortList {
       return false;
     }
     InterconnectionPortList interconnectionPortList = (InterconnectionPortList) o;
-    return Objects.equals(this.ports, interconnectionPortList.ports);
+    return Objects.equals(this.ports, interconnectionPortList.ports)&&
+        Objects.equals(this.additionalProperties, interconnectionPortList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ports);
+    return Objects.hash(ports, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class InterconnectionPortList {
     StringBuilder sb = new StringBuilder();
     sb.append("class InterconnectionPortList {\n");
     sb.append("    ports: ").append(toIndentedString(ports)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class InterconnectionPortList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InterconnectionPortList is not found in the empty JSON string", InterconnectionPortList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InterconnectionPortList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InterconnectionPortList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayports = jsonObj.getAsJsonArray("ports");
       if (jsonArrayports != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class InterconnectionPortList {
            @Override
            public void write(JsonWriter out, InterconnectionPortList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class InterconnectionPortList {
            public InterconnectionPortList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InterconnectionPortList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionUpdateInput.java
@@ -122,7 +122,7 @@ public class InterconnectionUpdateInput {
   @SerializedName(SERIALIZED_NAME_TAGS)
   private List<String> tags = null;
 
-  public InterconnectionUpdateInput() { 
+  public InterconnectionUpdateInput() {
   }
 
   public InterconnectionUpdateInput contactEmail(String contactEmail) {
@@ -270,6 +270,41 @@ public class InterconnectionUpdateInput {
     this.tags = tags;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InterconnectionUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -286,12 +321,13 @@ public class InterconnectionUpdateInput {
         Objects.equals(this.mode, interconnectionUpdateInput.mode) &&
         Objects.equals(this.name, interconnectionUpdateInput.name) &&
         Objects.equals(this.redundancy, interconnectionUpdateInput.redundancy) &&
-        Objects.equals(this.tags, interconnectionUpdateInput.tags);
+        Objects.equals(this.tags, interconnectionUpdateInput.tags)&&
+        Objects.equals(this.additionalProperties, interconnectionUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(contactEmail, description, mode, name, redundancy, tags);
+    return Objects.hash(contactEmail, description, mode, name, redundancy, tags, additionalProperties);
   }
 
   @Override
@@ -304,6 +340,7 @@ public class InterconnectionUpdateInput {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    redundancy: ").append(toIndentedString(redundancy)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -351,31 +388,23 @@ public class InterconnectionUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InterconnectionUpdateInput is not found in the empty JSON string", InterconnectionUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InterconnectionUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InterconnectionUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("contact_email") != null && !jsonObj.get("contact_email").isJsonPrimitive()) {
+      if ((jsonObj.get("contact_email") != null && !jsonObj.get("contact_email").isJsonNull()) && !jsonObj.get("contact_email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `contact_email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("contact_email").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonPrimitive()) {
+      if ((jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) && !jsonObj.get("mode").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `mode` to be a primitive type in the JSON string but got `%s`", jsonObj.get("mode").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonPrimitive()) {
+      if ((jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonNull()) && !jsonObj.get("redundancy").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `redundancy` to be a primitive type in the JSON string but got `%s`", jsonObj.get("redundancy").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
   }
@@ -395,6 +424,23 @@ public class InterconnectionUpdateInput {
            @Override
            public void write(JsonWriter out, InterconnectionUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -402,7 +448,25 @@ public class InterconnectionUpdateInput {
            public InterconnectionUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InterconnectionUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Invitation.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Invitation.java
@@ -94,7 +94,7 @@ public class Invitation {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public Invitation() { 
+  public Invitation() {
   }
 
   public Invitation createdAt(OffsetDateTime createdAt) {
@@ -342,6 +342,41 @@ public class Invitation {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Invitation putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -362,12 +397,13 @@ public class Invitation {
         Objects.equals(this.organization, invitation.organization) &&
         Objects.equals(this.projectsIds, invitation.projectsIds) &&
         Objects.equals(this.roles, invitation.roles) &&
-        Objects.equals(this.updatedAt, invitation.updatedAt);
+        Objects.equals(this.updatedAt, invitation.updatedAt)&&
+        Objects.equals(this.additionalProperties, invitation.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, href, id, invitation, invitedBy, invitee, organization, projectsIds, roles, updatedAt);
+    return Objects.hash(createdAt, href, id, invitation, invitedBy, invitee, organization, projectsIds, roles, updatedAt, additionalProperties);
   }
 
   @Override
@@ -384,6 +420,7 @@ public class Invitation {
     sb.append("    projectsIds: ").append(toIndentedString(projectsIds)).append("\n");
     sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -435,41 +472,33 @@ public class Invitation {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Invitation is not found in the empty JSON string", Invitation.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Invitation.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Invitation` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `invitation`
-      if (jsonObj.getAsJsonObject("invitation") != null) {
+      if (jsonObj.get("invitation") != null && !jsonObj.get("invitation").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("invitation"));
       }
       // validate the optional field `invited_by`
-      if (jsonObj.getAsJsonObject("invited_by") != null) {
+      if (jsonObj.get("invited_by") != null && !jsonObj.get("invited_by").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("invited_by"));
       }
-      if (jsonObj.get("invitee") != null && !jsonObj.get("invitee").isJsonPrimitive()) {
+      if ((jsonObj.get("invitee") != null && !jsonObj.get("invitee").isJsonNull()) && !jsonObj.get("invitee").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `invitee` to be a primitive type in the JSON string but got `%s`", jsonObj.get("invitee").toString()));
       }
       // validate the optional field `organization`
-      if (jsonObj.getAsJsonObject("organization") != null) {
+      if (jsonObj.get("organization") != null && !jsonObj.get("organization").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("organization"));
       }
       // ensure the json data is an array
-      if (jsonObj.get("projects_ids") != null && !jsonObj.get("projects_ids").isJsonArray()) {
+      if ((jsonObj.get("projects_ids") != null && !jsonObj.get("projects_ids").isJsonNull()) && !jsonObj.get("projects_ids").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `projects_ids` to be an array in the JSON string but got `%s`", jsonObj.get("projects_ids").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("roles") != null && !jsonObj.get("roles").isJsonArray()) {
+      if ((jsonObj.get("roles") != null && !jsonObj.get("roles").isJsonNull()) && !jsonObj.get("roles").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `roles` to be an array in the JSON string but got `%s`", jsonObj.get("roles").toString()));
       }
   }
@@ -489,6 +518,23 @@ public class Invitation {
            @Override
            public void write(JsonWriter out, Invitation value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -496,7 +542,25 @@ public class Invitation {
            public Invitation read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Invitation instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InvitationInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InvitationInput.java
@@ -67,7 +67,7 @@ public class InvitationInput {
   @SerializedName(SERIALIZED_NAME_ROLES)
   private List<String> roles = null;
 
-  public InvitationInput() { 
+  public InvitationInput() {
   }
 
   public InvitationInput invitee(String invitee) {
@@ -177,6 +177,41 @@ public class InvitationInput {
     this.roles = roles;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InvitationInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -191,12 +226,13 @@ public class InvitationInput {
     return Objects.equals(this.invitee, invitationInput.invitee) &&
         Objects.equals(this.message, invitationInput.message) &&
         Objects.equals(this.projectsIds, invitationInput.projectsIds) &&
-        Objects.equals(this.roles, invitationInput.roles);
+        Objects.equals(this.roles, invitationInput.roles)&&
+        Objects.equals(this.additionalProperties, invitationInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(invitee, message, projectsIds, roles);
+    return Objects.hash(invitee, message, projectsIds, roles, additionalProperties);
   }
 
   @Override
@@ -207,6 +243,7 @@ public class InvitationInput {
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    projectsIds: ").append(toIndentedString(projectsIds)).append("\n");
     sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -254,32 +291,24 @@ public class InvitationInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InvitationInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvitationInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvitationInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("invitee") != null && !jsonObj.get("invitee").isJsonPrimitive()) {
+      if ((jsonObj.get("invitee") != null && !jsonObj.get("invitee").isJsonNull()) && !jsonObj.get("invitee").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `invitee` to be a primitive type in the JSON string but got `%s`", jsonObj.get("invitee").toString()));
       }
-      if (jsonObj.get("message") != null && !jsonObj.get("message").isJsonPrimitive()) {
+      if ((jsonObj.get("message") != null && !jsonObj.get("message").isJsonNull()) && !jsonObj.get("message").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `message` to be a primitive type in the JSON string but got `%s`", jsonObj.get("message").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("projects_ids") != null && !jsonObj.get("projects_ids").isJsonArray()) {
+      if ((jsonObj.get("projects_ids") != null && !jsonObj.get("projects_ids").isJsonNull()) && !jsonObj.get("projects_ids").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `projects_ids` to be an array in the JSON string but got `%s`", jsonObj.get("projects_ids").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("roles") != null && !jsonObj.get("roles").isJsonArray()) {
+      if ((jsonObj.get("roles") != null && !jsonObj.get("roles").isJsonNull()) && !jsonObj.get("roles").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `roles` to be an array in the JSON string but got `%s`", jsonObj.get("roles").toString()));
       }
   }
@@ -299,6 +328,23 @@ public class InvitationInput {
            @Override
            public void write(JsonWriter out, InvitationInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -306,7 +352,25 @@ public class InvitationInput {
            public InvitationInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InvitationInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InvitationList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InvitationList.java
@@ -56,7 +56,7 @@ public class InvitationList {
   @SerializedName(SERIALIZED_NAME_INVITATIONS)
   private List<Membership> invitations = null;
 
-  public InvitationList() { 
+  public InvitationList() {
   }
 
   public InvitationList invitations(List<Membership> invitations) {
@@ -89,6 +89,41 @@ public class InvitationList {
     this.invitations = invitations;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public InvitationList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class InvitationList {
       return false;
     }
     InvitationList invitationList = (InvitationList) o;
-    return Objects.equals(this.invitations, invitationList.invitations);
+    return Objects.equals(this.invitations, invitationList.invitations)&&
+        Objects.equals(this.additionalProperties, invitationList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(invitations);
+    return Objects.hash(invitations, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class InvitationList {
     StringBuilder sb = new StringBuilder();
     sb.append("class InvitationList {\n");
     sb.append("    invitations: ").append(toIndentedString(invitations)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class InvitationList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in InvitationList is not found in the empty JSON string", InvitationList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!InvitationList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvitationList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayinvitations = jsonObj.getAsJsonArray("invitations");
       if (jsonArrayinvitations != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class InvitationList {
            @Override
            public void write(JsonWriter out, InvitationList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class InvitationList {
            public InvitationList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             InvitationList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/License.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/License.java
@@ -76,7 +76,7 @@ public class License {
   @SerializedName(SERIALIZED_NAME_SIZE)
   private BigDecimal size;
 
-  public License() { 
+  public License() {
   }
 
   public License description(String description) {
@@ -216,6 +216,41 @@ public class License {
     this.size = size;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public License putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -232,12 +267,13 @@ public class License {
         Objects.equals(this.licenseKey, license.licenseKey) &&
         Objects.equals(this.licenseeProduct, license.licenseeProduct) &&
         Objects.equals(this.project, license.project) &&
-        Objects.equals(this.size, license.size);
+        Objects.equals(this.size, license.size)&&
+        Objects.equals(this.additionalProperties, license.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, id, licenseKey, licenseeProduct, project, size);
+    return Objects.hash(description, id, licenseKey, licenseeProduct, project, size, additionalProperties);
   }
 
   @Override
@@ -250,6 +286,7 @@ public class License {
     sb.append("    licenseeProduct: ").append(toIndentedString(licenseeProduct)).append("\n");
     sb.append("    project: ").append(toIndentedString(project)).append("\n");
     sb.append("    size: ").append(toIndentedString(size)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -297,29 +334,21 @@ public class License {
           throw new IllegalArgumentException(String.format("The required field(s) %s in License is not found in the empty JSON string", License.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!License.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `License` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("license_key") != null && !jsonObj.get("license_key").isJsonPrimitive()) {
+      if ((jsonObj.get("license_key") != null && !jsonObj.get("license_key").isJsonNull()) && !jsonObj.get("license_key").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `license_key` to be a primitive type in the JSON string but got `%s`", jsonObj.get("license_key").toString()));
       }
       // validate the optional field `licensee_product`
-      if (jsonObj.getAsJsonObject("licensee_product") != null) {
+      if (jsonObj.get("licensee_product") != null && !jsonObj.get("licensee_product").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("licensee_product"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
   }
@@ -339,6 +368,23 @@ public class License {
            @Override
            public void write(JsonWriter out, License value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -346,7 +392,25 @@ public class License {
            public License read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             License instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/LicenseCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/LicenseCreateInput.java
@@ -62,7 +62,7 @@ public class LicenseCreateInput {
   @SerializedName(SERIALIZED_NAME_SIZE)
   private BigDecimal size;
 
-  public LicenseCreateInput() { 
+  public LicenseCreateInput() {
   }
 
   public LicenseCreateInput description(String description) {
@@ -133,6 +133,41 @@ public class LicenseCreateInput {
     this.size = size;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public LicenseCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -146,12 +181,13 @@ public class LicenseCreateInput {
     LicenseCreateInput licenseCreateInput = (LicenseCreateInput) o;
     return Objects.equals(this.description, licenseCreateInput.description) &&
         Objects.equals(this.licenseeProductId, licenseCreateInput.licenseeProductId) &&
-        Objects.equals(this.size, licenseCreateInput.size);
+        Objects.equals(this.size, licenseCreateInput.size)&&
+        Objects.equals(this.additionalProperties, licenseCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, licenseeProductId, size);
+    return Objects.hash(description, licenseeProductId, size, additionalProperties);
   }
 
   @Override
@@ -161,6 +197,7 @@ public class LicenseCreateInput {
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    licenseeProductId: ").append(toIndentedString(licenseeProductId)).append("\n");
     sb.append("    size: ").append(toIndentedString(size)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -205,18 +242,10 @@ public class LicenseCreateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in LicenseCreateInput is not found in the empty JSON string", LicenseCreateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!LicenseCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `LicenseCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("licensee_product_id") != null && !jsonObj.get("licensee_product_id").isJsonPrimitive()) {
+      if ((jsonObj.get("licensee_product_id") != null && !jsonObj.get("licensee_product_id").isJsonNull()) && !jsonObj.get("licensee_product_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `licensee_product_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("licensee_product_id").toString()));
       }
   }
@@ -236,6 +265,23 @@ public class LicenseCreateInput {
            @Override
            public void write(JsonWriter out, LicenseCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -243,7 +289,25 @@ public class LicenseCreateInput {
            public LicenseCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             LicenseCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/LicenseList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/LicenseList.java
@@ -56,7 +56,7 @@ public class LicenseList {
   @SerializedName(SERIALIZED_NAME_LICENSES)
   private List<License> licenses = null;
 
-  public LicenseList() { 
+  public LicenseList() {
   }
 
   public LicenseList licenses(List<License> licenses) {
@@ -89,6 +89,41 @@ public class LicenseList {
     this.licenses = licenses;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public LicenseList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class LicenseList {
       return false;
     }
     LicenseList licenseList = (LicenseList) o;
-    return Objects.equals(this.licenses, licenseList.licenses);
+    return Objects.equals(this.licenses, licenseList.licenses)&&
+        Objects.equals(this.additionalProperties, licenseList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(licenses);
+    return Objects.hash(licenses, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class LicenseList {
     StringBuilder sb = new StringBuilder();
     sb.append("class LicenseList {\n");
     sb.append("    licenses: ").append(toIndentedString(licenses)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class LicenseList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in LicenseList is not found in the empty JSON string", LicenseList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!LicenseList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `LicenseList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraylicenses = jsonObj.getAsJsonArray("licenses");
       if (jsonArraylicenses != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class LicenseList {
            @Override
            public void write(JsonWriter out, LicenseList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class LicenseList {
            public LicenseList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             LicenseList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/LicenseUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/LicenseUpdateInput.java
@@ -58,7 +58,7 @@ public class LicenseUpdateInput {
   @SerializedName(SERIALIZED_NAME_SIZE)
   private BigDecimal size;
 
-  public LicenseUpdateInput() { 
+  public LicenseUpdateInput() {
   }
 
   public LicenseUpdateInput description(String description) {
@@ -106,6 +106,41 @@ public class LicenseUpdateInput {
     this.size = size;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public LicenseUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -118,12 +153,13 @@ public class LicenseUpdateInput {
     }
     LicenseUpdateInput licenseUpdateInput = (LicenseUpdateInput) o;
     return Objects.equals(this.description, licenseUpdateInput.description) &&
-        Objects.equals(this.size, licenseUpdateInput.size);
+        Objects.equals(this.size, licenseUpdateInput.size)&&
+        Objects.equals(this.additionalProperties, licenseUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, size);
+    return Objects.hash(description, size, additionalProperties);
   }
 
   @Override
@@ -132,6 +168,7 @@ public class LicenseUpdateInput {
     sb.append("class LicenseUpdateInput {\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    size: ").append(toIndentedString(size)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -175,15 +212,7 @@ public class LicenseUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in LicenseUpdateInput is not found in the empty JSON string", LicenseUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!LicenseUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `LicenseUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
   }
@@ -203,6 +232,23 @@ public class LicenseUpdateInput {
            @Override
            public void write(JsonWriter out, LicenseUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -210,7 +256,25 @@ public class LicenseUpdateInput {
            public LicenseUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             LicenseUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Membership.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Membership.java
@@ -82,7 +82,7 @@ public class Membership {
   @SerializedName(SERIALIZED_NAME_USER)
   private Href user;
 
-  public Membership() { 
+  public Membership() {
   }
 
   public Membership createdAt(OffsetDateTime createdAt) {
@@ -253,6 +253,41 @@ public class Membership {
     this.user = user;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Membership putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -270,12 +305,13 @@ public class Membership {
         Objects.equals(this.project, membership.project) &&
         Objects.equals(this.roles, membership.roles) &&
         Objects.equals(this.updatedAt, membership.updatedAt) &&
-        Objects.equals(this.user, membership.user);
+        Objects.equals(this.user, membership.user)&&
+        Objects.equals(this.additionalProperties, membership.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, href, id, project, roles, updatedAt, user);
+    return Objects.hash(createdAt, href, id, project, roles, updatedAt, user, additionalProperties);
   }
 
   @Override
@@ -289,6 +325,7 @@ public class Membership {
     sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    user: ").append(toIndentedString(user)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -337,30 +374,22 @@ public class Membership {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Membership is not found in the empty JSON string", Membership.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Membership.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Membership` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
       // ensure the json data is an array
-      if (jsonObj.get("roles") != null && !jsonObj.get("roles").isJsonArray()) {
+      if ((jsonObj.get("roles") != null && !jsonObj.get("roles").isJsonNull()) && !jsonObj.get("roles").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `roles` to be an array in the JSON string but got `%s`", jsonObj.get("roles").toString()));
       }
       // validate the optional field `user`
-      if (jsonObj.getAsJsonObject("user") != null) {
+      if (jsonObj.get("user") != null && !jsonObj.get("user").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("user"));
       }
   }
@@ -380,6 +409,23 @@ public class Membership {
            @Override
            public void write(JsonWriter out, Membership value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -387,7 +433,25 @@ public class Membership {
            public Membership read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Membership instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MembershipInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MembershipInput.java
@@ -55,7 +55,7 @@ public class MembershipInput {
   @SerializedName(SERIALIZED_NAME_ROLE)
   private List<String> role = null;
 
-  public MembershipInput() { 
+  public MembershipInput() {
   }
 
   public MembershipInput role(List<String> role) {
@@ -88,6 +88,41 @@ public class MembershipInput {
     this.role = role;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MembershipInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -99,12 +134,13 @@ public class MembershipInput {
       return false;
     }
     MembershipInput membershipInput = (MembershipInput) o;
-    return Objects.equals(this.role, membershipInput.role);
+    return Objects.equals(this.role, membershipInput.role)&&
+        Objects.equals(this.additionalProperties, membershipInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(role);
+    return Objects.hash(role, additionalProperties);
   }
 
   @Override
@@ -112,6 +148,7 @@ public class MembershipInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class MembershipInput {\n");
     sb.append("    role: ").append(toIndentedString(role)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -154,16 +191,8 @@ public class MembershipInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MembershipInput is not found in the empty JSON string", MembershipInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MembershipInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MembershipInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("role") != null && !jsonObj.get("role").isJsonArray()) {
+      if ((jsonObj.get("role") != null && !jsonObj.get("role").isJsonNull()) && !jsonObj.get("role").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `role` to be an array in the JSON string but got `%s`", jsonObj.get("role").toString()));
       }
   }
@@ -183,6 +212,23 @@ public class MembershipInput {
            @Override
            public void write(JsonWriter out, MembershipInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -190,7 +236,25 @@ public class MembershipInput {
            public MembershipInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MembershipInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MembershipList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MembershipList.java
@@ -56,7 +56,7 @@ public class MembershipList {
   @SerializedName(SERIALIZED_NAME_MEMBERSHIPS)
   private List<Membership> memberships = null;
 
-  public MembershipList() { 
+  public MembershipList() {
   }
 
   public MembershipList memberships(List<Membership> memberships) {
@@ -89,6 +89,41 @@ public class MembershipList {
     this.memberships = memberships;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MembershipList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class MembershipList {
       return false;
     }
     MembershipList membershipList = (MembershipList) o;
-    return Objects.equals(this.memberships, membershipList.memberships);
+    return Objects.equals(this.memberships, membershipList.memberships)&&
+        Objects.equals(this.additionalProperties, membershipList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(memberships);
+    return Objects.hash(memberships, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class MembershipList {
     StringBuilder sb = new StringBuilder();
     sb.append("class MembershipList {\n");
     sb.append("    memberships: ").append(toIndentedString(memberships)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class MembershipList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MembershipList is not found in the empty JSON string", MembershipList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MembershipList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MembershipList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraymemberships = jsonObj.getAsJsonArray("memberships");
       if (jsonArraymemberships != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class MembershipList {
            @Override
            public void write(JsonWriter out, MembershipList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class MembershipList {
            public MembershipList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MembershipList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Meta.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Meta.java
@@ -74,7 +74,7 @@ public class Meta {
   @SerializedName(SERIALIZED_NAME_TOTAL)
   private Integer total;
 
-  public Meta() { 
+  public Meta() {
   }
 
   public Meta first(Href first) {
@@ -214,6 +214,41 @@ public class Meta {
     this.total = total;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Meta putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -230,12 +265,13 @@ public class Meta {
         Objects.equals(this.next, meta.next) &&
         Objects.equals(this.previous, meta.previous) &&
         Objects.equals(this.self, meta.self) &&
-        Objects.equals(this.total, meta.total);
+        Objects.equals(this.total, meta.total)&&
+        Objects.equals(this.additionalProperties, meta.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(first, last, next, previous, self, total);
+    return Objects.hash(first, last, next, previous, self, total, additionalProperties);
   }
 
   @Override
@@ -248,6 +284,7 @@ public class Meta {
     sb.append("    previous: ").append(toIndentedString(previous)).append("\n");
     sb.append("    self: ").append(toIndentedString(self)).append("\n");
     sb.append("    total: ").append(toIndentedString(total)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -295,32 +332,24 @@ public class Meta {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Meta is not found in the empty JSON string", Meta.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Meta.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Meta` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `first`
-      if (jsonObj.getAsJsonObject("first") != null) {
+      if (jsonObj.get("first") != null && !jsonObj.get("first").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("first"));
       }
       // validate the optional field `last`
-      if (jsonObj.getAsJsonObject("last") != null) {
+      if (jsonObj.get("last") != null && !jsonObj.get("last").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("last"));
       }
       // validate the optional field `next`
-      if (jsonObj.getAsJsonObject("next") != null) {
+      if (jsonObj.get("next") != null && !jsonObj.get("next").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("next"));
       }
       // validate the optional field `previous`
-      if (jsonObj.getAsJsonObject("previous") != null) {
+      if (jsonObj.get("previous") != null && !jsonObj.get("previous").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("previous"));
       }
       // validate the optional field `self`
-      if (jsonObj.getAsJsonObject("self") != null) {
+      if (jsonObj.get("self") != null && !jsonObj.get("self").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("self"));
       }
   }
@@ -340,6 +369,23 @@ public class Meta {
            @Override
            public void write(JsonWriter out, Meta value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -347,7 +393,25 @@ public class Meta {
            public Meta read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Meta instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGateway.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGateway.java
@@ -137,7 +137,7 @@ public class MetalGateway {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_NETWORK)
   private Href virtualNetwork;
 
-  public MetalGateway() { 
+  public MetalGateway() {
   }
 
   public MetalGateway createdAt(OffsetDateTime createdAt) {
@@ -346,6 +346,41 @@ public class MetalGateway {
     this.virtualNetwork = virtualNetwork;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetalGateway putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -365,12 +400,13 @@ public class MetalGateway {
         Objects.equals(this.project, metalGateway.project) &&
         Objects.equals(this.state, metalGateway.state) &&
         Objects.equals(this.updatedAt, metalGateway.updatedAt) &&
-        Objects.equals(this.virtualNetwork, metalGateway.virtualNetwork);
+        Objects.equals(this.virtualNetwork, metalGateway.virtualNetwork)&&
+        Objects.equals(this.additionalProperties, metalGateway.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, createdBy, href, id, ipReservation, project, state, updatedAt, virtualNetwork);
+    return Objects.hash(createdAt, createdBy, href, id, ipReservation, project, state, updatedAt, virtualNetwork, additionalProperties);
   }
 
   @Override
@@ -386,6 +422,7 @@ public class MetalGateway {
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    virtualNetwork: ").append(toIndentedString(virtualNetwork)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -436,37 +473,29 @@ public class MetalGateway {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MetalGateway is not found in the empty JSON string", MetalGateway.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetalGateway.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetalGateway` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `created_by`
-      if (jsonObj.getAsJsonObject("created_by") != null) {
+      if (jsonObj.get("created_by") != null && !jsonObj.get("created_by").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("created_by"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `ip_reservation`
-      if (jsonObj.getAsJsonObject("ip_reservation") != null) {
+      if (jsonObj.get("ip_reservation") != null && !jsonObj.get("ip_reservation").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("ip_reservation"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
       // validate the optional field `virtual_network`
-      if (jsonObj.getAsJsonObject("virtual_network") != null) {
+      if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("virtual_network"));
       }
   }
@@ -486,6 +515,23 @@ public class MetalGateway {
            @Override
            public void write(JsonWriter out, MetalGateway value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -493,7 +539,25 @@ public class MetalGateway {
            public MetalGateway read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetalGateway instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayInput.java
@@ -62,7 +62,7 @@ public class MetalGatewayInput {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_NETWORK_ID)
   private UUID virtualNetworkId;
 
-  public MetalGatewayInput() { 
+  public MetalGatewayInput() {
   }
 
   public MetalGatewayInput ipReservationId(UUID ipReservationId) {
@@ -133,6 +133,41 @@ public class MetalGatewayInput {
     this.virtualNetworkId = virtualNetworkId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetalGatewayInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -146,12 +181,13 @@ public class MetalGatewayInput {
     MetalGatewayInput metalGatewayInput = (MetalGatewayInput) o;
     return Objects.equals(this.ipReservationId, metalGatewayInput.ipReservationId) &&
         Objects.equals(this.privateIpv4SubnetSize, metalGatewayInput.privateIpv4SubnetSize) &&
-        Objects.equals(this.virtualNetworkId, metalGatewayInput.virtualNetworkId);
+        Objects.equals(this.virtualNetworkId, metalGatewayInput.virtualNetworkId)&&
+        Objects.equals(this.additionalProperties, metalGatewayInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ipReservationId, privateIpv4SubnetSize, virtualNetworkId);
+    return Objects.hash(ipReservationId, privateIpv4SubnetSize, virtualNetworkId, additionalProperties);
   }
 
   @Override
@@ -161,6 +197,7 @@ public class MetalGatewayInput {
     sb.append("    ipReservationId: ").append(toIndentedString(ipReservationId)).append("\n");
     sb.append("    privateIpv4SubnetSize: ").append(toIndentedString(privateIpv4SubnetSize)).append("\n");
     sb.append("    virtualNetworkId: ").append(toIndentedString(virtualNetworkId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -207,24 +244,16 @@ public class MetalGatewayInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetalGatewayInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetalGatewayInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : MetalGatewayInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("ip_reservation_id") != null && !jsonObj.get("ip_reservation_id").isJsonPrimitive()) {
+      if ((jsonObj.get("ip_reservation_id") != null && !jsonObj.get("ip_reservation_id").isJsonNull()) && !jsonObj.get("ip_reservation_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_reservation_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("ip_reservation_id").toString()));
       }
-      if (jsonObj.get("virtual_network_id") != null && !jsonObj.get("virtual_network_id").isJsonPrimitive()) {
+      if ((jsonObj.get("virtual_network_id") != null && !jsonObj.get("virtual_network_id").isJsonNull()) && !jsonObj.get("virtual_network_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `virtual_network_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("virtual_network_id").toString()));
       }
   }
@@ -244,6 +273,23 @@ public class MetalGatewayInput {
            @Override
            public void write(JsonWriter out, MetalGatewayInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -251,7 +297,25 @@ public class MetalGatewayInput {
            public MetalGatewayInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetalGatewayInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayList.java
@@ -56,7 +56,7 @@ public class MetalGatewayList {
   @SerializedName(SERIALIZED_NAME_METAL_GATEWAYS)
   private List<MetalGatewayListMetalGatewaysInner> metalGateways = null;
 
-  public MetalGatewayList() { 
+  public MetalGatewayList() {
   }
 
   public MetalGatewayList metalGateways(List<MetalGatewayListMetalGatewaysInner> metalGateways) {
@@ -89,6 +89,41 @@ public class MetalGatewayList {
     this.metalGateways = metalGateways;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetalGatewayList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class MetalGatewayList {
       return false;
     }
     MetalGatewayList metalGatewayList = (MetalGatewayList) o;
-    return Objects.equals(this.metalGateways, metalGatewayList.metalGateways);
+    return Objects.equals(this.metalGateways, metalGatewayList.metalGateways)&&
+        Objects.equals(this.additionalProperties, metalGatewayList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(metalGateways);
+    return Objects.hash(metalGateways, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class MetalGatewayList {
     StringBuilder sb = new StringBuilder();
     sb.append("class MetalGatewayList {\n");
     sb.append("    metalGateways: ").append(toIndentedString(metalGateways)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class MetalGatewayList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MetalGatewayList is not found in the empty JSON string", MetalGatewayList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetalGatewayList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetalGatewayList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraymetalGateways = jsonObj.getAsJsonArray("MetalGateways");
       if (jsonArraymetalGateways != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class MetalGatewayList {
            @Override
            public void write(JsonWriter out, MetalGatewayList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class MetalGatewayList {
            public MetalGatewayList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetalGatewayList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayLite.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayLite.java
@@ -129,7 +129,7 @@ public class MetalGatewayLite {
   @SerializedName(SERIALIZED_NAME_VLAN)
   private BigDecimal vlan;
 
-  public MetalGatewayLite() { 
+  public MetalGatewayLite() {
   }
 
   public MetalGatewayLite createdAt(OffsetDateTime createdAt) {
@@ -292,6 +292,41 @@ public class MetalGatewayLite {
     this.vlan = vlan;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetalGatewayLite putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -309,12 +344,13 @@ public class MetalGatewayLite {
         Objects.equals(this.id, metalGatewayLite.id) &&
         Objects.equals(this.state, metalGatewayLite.state) &&
         Objects.equals(this.updatedAt, metalGatewayLite.updatedAt) &&
-        Objects.equals(this.vlan, metalGatewayLite.vlan);
+        Objects.equals(this.vlan, metalGatewayLite.vlan)&&
+        Objects.equals(this.additionalProperties, metalGatewayLite.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, gatewayAddress, href, id, state, updatedAt, vlan);
+    return Objects.hash(createdAt, gatewayAddress, href, id, state, updatedAt, vlan, additionalProperties);
   }
 
   @Override
@@ -328,6 +364,7 @@ public class MetalGatewayLite {
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    vlan: ").append(toIndentedString(vlan)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -376,24 +413,16 @@ public class MetalGatewayLite {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MetalGatewayLite is not found in the empty JSON string", MetalGatewayLite.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetalGatewayLite.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetalGatewayLite` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("gateway_address") != null && !jsonObj.get("gateway_address").isJsonPrimitive()) {
+      if ((jsonObj.get("gateway_address") != null && !jsonObj.get("gateway_address").isJsonNull()) && !jsonObj.get("gateway_address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `gateway_address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("gateway_address").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
   }
@@ -413,6 +442,23 @@ public class MetalGatewayLite {
            @Override
            public void write(JsonWriter out, MetalGatewayLite value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -420,7 +466,25 @@ public class MetalGatewayLite {
            public MetalGatewayLite read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetalGatewayLite instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Metro.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Metro.java
@@ -66,7 +66,7 @@ public class Metro {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public Metro() { 
+  public Metro() {
   }
 
   public Metro code(String code) {
@@ -160,6 +160,41 @@ public class Metro {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Metro putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -174,12 +209,13 @@ public class Metro {
     return Objects.equals(this.code, metro.code) &&
         Objects.equals(this.country, metro.country) &&
         Objects.equals(this.id, metro.id) &&
-        Objects.equals(this.name, metro.name);
+        Objects.equals(this.name, metro.name)&&
+        Objects.equals(this.additionalProperties, metro.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(code, country, id, name);
+    return Objects.hash(code, country, id, name, additionalProperties);
   }
 
   @Override
@@ -190,6 +226,7 @@ public class Metro {
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -235,24 +272,16 @@ public class Metro {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Metro is not found in the empty JSON string", Metro.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Metro.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Metro` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
-      if (jsonObj.get("country") != null && !jsonObj.get("country").isJsonPrimitive()) {
+      if ((jsonObj.get("country") != null && !jsonObj.get("country").isJsonNull()) && !jsonObj.get("country").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -272,6 +301,23 @@ public class Metro {
            @Override
            public void write(JsonWriter out, Metro value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -279,7 +325,25 @@ public class Metro {
            public Metro read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Metro instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroCapacityList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroCapacityList.java
@@ -54,7 +54,7 @@ public class MetroCapacityList {
   @SerializedName(SERIALIZED_NAME_CAPACITY)
   private MetroCapacityReport capacity;
 
-  public MetroCapacityList() { 
+  public MetroCapacityList() {
   }
 
   public MetroCapacityList capacity(MetroCapacityReport capacity) {
@@ -79,6 +79,41 @@ public class MetroCapacityList {
     this.capacity = capacity;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetroCapacityList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class MetroCapacityList {
       return false;
     }
     MetroCapacityList metroCapacityList = (MetroCapacityList) o;
-    return Objects.equals(this.capacity, metroCapacityList.capacity);
+    return Objects.equals(this.capacity, metroCapacityList.capacity)&&
+        Objects.equals(this.additionalProperties, metroCapacityList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(capacity);
+    return Objects.hash(capacity, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class MetroCapacityList {
     StringBuilder sb = new StringBuilder();
     sb.append("class MetroCapacityList {\n");
     sb.append("    capacity: ").append(toIndentedString(capacity)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,16 +182,8 @@ public class MetroCapacityList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MetroCapacityList is not found in the empty JSON string", MetroCapacityList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetroCapacityList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetroCapacityList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `capacity`
-      if (jsonObj.getAsJsonObject("capacity") != null) {
+      if (jsonObj.get("capacity") != null && !jsonObj.get("capacity").isJsonNull()) {
         MetroCapacityReport.validateJsonObject(jsonObj.getAsJsonObject("capacity"));
       }
   }
@@ -174,6 +203,23 @@ public class MetroCapacityList {
            @Override
            public void write(JsonWriter out, MetroCapacityList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -181,7 +227,25 @@ public class MetroCapacityList {
            public MetroCapacityList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetroCapacityList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroCapacityReport.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroCapacityReport.java
@@ -130,7 +130,7 @@ public class MetroCapacityReport {
   @SerializedName(SERIALIZED_NAME_TY)
   private CapacityPerFacility ty;
 
-  public MetroCapacityReport() { 
+  public MetroCapacityReport() {
   }
 
   public MetroCapacityReport am(CapacityPerFacility am) {
@@ -592,6 +592,41 @@ public class MetroCapacityReport {
     this.ty = ty;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetroCapacityReport putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -622,12 +657,13 @@ public class MetroCapacityReport {
         Objects.equals(this.sv, metroCapacityReport.sv) &&
         Objects.equals(this.sy, metroCapacityReport.sy) &&
         Objects.equals(this.tr, metroCapacityReport.tr) &&
-        Objects.equals(this.ty, metroCapacityReport.ty);
+        Objects.equals(this.ty, metroCapacityReport.ty)&&
+        Objects.equals(this.additionalProperties, metroCapacityReport.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(am, at, ch, da, dc, fr, hk, la, ld, md, ny, pa, se, sg, sl, sp, sv, sy, tr, ty);
+    return Objects.hash(am, at, ch, da, dc, fr, hk, la, ld, md, ny, pa, se, sg, sl, sp, sv, sy, tr, ty, additionalProperties);
   }
 
   @Override
@@ -654,6 +690,7 @@ public class MetroCapacityReport {
     sb.append("    sy: ").append(toIndentedString(sy)).append("\n");
     sb.append("    tr: ").append(toIndentedString(tr)).append("\n");
     sb.append("    ty: ").append(toIndentedString(ty)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -715,92 +752,84 @@ public class MetroCapacityReport {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MetroCapacityReport is not found in the empty JSON string", MetroCapacityReport.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetroCapacityReport.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetroCapacityReport` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `am`
-      if (jsonObj.getAsJsonObject("am") != null) {
+      if (jsonObj.get("am") != null && !jsonObj.get("am").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("am"));
       }
       // validate the optional field `at`
-      if (jsonObj.getAsJsonObject("at") != null) {
+      if (jsonObj.get("at") != null && !jsonObj.get("at").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("at"));
       }
       // validate the optional field `ch`
-      if (jsonObj.getAsJsonObject("ch") != null) {
+      if (jsonObj.get("ch") != null && !jsonObj.get("ch").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ch"));
       }
       // validate the optional field `da`
-      if (jsonObj.getAsJsonObject("da") != null) {
+      if (jsonObj.get("da") != null && !jsonObj.get("da").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("da"));
       }
       // validate the optional field `dc`
-      if (jsonObj.getAsJsonObject("dc") != null) {
+      if (jsonObj.get("dc") != null && !jsonObj.get("dc").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("dc"));
       }
       // validate the optional field `fr`
-      if (jsonObj.getAsJsonObject("fr") != null) {
+      if (jsonObj.get("fr") != null && !jsonObj.get("fr").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("fr"));
       }
       // validate the optional field `hk`
-      if (jsonObj.getAsJsonObject("hk") != null) {
+      if (jsonObj.get("hk") != null && !jsonObj.get("hk").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("hk"));
       }
       // validate the optional field `la`
-      if (jsonObj.getAsJsonObject("la") != null) {
+      if (jsonObj.get("la") != null && !jsonObj.get("la").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("la"));
       }
       // validate the optional field `ld`
-      if (jsonObj.getAsJsonObject("ld") != null) {
+      if (jsonObj.get("ld") != null && !jsonObj.get("ld").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ld"));
       }
       // validate the optional field `md`
-      if (jsonObj.getAsJsonObject("md") != null) {
+      if (jsonObj.get("md") != null && !jsonObj.get("md").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("md"));
       }
       // validate the optional field `ny`
-      if (jsonObj.getAsJsonObject("ny") != null) {
+      if (jsonObj.get("ny") != null && !jsonObj.get("ny").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ny"));
       }
       // validate the optional field `pa`
-      if (jsonObj.getAsJsonObject("pa") != null) {
+      if (jsonObj.get("pa") != null && !jsonObj.get("pa").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("pa"));
       }
       // validate the optional field `se`
-      if (jsonObj.getAsJsonObject("se") != null) {
+      if (jsonObj.get("se") != null && !jsonObj.get("se").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("se"));
       }
       // validate the optional field `sg`
-      if (jsonObj.getAsJsonObject("sg") != null) {
+      if (jsonObj.get("sg") != null && !jsonObj.get("sg").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sg"));
       }
       // validate the optional field `sl`
-      if (jsonObj.getAsJsonObject("sl") != null) {
+      if (jsonObj.get("sl") != null && !jsonObj.get("sl").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sl"));
       }
       // validate the optional field `sp`
-      if (jsonObj.getAsJsonObject("sp") != null) {
+      if (jsonObj.get("sp") != null && !jsonObj.get("sp").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sp"));
       }
       // validate the optional field `sv`
-      if (jsonObj.getAsJsonObject("sv") != null) {
+      if (jsonObj.get("sv") != null && !jsonObj.get("sv").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sv"));
       }
       // validate the optional field `sy`
-      if (jsonObj.getAsJsonObject("sy") != null) {
+      if (jsonObj.get("sy") != null && !jsonObj.get("sy").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sy"));
       }
       // validate the optional field `tr`
-      if (jsonObj.getAsJsonObject("tr") != null) {
+      if (jsonObj.get("tr") != null && !jsonObj.get("tr").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("tr"));
       }
       // validate the optional field `ty`
-      if (jsonObj.getAsJsonObject("ty") != null) {
+      if (jsonObj.get("ty") != null && !jsonObj.get("ty").isJsonNull()) {
         CapacityPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ty"));
       }
   }
@@ -820,6 +849,23 @@ public class MetroCapacityReport {
            @Override
            public void write(JsonWriter out, MetroCapacityReport value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -827,7 +873,25 @@ public class MetroCapacityReport {
            public MetroCapacityReport read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetroCapacityReport instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroList.java
@@ -56,7 +56,7 @@ public class MetroList {
   @SerializedName(SERIALIZED_NAME_METROS)
   private List<Metro> metros = null;
 
-  public MetroList() { 
+  public MetroList() {
   }
 
   public MetroList metros(List<Metro> metros) {
@@ -89,6 +89,41 @@ public class MetroList {
     this.metros = metros;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetroList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class MetroList {
       return false;
     }
     MetroList metroList = (MetroList) o;
-    return Objects.equals(this.metros, metroList.metros);
+    return Objects.equals(this.metros, metroList.metros)&&
+        Objects.equals(this.additionalProperties, metroList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(metros);
+    return Objects.hash(metros, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class MetroList {
     StringBuilder sb = new StringBuilder();
     sb.append("class MetroList {\n");
     sb.append("    metros: ").append(toIndentedString(metros)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class MetroList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MetroList is not found in the empty JSON string", MetroList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetroList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetroList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraymetros = jsonObj.getAsJsonArray("metros");
       if (jsonArraymetros != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class MetroList {
            @Override
            public void write(JsonWriter out, MetroList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class MetroList {
            public MetroList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetroList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroServerInfo.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetroServerInfo.java
@@ -61,7 +61,7 @@ public class MetroServerInfo {
   @SerializedName(SERIALIZED_NAME_QUANTITY)
   private String quantity;
 
-  public MetroServerInfo() { 
+  public MetroServerInfo() {
   }
 
   public MetroServerInfo metro(String metro) {
@@ -132,6 +132,41 @@ public class MetroServerInfo {
     this.quantity = quantity;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public MetroServerInfo putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -145,12 +180,13 @@ public class MetroServerInfo {
     MetroServerInfo metroServerInfo = (MetroServerInfo) o;
     return Objects.equals(this.metro, metroServerInfo.metro) &&
         Objects.equals(this.plan, metroServerInfo.plan) &&
-        Objects.equals(this.quantity, metroServerInfo.quantity);
+        Objects.equals(this.quantity, metroServerInfo.quantity)&&
+        Objects.equals(this.additionalProperties, metroServerInfo.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(metro, plan, quantity);
+    return Objects.hash(metro, plan, quantity, additionalProperties);
   }
 
   @Override
@@ -160,6 +196,7 @@ public class MetroServerInfo {
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    plan: ").append(toIndentedString(plan)).append("\n");
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -204,21 +241,13 @@ public class MetroServerInfo {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MetroServerInfo is not found in the empty JSON string", MetroServerInfo.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!MetroServerInfo.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MetroServerInfo` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
-      if (jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonPrimitive()) {
+      if ((jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonNull()) && !jsonObj.get("quantity").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `quantity` to be a primitive type in the JSON string but got `%s`", jsonObj.get("quantity").toString()));
       }
   }
@@ -238,6 +267,23 @@ public class MetroServerInfo {
            @Override
            public void write(JsonWriter out, MetroServerInfo value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -245,7 +291,25 @@ public class MetroServerInfo {
            public MetroServerInfo read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             MetroServerInfo instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/NewPassword.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/NewPassword.java
@@ -53,7 +53,7 @@ public class NewPassword {
   @SerializedName(SERIALIZED_NAME_NEW_PASSWORD)
   private String newPassword;
 
-  public NewPassword() { 
+  public NewPassword() {
   }
 
   public NewPassword newPassword(String newPassword) {
@@ -78,6 +78,41 @@ public class NewPassword {
     this.newPassword = newPassword;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public NewPassword putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -89,12 +124,13 @@ public class NewPassword {
       return false;
     }
     NewPassword newPassword = (NewPassword) o;
-    return Objects.equals(this.newPassword, newPassword.newPassword);
+    return Objects.equals(this.newPassword, newPassword.newPassword)&&
+        Objects.equals(this.additionalProperties, newPassword.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(newPassword);
+    return Objects.hash(newPassword, additionalProperties);
   }
 
   @Override
@@ -102,6 +138,7 @@ public class NewPassword {
     StringBuilder sb = new StringBuilder();
     sb.append("class NewPassword {\n");
     sb.append("    newPassword: ").append(toIndentedString(newPassword)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -144,15 +181,7 @@ public class NewPassword {
           throw new IllegalArgumentException(String.format("The required field(s) %s in NewPassword is not found in the empty JSON string", NewPassword.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!NewPassword.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `NewPassword` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("new_password") != null && !jsonObj.get("new_password").isJsonPrimitive()) {
+      if ((jsonObj.get("new_password") != null && !jsonObj.get("new_password").isJsonNull()) && !jsonObj.get("new_password").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `new_password` to be a primitive type in the JSON string but got `%s`", jsonObj.get("new_password").toString()));
       }
   }
@@ -172,6 +201,23 @@ public class NewPassword {
            @Override
            public void write(JsonWriter out, NewPassword value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -179,7 +225,25 @@ public class NewPassword {
            public NewPassword read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             NewPassword instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OperatingSystem.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OperatingSystem.java
@@ -88,7 +88,7 @@ public class OperatingSystem {
   @SerializedName(SERIALIZED_NAME_VERSION)
   private String version;
 
-  public OperatingSystem() { 
+  public OperatingSystem() {
   }
 
   public OperatingSystem distro(String distro) {
@@ -305,6 +305,41 @@ public class OperatingSystem {
     this.version = version;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public OperatingSystem putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -324,12 +359,13 @@ public class OperatingSystem {
         Objects.equals(this.pricing, operatingSystem.pricing) &&
         Objects.equals(this.provisionableOn, operatingSystem.provisionableOn) &&
         Objects.equals(this.slug, operatingSystem.slug) &&
-        Objects.equals(this.version, operatingSystem.version);
+        Objects.equals(this.version, operatingSystem.version)&&
+        Objects.equals(this.additionalProperties, operatingSystem.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(distro, id, licensed, name, preinstallable, pricing, provisionableOn, slug, version);
+    return Objects.hash(distro, id, licensed, name, preinstallable, pricing, provisionableOn, slug, version, additionalProperties);
   }
 
   @Override
@@ -345,6 +381,7 @@ public class OperatingSystem {
     sb.append("    provisionableOn: ").append(toIndentedString(provisionableOn)).append("\n");
     sb.append("    slug: ").append(toIndentedString(slug)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -395,31 +432,23 @@ public class OperatingSystem {
           throw new IllegalArgumentException(String.format("The required field(s) %s in OperatingSystem is not found in the empty JSON string", OperatingSystem.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!OperatingSystem.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `OperatingSystem` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("distro") != null && !jsonObj.get("distro").isJsonPrimitive()) {
+      if ((jsonObj.get("distro") != null && !jsonObj.get("distro").isJsonNull()) && !jsonObj.get("distro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `distro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("distro").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("provisionable_on") != null && !jsonObj.get("provisionable_on").isJsonArray()) {
+      if ((jsonObj.get("provisionable_on") != null && !jsonObj.get("provisionable_on").isJsonNull()) && !jsonObj.get("provisionable_on").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `provisionable_on` to be an array in the JSON string but got `%s`", jsonObj.get("provisionable_on").toString()));
       }
-      if (jsonObj.get("slug") != null && !jsonObj.get("slug").isJsonPrimitive()) {
+      if ((jsonObj.get("slug") != null && !jsonObj.get("slug").isJsonNull()) && !jsonObj.get("slug").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `slug` to be a primitive type in the JSON string but got `%s`", jsonObj.get("slug").toString()));
       }
-      if (jsonObj.get("version") != null && !jsonObj.get("version").isJsonPrimitive()) {
+      if ((jsonObj.get("version") != null && !jsonObj.get("version").isJsonNull()) && !jsonObj.get("version").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `version` to be a primitive type in the JSON string but got `%s`", jsonObj.get("version").toString()));
       }
   }
@@ -439,6 +468,23 @@ public class OperatingSystem {
            @Override
            public void write(JsonWriter out, OperatingSystem value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -446,7 +492,25 @@ public class OperatingSystem {
            public OperatingSystem read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             OperatingSystem instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OperatingSystemList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OperatingSystemList.java
@@ -56,7 +56,7 @@ public class OperatingSystemList {
   @SerializedName(SERIALIZED_NAME_OPERATING_SYSTEMS)
   private List<OperatingSystem> operatingSystems = null;
 
-  public OperatingSystemList() { 
+  public OperatingSystemList() {
   }
 
   public OperatingSystemList operatingSystems(List<OperatingSystem> operatingSystems) {
@@ -89,6 +89,41 @@ public class OperatingSystemList {
     this.operatingSystems = operatingSystems;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public OperatingSystemList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class OperatingSystemList {
       return false;
     }
     OperatingSystemList operatingSystemList = (OperatingSystemList) o;
-    return Objects.equals(this.operatingSystems, operatingSystemList.operatingSystems);
+    return Objects.equals(this.operatingSystems, operatingSystemList.operatingSystems)&&
+        Objects.equals(this.additionalProperties, operatingSystemList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(operatingSystems);
+    return Objects.hash(operatingSystems, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class OperatingSystemList {
     StringBuilder sb = new StringBuilder();
     sb.append("class OperatingSystemList {\n");
     sb.append("    operatingSystems: ").append(toIndentedString(operatingSystems)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class OperatingSystemList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in OperatingSystemList is not found in the empty JSON string", OperatingSystemList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!OperatingSystemList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `OperatingSystemList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayoperatingSystems = jsonObj.getAsJsonArray("operating_systems");
       if (jsonArrayoperatingSystems != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class OperatingSystemList {
            @Override
            public void write(JsonWriter out, OperatingSystemList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class OperatingSystemList {
            public OperatingSystemList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             OperatingSystemList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Organization.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Organization.java
@@ -124,7 +124,7 @@ public class Organization {
   @SerializedName(SERIALIZED_NAME_WEBSITE)
   private String website;
 
-  public Organization() { 
+  public Organization() {
   }
 
   public Organization address(Address address) {
@@ -541,6 +541,41 @@ public class Organization {
     this.website = website;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Organization putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -568,12 +603,13 @@ public class Organization {
         Objects.equals(this.terms, organization.terms) &&
         Objects.equals(this.twitter, organization.twitter) &&
         Objects.equals(this.updatedAt, organization.updatedAt) &&
-        Objects.equals(this.website, organization.website);
+        Objects.equals(this.website, organization.website)&&
+        Objects.equals(this.additionalProperties, organization.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, billingAddress, createdAt, creditAmount, customdata, description, enforce2faAt, id, logo, members, memberships, name, projects, terms, twitter, updatedAt, website);
+    return Objects.hash(address, billingAddress, createdAt, creditAmount, customdata, description, enforce2faAt, id, logo, members, memberships, name, projects, terms, twitter, updatedAt, website, additionalProperties);
   }
 
   @Override
@@ -597,6 +633,7 @@ public class Organization {
     sb.append("    twitter: ").append(toIndentedString(twitter)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    website: ").append(toIndentedString(website)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -655,26 +692,18 @@ public class Organization {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Organization is not found in the empty JSON string", Organization.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Organization.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Organization` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `address`
-      if (jsonObj.getAsJsonObject("address") != null) {
+      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) {
         Address.validateJsonObject(jsonObj.getAsJsonObject("address"));
       }
       // validate the optional field `billing_address`
-      if (jsonObj.getAsJsonObject("billing_address") != null) {
+      if (jsonObj.get("billing_address") != null && !jsonObj.get("billing_address").isJsonNull()) {
         Address.validateJsonObject(jsonObj.getAsJsonObject("billing_address"));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       JsonArray jsonArraymembers = jsonObj.getAsJsonArray("members");
@@ -701,7 +730,7 @@ public class Organization {
           Href.validateJsonObject(jsonArraymemberships.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       JsonArray jsonArrayprojects = jsonObj.getAsJsonArray("projects");
@@ -716,10 +745,10 @@ public class Organization {
           Href.validateJsonObject(jsonArrayprojects.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("twitter") != null && !jsonObj.get("twitter").isJsonPrimitive()) {
+      if ((jsonObj.get("twitter") != null && !jsonObj.get("twitter").isJsonNull()) && !jsonObj.get("twitter").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `twitter` to be a primitive type in the JSON string but got `%s`", jsonObj.get("twitter").toString()));
       }
-      if (jsonObj.get("website") != null && !jsonObj.get("website").isJsonPrimitive()) {
+      if ((jsonObj.get("website") != null && !jsonObj.get("website").isJsonNull()) && !jsonObj.get("website").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `website` to be a primitive type in the JSON string but got `%s`", jsonObj.get("website").toString()));
       }
   }
@@ -739,6 +768,23 @@ public class Organization {
            @Override
            public void write(JsonWriter out, Organization value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -746,7 +792,25 @@ public class Organization {
            public Organization read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Organization instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OrganizationInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OrganizationInput.java
@@ -88,7 +88,7 @@ public class OrganizationInput {
   @SerializedName(SERIALIZED_NAME_WEBSITE)
   private String website;
 
-  public OrganizationInput() { 
+  public OrganizationInput() {
   }
 
   public OrganizationInput address(Address address) {
@@ -297,6 +297,41 @@ public class OrganizationInput {
     this.website = website;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public OrganizationInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -316,12 +351,13 @@ public class OrganizationInput {
         Objects.equals(this.logo, organizationInput.logo) &&
         Objects.equals(this.name, organizationInput.name) &&
         Objects.equals(this.twitter, organizationInput.twitter) &&
-        Objects.equals(this.website, organizationInput.website);
+        Objects.equals(this.website, organizationInput.website)&&
+        Objects.equals(this.additionalProperties, organizationInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, billingAddress, customdata, description, enforce2faAt, logo, name, twitter, website);
+    return Objects.hash(address, billingAddress, customdata, description, enforce2faAt, logo, name, twitter, website, additionalProperties);
   }
 
   @Override
@@ -337,6 +373,7 @@ public class OrganizationInput {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    twitter: ").append(toIndentedString(twitter)).append("\n");
     sb.append("    website: ").append(toIndentedString(website)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -387,32 +424,24 @@ public class OrganizationInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in OrganizationInput is not found in the empty JSON string", OrganizationInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!OrganizationInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `OrganizationInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `address`
-      if (jsonObj.getAsJsonObject("address") != null) {
+      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) {
         Address.validateJsonObject(jsonObj.getAsJsonObject("address"));
       }
       // validate the optional field `billing_address`
-      if (jsonObj.getAsJsonObject("billing_address") != null) {
+      if (jsonObj.get("billing_address") != null && !jsonObj.get("billing_address").isJsonNull()) {
         Address.validateJsonObject(jsonObj.getAsJsonObject("billing_address"));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("twitter") != null && !jsonObj.get("twitter").isJsonPrimitive()) {
+      if ((jsonObj.get("twitter") != null && !jsonObj.get("twitter").isJsonNull()) && !jsonObj.get("twitter").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `twitter` to be a primitive type in the JSON string but got `%s`", jsonObj.get("twitter").toString()));
       }
-      if (jsonObj.get("website") != null && !jsonObj.get("website").isJsonPrimitive()) {
+      if ((jsonObj.get("website") != null && !jsonObj.get("website").isJsonNull()) && !jsonObj.get("website").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `website` to be a primitive type in the JSON string but got `%s`", jsonObj.get("website").toString()));
       }
   }
@@ -432,6 +461,23 @@ public class OrganizationInput {
            @Override
            public void write(JsonWriter out, OrganizationInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -439,7 +485,25 @@ public class OrganizationInput {
            public OrganizationInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             OrganizationInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OrganizationList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/OrganizationList.java
@@ -61,7 +61,7 @@ public class OrganizationList {
   @SerializedName(SERIALIZED_NAME_ORGANIZATIONS)
   private List<Organization> organizations = null;
 
-  public OrganizationList() { 
+  public OrganizationList() {
   }
 
   public OrganizationList meta(Meta meta) {
@@ -117,6 +117,41 @@ public class OrganizationList {
     this.organizations = organizations;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public OrganizationList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -129,12 +164,13 @@ public class OrganizationList {
     }
     OrganizationList organizationList = (OrganizationList) o;
     return Objects.equals(this.meta, organizationList.meta) &&
-        Objects.equals(this.organizations, organizationList.organizations);
+        Objects.equals(this.organizations, organizationList.organizations)&&
+        Objects.equals(this.additionalProperties, organizationList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(meta, organizations);
+    return Objects.hash(meta, organizations, additionalProperties);
   }
 
   @Override
@@ -143,6 +179,7 @@ public class OrganizationList {
     sb.append("class OrganizationList {\n");
     sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
     sb.append("    organizations: ").append(toIndentedString(organizations)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -186,16 +223,8 @@ public class OrganizationList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in OrganizationList is not found in the empty JSON string", OrganizationList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!OrganizationList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `OrganizationList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `meta`
-      if (jsonObj.getAsJsonObject("meta") != null) {
+      if (jsonObj.get("meta") != null && !jsonObj.get("meta").isJsonNull()) {
         Meta.validateJsonObject(jsonObj.getAsJsonObject("meta"));
       }
       JsonArray jsonArrayorganizations = jsonObj.getAsJsonArray("organizations");
@@ -227,6 +256,23 @@ public class OrganizationList {
            @Override
            public void write(JsonWriter out, OrganizationList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -234,7 +280,25 @@ public class OrganizationList {
            public OrganizationList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             OrganizationList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ParentBlock.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ParentBlock.java
@@ -65,7 +65,7 @@ public class ParentBlock {
   @SerializedName(SERIALIZED_NAME_NETWORK)
   private String network;
 
-  public ParentBlock() { 
+  public ParentBlock() {
   }
 
   public ParentBlock cidr(Integer cidr) {
@@ -159,6 +159,41 @@ public class ParentBlock {
     this.network = network;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ParentBlock putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -173,12 +208,13 @@ public class ParentBlock {
     return Objects.equals(this.cidr, parentBlock.cidr) &&
         Objects.equals(this.href, parentBlock.href) &&
         Objects.equals(this.netmask, parentBlock.netmask) &&
-        Objects.equals(this.network, parentBlock.network);
+        Objects.equals(this.network, parentBlock.network)&&
+        Objects.equals(this.additionalProperties, parentBlock.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(cidr, href, netmask, network);
+    return Objects.hash(cidr, href, netmask, network, additionalProperties);
   }
 
   @Override
@@ -189,6 +225,7 @@ public class ParentBlock {
     sb.append("    href: ").append(toIndentedString(href)).append("\n");
     sb.append("    netmask: ").append(toIndentedString(netmask)).append("\n");
     sb.append("    network: ").append(toIndentedString(network)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -234,21 +271,13 @@ public class ParentBlock {
           throw new IllegalArgumentException(String.format("The required field(s) %s in ParentBlock is not found in the empty JSON string", ParentBlock.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ParentBlock.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ParentBlock` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonPrimitive()) {
+      if ((jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonNull()) && !jsonObj.get("netmask").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `netmask` to be a primitive type in the JSON string but got `%s`", jsonObj.get("netmask").toString()));
       }
-      if (jsonObj.get("network") != null && !jsonObj.get("network").isJsonPrimitive()) {
+      if ((jsonObj.get("network") != null && !jsonObj.get("network").isJsonNull()) && !jsonObj.get("network").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `network` to be a primitive type in the JSON string but got `%s`", jsonObj.get("network").toString()));
       }
   }
@@ -268,6 +297,23 @@ public class ParentBlock {
            @Override
            public void write(JsonWriter out, ParentBlock value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -275,7 +321,25 @@ public class ParentBlock {
            public ParentBlock read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ParentBlock instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethod.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethod.java
@@ -115,7 +115,7 @@ public class PaymentMethod {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public PaymentMethod() { 
+  public PaymentMethod() {
   }
 
   public PaymentMethod billingAddress(PaymentMethodBillingAddress billingAddress) {
@@ -470,6 +470,41 @@ public class PaymentMethod {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PaymentMethod putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -495,12 +530,13 @@ public class PaymentMethod {
         Objects.equals(this.organization, paymentMethod.organization) &&
         Objects.equals(this.projects, paymentMethod.projects) &&
         Objects.equals(this.type, paymentMethod.type) &&
-        Objects.equals(this.updatedAt, paymentMethod.updatedAt);
+        Objects.equals(this.updatedAt, paymentMethod.updatedAt)&&
+        Objects.equals(this.additionalProperties, paymentMethod.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(billingAddress, cardType, cardholderName, createdAt, createdByUser, _default, email, expirationMonth, expirationYear, id, name, organization, projects, type, updatedAt);
+    return Objects.hash(billingAddress, cardType, cardholderName, createdAt, createdByUser, _default, email, expirationMonth, expirationYear, id, name, organization, projects, type, updatedAt, additionalProperties);
   }
 
   @Override
@@ -522,6 +558,7 @@ public class PaymentMethod {
     sb.append("    projects: ").append(toIndentedString(projects)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -578,45 +615,37 @@ public class PaymentMethod {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PaymentMethod is not found in the empty JSON string", PaymentMethod.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PaymentMethod.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentMethod` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `billing_address`
-      if (jsonObj.getAsJsonObject("billing_address") != null) {
+      if (jsonObj.get("billing_address") != null && !jsonObj.get("billing_address").isJsonNull()) {
         PaymentMethodBillingAddress.validateJsonObject(jsonObj.getAsJsonObject("billing_address"));
       }
-      if (jsonObj.get("card_type") != null && !jsonObj.get("card_type").isJsonPrimitive()) {
+      if ((jsonObj.get("card_type") != null && !jsonObj.get("card_type").isJsonNull()) && !jsonObj.get("card_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `card_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("card_type").toString()));
       }
-      if (jsonObj.get("cardholder_name") != null && !jsonObj.get("cardholder_name").isJsonPrimitive()) {
+      if ((jsonObj.get("cardholder_name") != null && !jsonObj.get("cardholder_name").isJsonNull()) && !jsonObj.get("cardholder_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `cardholder_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("cardholder_name").toString()));
       }
       // validate the optional field `created_by_user`
-      if (jsonObj.getAsJsonObject("created_by_user") != null) {
+      if (jsonObj.get("created_by_user") != null && !jsonObj.get("created_by_user").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("created_by_user"));
       }
-      if (jsonObj.get("email") != null && !jsonObj.get("email").isJsonPrimitive()) {
+      if ((jsonObj.get("email") != null && !jsonObj.get("email").isJsonNull()) && !jsonObj.get("email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
       }
-      if (jsonObj.get("expiration_month") != null && !jsonObj.get("expiration_month").isJsonPrimitive()) {
+      if ((jsonObj.get("expiration_month") != null && !jsonObj.get("expiration_month").isJsonNull()) && !jsonObj.get("expiration_month").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `expiration_month` to be a primitive type in the JSON string but got `%s`", jsonObj.get("expiration_month").toString()));
       }
-      if (jsonObj.get("expiration_year") != null && !jsonObj.get("expiration_year").isJsonPrimitive()) {
+      if ((jsonObj.get("expiration_year") != null && !jsonObj.get("expiration_year").isJsonNull()) && !jsonObj.get("expiration_year").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `expiration_year` to be a primitive type in the JSON string but got `%s`", jsonObj.get("expiration_year").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       // validate the optional field `organization`
-      if (jsonObj.getAsJsonObject("organization") != null) {
+      if (jsonObj.get("organization") != null && !jsonObj.get("organization").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("organization"));
       }
       JsonArray jsonArrayprojects = jsonObj.getAsJsonArray("projects");
@@ -631,7 +660,7 @@ public class PaymentMethod {
           Href.validateJsonObject(jsonArrayprojects.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
   }
@@ -651,6 +680,23 @@ public class PaymentMethod {
            @Override
            public void write(JsonWriter out, PaymentMethod value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -658,7 +704,25 @@ public class PaymentMethod {
            public PaymentMethod read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PaymentMethod instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodBillingAddress.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodBillingAddress.java
@@ -61,7 +61,7 @@ public class PaymentMethodBillingAddress {
   @SerializedName(SERIALIZED_NAME_STREET_ADDRESS)
   private String streetAddress;
 
-  public PaymentMethodBillingAddress() { 
+  public PaymentMethodBillingAddress() {
   }
 
   public PaymentMethodBillingAddress countryCodeAlpha2(String countryCodeAlpha2) {
@@ -132,6 +132,41 @@ public class PaymentMethodBillingAddress {
     this.streetAddress = streetAddress;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PaymentMethodBillingAddress putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -145,12 +180,13 @@ public class PaymentMethodBillingAddress {
     PaymentMethodBillingAddress paymentMethodBillingAddress = (PaymentMethodBillingAddress) o;
     return Objects.equals(this.countryCodeAlpha2, paymentMethodBillingAddress.countryCodeAlpha2) &&
         Objects.equals(this.postalCode, paymentMethodBillingAddress.postalCode) &&
-        Objects.equals(this.streetAddress, paymentMethodBillingAddress.streetAddress);
+        Objects.equals(this.streetAddress, paymentMethodBillingAddress.streetAddress)&&
+        Objects.equals(this.additionalProperties, paymentMethodBillingAddress.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(countryCodeAlpha2, postalCode, streetAddress);
+    return Objects.hash(countryCodeAlpha2, postalCode, streetAddress, additionalProperties);
   }
 
   @Override
@@ -160,6 +196,7 @@ public class PaymentMethodBillingAddress {
     sb.append("    countryCodeAlpha2: ").append(toIndentedString(countryCodeAlpha2)).append("\n");
     sb.append("    postalCode: ").append(toIndentedString(postalCode)).append("\n");
     sb.append("    streetAddress: ").append(toIndentedString(streetAddress)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -204,21 +241,13 @@ public class PaymentMethodBillingAddress {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PaymentMethodBillingAddress is not found in the empty JSON string", PaymentMethodBillingAddress.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PaymentMethodBillingAddress.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentMethodBillingAddress` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("country_code_alpha2") != null && !jsonObj.get("country_code_alpha2").isJsonPrimitive()) {
+      if ((jsonObj.get("country_code_alpha2") != null && !jsonObj.get("country_code_alpha2").isJsonNull()) && !jsonObj.get("country_code_alpha2").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country_code_alpha2` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country_code_alpha2").toString()));
       }
-      if (jsonObj.get("postal_code") != null && !jsonObj.get("postal_code").isJsonPrimitive()) {
+      if ((jsonObj.get("postal_code") != null && !jsonObj.get("postal_code").isJsonNull()) && !jsonObj.get("postal_code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `postal_code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("postal_code").toString()));
       }
-      if (jsonObj.get("street_address") != null && !jsonObj.get("street_address").isJsonPrimitive()) {
+      if ((jsonObj.get("street_address") != null && !jsonObj.get("street_address").isJsonNull()) && !jsonObj.get("street_address").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `street_address` to be a primitive type in the JSON string but got `%s`", jsonObj.get("street_address").toString()));
       }
   }
@@ -238,6 +267,23 @@ public class PaymentMethodBillingAddress {
            @Override
            public void write(JsonWriter out, PaymentMethodBillingAddress value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -245,7 +291,25 @@ public class PaymentMethodBillingAddress {
            public PaymentMethodBillingAddress read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PaymentMethodBillingAddress instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodCreateInput.java
@@ -61,7 +61,7 @@ public class PaymentMethodCreateInput {
   @SerializedName(SERIALIZED_NAME_NONCE)
   private String nonce;
 
-  public PaymentMethodCreateInput() { 
+  public PaymentMethodCreateInput() {
   }
 
   public PaymentMethodCreateInput _default(Boolean _default) {
@@ -132,6 +132,41 @@ public class PaymentMethodCreateInput {
     this.nonce = nonce;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PaymentMethodCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -145,12 +180,13 @@ public class PaymentMethodCreateInput {
     PaymentMethodCreateInput paymentMethodCreateInput = (PaymentMethodCreateInput) o;
     return Objects.equals(this._default, paymentMethodCreateInput._default) &&
         Objects.equals(this.name, paymentMethodCreateInput.name) &&
-        Objects.equals(this.nonce, paymentMethodCreateInput.nonce);
+        Objects.equals(this.nonce, paymentMethodCreateInput.nonce)&&
+        Objects.equals(this.additionalProperties, paymentMethodCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_default, name, nonce);
+    return Objects.hash(_default, name, nonce, additionalProperties);
   }
 
   @Override
@@ -160,6 +196,7 @@ public class PaymentMethodCreateInput {
     sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    nonce: ").append(toIndentedString(nonce)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -207,24 +244,16 @@ public class PaymentMethodCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PaymentMethodCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentMethodCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PaymentMethodCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("nonce") != null && !jsonObj.get("nonce").isJsonPrimitive()) {
+      if ((jsonObj.get("nonce") != null && !jsonObj.get("nonce").isJsonNull()) && !jsonObj.get("nonce").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `nonce` to be a primitive type in the JSON string but got `%s`", jsonObj.get("nonce").toString()));
       }
   }
@@ -244,6 +273,23 @@ public class PaymentMethodCreateInput {
            @Override
            public void write(JsonWriter out, PaymentMethodCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -251,7 +297,25 @@ public class PaymentMethodCreateInput {
            public PaymentMethodCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PaymentMethodCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodList.java
@@ -56,7 +56,7 @@ public class PaymentMethodList {
   @SerializedName(SERIALIZED_NAME_PAYMENT_METHODS)
   private List<PaymentMethod> paymentMethods = null;
 
-  public PaymentMethodList() { 
+  public PaymentMethodList() {
   }
 
   public PaymentMethodList paymentMethods(List<PaymentMethod> paymentMethods) {
@@ -89,6 +89,41 @@ public class PaymentMethodList {
     this.paymentMethods = paymentMethods;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PaymentMethodList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class PaymentMethodList {
       return false;
     }
     PaymentMethodList paymentMethodList = (PaymentMethodList) o;
-    return Objects.equals(this.paymentMethods, paymentMethodList.paymentMethods);
+    return Objects.equals(this.paymentMethods, paymentMethodList.paymentMethods)&&
+        Objects.equals(this.additionalProperties, paymentMethodList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(paymentMethods);
+    return Objects.hash(paymentMethods, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class PaymentMethodList {
     StringBuilder sb = new StringBuilder();
     sb.append("class PaymentMethodList {\n");
     sb.append("    paymentMethods: ").append(toIndentedString(paymentMethods)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class PaymentMethodList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PaymentMethodList is not found in the empty JSON string", PaymentMethodList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PaymentMethodList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentMethodList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraypaymentMethods = jsonObj.getAsJsonArray("payment_methods");
       if (jsonArraypaymentMethods != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class PaymentMethodList {
            @Override
            public void write(JsonWriter out, PaymentMethodList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class PaymentMethodList {
            public PaymentMethodList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PaymentMethodList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PaymentMethodUpdateInput.java
@@ -73,7 +73,7 @@ public class PaymentMethodUpdateInput {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public PaymentMethodUpdateInput() { 
+  public PaymentMethodUpdateInput() {
   }
 
   public PaymentMethodUpdateInput billingAddress(Object billingAddress) {
@@ -213,6 +213,41 @@ public class PaymentMethodUpdateInput {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PaymentMethodUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -229,12 +264,13 @@ public class PaymentMethodUpdateInput {
         Objects.equals(this._default, paymentMethodUpdateInput._default) &&
         Objects.equals(this.expirationMonth, paymentMethodUpdateInput.expirationMonth) &&
         Objects.equals(this.expirationYear, paymentMethodUpdateInput.expirationYear) &&
-        Objects.equals(this.name, paymentMethodUpdateInput.name);
+        Objects.equals(this.name, paymentMethodUpdateInput.name)&&
+        Objects.equals(this.additionalProperties, paymentMethodUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(billingAddress, cardholderName, _default, expirationMonth, expirationYear, name);
+    return Objects.hash(billingAddress, cardholderName, _default, expirationMonth, expirationYear, name, additionalProperties);
   }
 
   @Override
@@ -247,6 +283,7 @@ public class PaymentMethodUpdateInput {
     sb.append("    expirationMonth: ").append(toIndentedString(expirationMonth)).append("\n");
     sb.append("    expirationYear: ").append(toIndentedString(expirationYear)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -294,21 +331,13 @@ public class PaymentMethodUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PaymentMethodUpdateInput is not found in the empty JSON string", PaymentMethodUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PaymentMethodUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentMethodUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("cardholder_name") != null && !jsonObj.get("cardholder_name").isJsonPrimitive()) {
+      if ((jsonObj.get("cardholder_name") != null && !jsonObj.get("cardholder_name").isJsonNull()) && !jsonObj.get("cardholder_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `cardholder_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("cardholder_name").toString()));
       }
-      if (jsonObj.get("expiration_month") != null && !jsonObj.get("expiration_month").isJsonPrimitive()) {
+      if ((jsonObj.get("expiration_month") != null && !jsonObj.get("expiration_month").isJsonNull()) && !jsonObj.get("expiration_month").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `expiration_month` to be a primitive type in the JSON string but got `%s`", jsonObj.get("expiration_month").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -328,6 +357,23 @@ public class PaymentMethodUpdateInput {
            @Override
            public void write(JsonWriter out, PaymentMethodUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -335,7 +381,25 @@ public class PaymentMethodUpdateInput {
            public PaymentMethodUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PaymentMethodUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Plan.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Plan.java
@@ -93,7 +93,7 @@ public class Plan {
   @SerializedName(SERIALIZED_NAME_SPECS)
   private Object specs;
 
-  public Plan() { 
+  public Plan() {
   }
 
   public Plan availableIn(List<Href> availableIn) {
@@ -333,6 +333,41 @@ public class Plan {
     this.specs = specs;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Plan putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -353,12 +388,13 @@ public class Plan {
         Objects.equals(this.name, plan.name) &&
         Objects.equals(this.pricing, plan.pricing) &&
         Objects.equals(this.slug, plan.slug) &&
-        Objects.equals(this.specs, plan.specs);
+        Objects.equals(this.specs, plan.specs)&&
+        Objects.equals(this.additionalProperties, plan.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(availableIn, propertyClass, description, id, legacy, line, name, pricing, slug, specs);
+    return Objects.hash(availableIn, propertyClass, description, id, legacy, line, name, pricing, slug, specs, additionalProperties);
   }
 
   @Override
@@ -375,6 +411,7 @@ public class Plan {
     sb.append("    pricing: ").append(toIndentedString(pricing)).append("\n");
     sb.append("    slug: ").append(toIndentedString(slug)).append("\n");
     sb.append("    specs: ").append(toIndentedString(specs)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -426,14 +463,6 @@ public class Plan {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Plan is not found in the empty JSON string", Plan.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Plan.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Plan` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayavailableIn = jsonObj.getAsJsonArray("available_in");
       if (jsonArrayavailableIn != null) {
         // ensure the json data is an array
@@ -446,22 +475,22 @@ public class Plan {
           Href.validateJsonObject(jsonArrayavailableIn.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("class") != null && !jsonObj.get("class").isJsonPrimitive()) {
+      if ((jsonObj.get("class") != null && !jsonObj.get("class").isJsonNull()) && !jsonObj.get("class").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `class` to be a primitive type in the JSON string but got `%s`", jsonObj.get("class").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("line") != null && !jsonObj.get("line").isJsonPrimitive()) {
+      if ((jsonObj.get("line") != null && !jsonObj.get("line").isJsonNull()) && !jsonObj.get("line").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `line` to be a primitive type in the JSON string but got `%s`", jsonObj.get("line").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("slug") != null && !jsonObj.get("slug").isJsonPrimitive()) {
+      if ((jsonObj.get("slug") != null && !jsonObj.get("slug").isJsonNull()) && !jsonObj.get("slug").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `slug` to be a primitive type in the JSON string but got `%s`", jsonObj.get("slug").toString()));
       }
   }
@@ -481,6 +510,23 @@ public class Plan {
            @Override
            public void write(JsonWriter out, Plan value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -488,7 +534,25 @@ public class Plan {
            public Plan read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Plan instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PlanList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PlanList.java
@@ -56,7 +56,7 @@ public class PlanList {
   @SerializedName(SERIALIZED_NAME_PLANS)
   private List<Plan> plans = null;
 
-  public PlanList() { 
+  public PlanList() {
   }
 
   public PlanList plans(List<Plan> plans) {
@@ -89,6 +89,41 @@ public class PlanList {
     this.plans = plans;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PlanList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class PlanList {
       return false;
     }
     PlanList planList = (PlanList) o;
-    return Objects.equals(this.plans, planList.plans);
+    return Objects.equals(this.plans, planList.plans)&&
+        Objects.equals(this.additionalProperties, planList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(plans);
+    return Objects.hash(plans, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class PlanList {
     StringBuilder sb = new StringBuilder();
     sb.append("class PlanList {\n");
     sb.append("    plans: ").append(toIndentedString(plans)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class PlanList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PlanList is not found in the empty JSON string", PlanList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PlanList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PlanList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayplans = jsonObj.getAsJsonArray("plans");
       if (jsonArrayplans != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class PlanList {
            @Override
            public void write(JsonWriter out, PlanList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class PlanList {
            public PlanList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PlanList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Port.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Port.java
@@ -81,7 +81,7 @@ public class Port {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_NETWORKS)
   private List<Href> virtualNetworks = null;
 
-  public Port() { 
+  public Port() {
   }
 
   public Port data(Object data) {
@@ -252,6 +252,41 @@ public class Port {
     this.virtualNetworks = virtualNetworks;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Port putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -269,12 +304,13 @@ public class Port {
         Objects.equals(this.id, port.id) &&
         Objects.equals(this.name, port.name) &&
         Objects.equals(this.type, port.type) &&
-        Objects.equals(this.virtualNetworks, port.virtualNetworks);
+        Objects.equals(this.virtualNetworks, port.virtualNetworks)&&
+        Objects.equals(this.additionalProperties, port.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(data, disbondOperationSupported, href, id, name, type, virtualNetworks);
+    return Objects.hash(data, disbondOperationSupported, href, id, name, type, virtualNetworks, additionalProperties);
   }
 
   @Override
@@ -288,6 +324,7 @@ public class Port {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    virtualNetworks: ").append(toIndentedString(virtualNetworks)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -336,24 +373,16 @@ public class Port {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Port is not found in the empty JSON string", Port.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Port.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Port` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
       JsonArray jsonArrayvirtualNetworks = jsonObj.getAsJsonArray("virtual_networks");
@@ -385,6 +414,23 @@ public class Port {
            @Override
            public void write(JsonWriter out, Port value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -392,7 +438,25 @@ public class Port {
            public Port read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Port instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortAssignInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortAssignInput.java
@@ -53,7 +53,7 @@ public class PortAssignInput {
   @SerializedName(SERIALIZED_NAME_VNID)
   private String vnid;
 
-  public PortAssignInput() { 
+  public PortAssignInput() {
   }
 
   public PortAssignInput vnid(String vnid) {
@@ -78,6 +78,41 @@ public class PortAssignInput {
     this.vnid = vnid;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortAssignInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -89,12 +124,13 @@ public class PortAssignInput {
       return false;
     }
     PortAssignInput portAssignInput = (PortAssignInput) o;
-    return Objects.equals(this.vnid, portAssignInput.vnid);
+    return Objects.equals(this.vnid, portAssignInput.vnid)&&
+        Objects.equals(this.additionalProperties, portAssignInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(vnid);
+    return Objects.hash(vnid, additionalProperties);
   }
 
   @Override
@@ -102,6 +138,7 @@ public class PortAssignInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class PortAssignInput {\n");
     sb.append("    vnid: ").append(toIndentedString(vnid)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -144,15 +181,7 @@ public class PortAssignInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortAssignInput is not found in the empty JSON string", PortAssignInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortAssignInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortAssignInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("vnid") != null && !jsonObj.get("vnid").isJsonPrimitive()) {
+      if ((jsonObj.get("vnid") != null && !jsonObj.get("vnid").isJsonNull()) && !jsonObj.get("vnid").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `vnid` to be a primitive type in the JSON string but got `%s`", jsonObj.get("vnid").toString()));
       }
   }
@@ -172,6 +201,23 @@ public class PortAssignInput {
            @Override
            public void write(JsonWriter out, PortAssignInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -179,7 +225,25 @@ public class PortAssignInput {
            public PortAssignInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortAssignInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortConvertLayer3Input.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortConvertLayer3Input.java
@@ -56,7 +56,7 @@ public class PortConvertLayer3Input {
   @SerializedName(SERIALIZED_NAME_REQUEST_IPS)
   private List<PortConvertLayer3InputRequestIpsInner> requestIps = null;
 
-  public PortConvertLayer3Input() { 
+  public PortConvertLayer3Input() {
   }
 
   public PortConvertLayer3Input requestIps(List<PortConvertLayer3InputRequestIpsInner> requestIps) {
@@ -89,6 +89,41 @@ public class PortConvertLayer3Input {
     this.requestIps = requestIps;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortConvertLayer3Input putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class PortConvertLayer3Input {
       return false;
     }
     PortConvertLayer3Input portConvertLayer3Input = (PortConvertLayer3Input) o;
-    return Objects.equals(this.requestIps, portConvertLayer3Input.requestIps);
+    return Objects.equals(this.requestIps, portConvertLayer3Input.requestIps)&&
+        Objects.equals(this.additionalProperties, portConvertLayer3Input.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(requestIps);
+    return Objects.hash(requestIps, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class PortConvertLayer3Input {
     StringBuilder sb = new StringBuilder();
     sb.append("class PortConvertLayer3Input {\n");
     sb.append("    requestIps: ").append(toIndentedString(requestIps)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class PortConvertLayer3Input {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortConvertLayer3Input is not found in the empty JSON string", PortConvertLayer3Input.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortConvertLayer3Input.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortConvertLayer3Input` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayrequestIps = jsonObj.getAsJsonArray("request_ips");
       if (jsonArrayrequestIps != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class PortConvertLayer3Input {
            @Override
            public void write(JsonWriter out, PortConvertLayer3Input value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class PortConvertLayer3Input {
            public PortConvertLayer3Input read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortConvertLayer3Input instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortConvertLayer3InputRequestIpsInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortConvertLayer3InputRequestIpsInner.java
@@ -57,7 +57,7 @@ public class PortConvertLayer3InputRequestIpsInner {
   @SerializedName(SERIALIZED_NAME_PUBLIC)
   private Boolean _public;
 
-  public PortConvertLayer3InputRequestIpsInner() { 
+  public PortConvertLayer3InputRequestIpsInner() {
   }
 
   public PortConvertLayer3InputRequestIpsInner addressFamily(Integer addressFamily) {
@@ -105,6 +105,41 @@ public class PortConvertLayer3InputRequestIpsInner {
     this._public = _public;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortConvertLayer3InputRequestIpsInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -117,12 +152,13 @@ public class PortConvertLayer3InputRequestIpsInner {
     }
     PortConvertLayer3InputRequestIpsInner portConvertLayer3InputRequestIpsInner = (PortConvertLayer3InputRequestIpsInner) o;
     return Objects.equals(this.addressFamily, portConvertLayer3InputRequestIpsInner.addressFamily) &&
-        Objects.equals(this._public, portConvertLayer3InputRequestIpsInner._public);
+        Objects.equals(this._public, portConvertLayer3InputRequestIpsInner._public)&&
+        Objects.equals(this.additionalProperties, portConvertLayer3InputRequestIpsInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, _public);
+    return Objects.hash(addressFamily, _public, additionalProperties);
   }
 
   @Override
@@ -131,6 +167,7 @@ public class PortConvertLayer3InputRequestIpsInner {
     sb.append("class PortConvertLayer3InputRequestIpsInner {\n");
     sb.append("    addressFamily: ").append(toIndentedString(addressFamily)).append("\n");
     sb.append("    _public: ").append(toIndentedString(_public)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -174,14 +211,6 @@ public class PortConvertLayer3InputRequestIpsInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortConvertLayer3InputRequestIpsInner is not found in the empty JSON string", PortConvertLayer3InputRequestIpsInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortConvertLayer3InputRequestIpsInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortConvertLayer3InputRequestIpsInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
@@ -199,6 +228,23 @@ public class PortConvertLayer3InputRequestIpsInner {
            @Override
            public void write(JsonWriter out, PortConvertLayer3InputRequestIpsInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -206,7 +252,25 @@ public class PortConvertLayer3InputRequestIpsInner {
            public PortConvertLayer3InputRequestIpsInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortConvertLayer3InputRequestIpsInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignment.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignment.java
@@ -131,7 +131,7 @@ public class PortVlanAssignment {
   @SerializedName(SERIALIZED_NAME_VLAN)
   private Integer vlan;
 
-  public PortVlanAssignment() { 
+  public PortVlanAssignment() {
   }
 
   public PortVlanAssignment createdAt(OffsetDateTime createdAt) {
@@ -317,6 +317,41 @@ public class PortVlanAssignment {
     this.vlan = vlan;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortVlanAssignment putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -335,12 +370,13 @@ public class PortVlanAssignment {
         Objects.equals(this.state, portVlanAssignment.state) &&
         Objects.equals(this.updatedAt, portVlanAssignment.updatedAt) &&
         Objects.equals(this.virtualNetwork, portVlanAssignment.virtualNetwork) &&
-        Objects.equals(this.vlan, portVlanAssignment.vlan);
+        Objects.equals(this.vlan, portVlanAssignment.vlan)&&
+        Objects.equals(this.additionalProperties, portVlanAssignment.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, id, _native, port, state, updatedAt, virtualNetwork, vlan);
+    return Objects.hash(createdAt, id, _native, port, state, updatedAt, virtualNetwork, vlan, additionalProperties);
   }
 
   @Override
@@ -355,6 +391,7 @@ public class PortVlanAssignment {
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    virtualNetwork: ").append(toIndentedString(virtualNetwork)).append("\n");
     sb.append("    vlan: ").append(toIndentedString(vlan)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -404,26 +441,18 @@ public class PortVlanAssignment {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortVlanAssignment is not found in the empty JSON string", PortVlanAssignment.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortVlanAssignment.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortVlanAssignment` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `port`
-      if (jsonObj.getAsJsonObject("port") != null) {
+      if (jsonObj.get("port") != null && !jsonObj.get("port").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("port"));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
       // validate the optional field `virtual_network`
-      if (jsonObj.getAsJsonObject("virtual_network") != null) {
+      if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("virtual_network"));
       }
   }
@@ -443,6 +472,23 @@ public class PortVlanAssignment {
            @Override
            public void write(JsonWriter out, PortVlanAssignment value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -450,7 +496,25 @@ public class PortVlanAssignment {
            public PortVlanAssignment read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortVlanAssignment instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatch.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatch.java
@@ -138,7 +138,7 @@ public class PortVlanAssignmentBatch {
   @SerializedName(SERIALIZED_NAME_VLAN_ASSIGNMENTS)
   private List<PortVlanAssignmentBatchVlanAssignmentsInner> vlanAssignments = null;
 
-  public PortVlanAssignmentBatch() { 
+  public PortVlanAssignmentBatch() {
   }
 
   public PortVlanAssignmentBatch createdAt(OffsetDateTime createdAt) {
@@ -340,6 +340,41 @@ public class PortVlanAssignmentBatch {
     this.vlanAssignments = vlanAssignments;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortVlanAssignmentBatch putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -358,12 +393,13 @@ public class PortVlanAssignmentBatch {
         Objects.equals(this.quantity, portVlanAssignmentBatch.quantity) &&
         Objects.equals(this.state, portVlanAssignmentBatch.state) &&
         Objects.equals(this.updatedAt, portVlanAssignmentBatch.updatedAt) &&
-        Objects.equals(this.vlanAssignments, portVlanAssignmentBatch.vlanAssignments);
+        Objects.equals(this.vlanAssignments, portVlanAssignmentBatch.vlanAssignments)&&
+        Objects.equals(this.additionalProperties, portVlanAssignmentBatch.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, errorMessages, id, port, quantity, state, updatedAt, vlanAssignments);
+    return Objects.hash(createdAt, errorMessages, id, port, quantity, state, updatedAt, vlanAssignments, additionalProperties);
   }
 
   @Override
@@ -378,6 +414,7 @@ public class PortVlanAssignmentBatch {
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    vlanAssignments: ").append(toIndentedString(vlanAssignments)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -427,26 +464,18 @@ public class PortVlanAssignmentBatch {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortVlanAssignmentBatch is not found in the empty JSON string", PortVlanAssignmentBatch.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortVlanAssignmentBatch.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortVlanAssignmentBatch` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("error_messages") != null && !jsonObj.get("error_messages").isJsonArray()) {
+      if ((jsonObj.get("error_messages") != null && !jsonObj.get("error_messages").isJsonNull()) && !jsonObj.get("error_messages").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `error_messages` to be an array in the JSON string but got `%s`", jsonObj.get("error_messages").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `port`
-      if (jsonObj.getAsJsonObject("port") != null) {
+      if (jsonObj.get("port") != null && !jsonObj.get("port").isJsonNull()) {
         Port.validateJsonObject(jsonObj.getAsJsonObject("port"));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
       JsonArray jsonArrayvlanAssignments = jsonObj.getAsJsonArray("vlan_assignments");
@@ -478,6 +507,23 @@ public class PortVlanAssignmentBatch {
            @Override
            public void write(JsonWriter out, PortVlanAssignmentBatch value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -485,7 +531,25 @@ public class PortVlanAssignmentBatch {
            public PortVlanAssignmentBatch read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortVlanAssignmentBatch instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchCreateInput.java
@@ -56,7 +56,7 @@ public class PortVlanAssignmentBatchCreateInput {
   @SerializedName(SERIALIZED_NAME_VLAN_ASSIGNMENTS)
   private List<PortVlanAssignmentBatchCreateInputVlanAssignmentsInner> vlanAssignments = null;
 
-  public PortVlanAssignmentBatchCreateInput() { 
+  public PortVlanAssignmentBatchCreateInput() {
   }
 
   public PortVlanAssignmentBatchCreateInput vlanAssignments(List<PortVlanAssignmentBatchCreateInputVlanAssignmentsInner> vlanAssignments) {
@@ -89,6 +89,41 @@ public class PortVlanAssignmentBatchCreateInput {
     this.vlanAssignments = vlanAssignments;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortVlanAssignmentBatchCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class PortVlanAssignmentBatchCreateInput {
       return false;
     }
     PortVlanAssignmentBatchCreateInput portVlanAssignmentBatchCreateInput = (PortVlanAssignmentBatchCreateInput) o;
-    return Objects.equals(this.vlanAssignments, portVlanAssignmentBatchCreateInput.vlanAssignments);
+    return Objects.equals(this.vlanAssignments, portVlanAssignmentBatchCreateInput.vlanAssignments)&&
+        Objects.equals(this.additionalProperties, portVlanAssignmentBatchCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(vlanAssignments);
+    return Objects.hash(vlanAssignments, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class PortVlanAssignmentBatchCreateInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class PortVlanAssignmentBatchCreateInput {\n");
     sb.append("    vlanAssignments: ").append(toIndentedString(vlanAssignments)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class PortVlanAssignmentBatchCreateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortVlanAssignmentBatchCreateInput is not found in the empty JSON string", PortVlanAssignmentBatchCreateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortVlanAssignmentBatchCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortVlanAssignmentBatchCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayvlanAssignments = jsonObj.getAsJsonArray("vlan_assignments");
       if (jsonArrayvlanAssignments != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class PortVlanAssignmentBatchCreateInput {
            @Override
            public void write(JsonWriter out, PortVlanAssignmentBatchCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class PortVlanAssignmentBatchCreateInput {
            public PortVlanAssignmentBatchCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortVlanAssignmentBatchCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchCreateInputVlanAssignmentsInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchCreateInputVlanAssignmentsInner.java
@@ -108,7 +108,7 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
   @SerializedName(SERIALIZED_NAME_VLAN)
   private String vlan;
 
-  public PortVlanAssignmentBatchCreateInputVlanAssignmentsInner() { 
+  public PortVlanAssignmentBatchCreateInputVlanAssignmentsInner() {
   }
 
   public PortVlanAssignmentBatchCreateInputVlanAssignmentsInner _native(Boolean _native) {
@@ -179,6 +179,41 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
     this.vlan = vlan;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortVlanAssignmentBatchCreateInputVlanAssignmentsInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -192,12 +227,13 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
     PortVlanAssignmentBatchCreateInputVlanAssignmentsInner portVlanAssignmentBatchCreateInputVlanAssignmentsInner = (PortVlanAssignmentBatchCreateInputVlanAssignmentsInner) o;
     return Objects.equals(this._native, portVlanAssignmentBatchCreateInputVlanAssignmentsInner._native) &&
         Objects.equals(this.state, portVlanAssignmentBatchCreateInputVlanAssignmentsInner.state) &&
-        Objects.equals(this.vlan, portVlanAssignmentBatchCreateInputVlanAssignmentsInner.vlan);
+        Objects.equals(this.vlan, portVlanAssignmentBatchCreateInputVlanAssignmentsInner.vlan)&&
+        Objects.equals(this.additionalProperties, portVlanAssignmentBatchCreateInputVlanAssignmentsInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_native, state, vlan);
+    return Objects.hash(_native, state, vlan, additionalProperties);
   }
 
   @Override
@@ -207,6 +243,7 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
     sb.append("    _native: ").append(toIndentedString(_native)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    vlan: ").append(toIndentedString(vlan)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -251,18 +288,10 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortVlanAssignmentBatchCreateInputVlanAssignmentsInner is not found in the empty JSON string", PortVlanAssignmentBatchCreateInputVlanAssignmentsInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortVlanAssignmentBatchCreateInputVlanAssignmentsInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortVlanAssignmentBatchCreateInputVlanAssignmentsInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
-      if (jsonObj.get("vlan") != null && !jsonObj.get("vlan").isJsonPrimitive()) {
+      if ((jsonObj.get("vlan") != null && !jsonObj.get("vlan").isJsonNull()) && !jsonObj.get("vlan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `vlan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("vlan").toString()));
       }
   }
@@ -282,6 +311,23 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
            @Override
            public void write(JsonWriter out, PortVlanAssignmentBatchCreateInputVlanAssignmentsInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -289,7 +335,25 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
            public PortVlanAssignmentBatchCreateInputVlanAssignmentsInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortVlanAssignmentBatchCreateInputVlanAssignmentsInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchList.java
@@ -56,7 +56,7 @@ public class PortVlanAssignmentBatchList {
   @SerializedName(SERIALIZED_NAME_BATCHES)
   private List<PortVlanAssignmentBatch> batches = null;
 
-  public PortVlanAssignmentBatchList() { 
+  public PortVlanAssignmentBatchList() {
   }
 
   public PortVlanAssignmentBatchList batches(List<PortVlanAssignmentBatch> batches) {
@@ -89,6 +89,41 @@ public class PortVlanAssignmentBatchList {
     this.batches = batches;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortVlanAssignmentBatchList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class PortVlanAssignmentBatchList {
       return false;
     }
     PortVlanAssignmentBatchList portVlanAssignmentBatchList = (PortVlanAssignmentBatchList) o;
-    return Objects.equals(this.batches, portVlanAssignmentBatchList.batches);
+    return Objects.equals(this.batches, portVlanAssignmentBatchList.batches)&&
+        Objects.equals(this.additionalProperties, portVlanAssignmentBatchList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(batches);
+    return Objects.hash(batches, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class PortVlanAssignmentBatchList {
     StringBuilder sb = new StringBuilder();
     sb.append("class PortVlanAssignmentBatchList {\n");
     sb.append("    batches: ").append(toIndentedString(batches)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class PortVlanAssignmentBatchList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortVlanAssignmentBatchList is not found in the empty JSON string", PortVlanAssignmentBatchList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortVlanAssignmentBatchList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortVlanAssignmentBatchList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraybatches = jsonObj.getAsJsonArray("batches");
       if (jsonArraybatches != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class PortVlanAssignmentBatchList {
            @Override
            public void write(JsonWriter out, PortVlanAssignmentBatchList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class PortVlanAssignmentBatchList {
            public PortVlanAssignmentBatchList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortVlanAssignmentBatchList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchVlanAssignmentsInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchVlanAssignmentsInner.java
@@ -113,7 +113,7 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
   @SerializedName(SERIALIZED_NAME_VLAN)
   private Integer vlan;
 
-  public PortVlanAssignmentBatchVlanAssignmentsInner() { 
+  public PortVlanAssignmentBatchVlanAssignmentsInner() {
   }
 
   public PortVlanAssignmentBatchVlanAssignmentsInner id(UUID id) {
@@ -207,6 +207,41 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
     this.vlan = vlan;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortVlanAssignmentBatchVlanAssignmentsInner putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -221,12 +256,13 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
     return Objects.equals(this.id, portVlanAssignmentBatchVlanAssignmentsInner.id) &&
         Objects.equals(this._native, portVlanAssignmentBatchVlanAssignmentsInner._native) &&
         Objects.equals(this.state, portVlanAssignmentBatchVlanAssignmentsInner.state) &&
-        Objects.equals(this.vlan, portVlanAssignmentBatchVlanAssignmentsInner.vlan);
+        Objects.equals(this.vlan, portVlanAssignmentBatchVlanAssignmentsInner.vlan)&&
+        Objects.equals(this.additionalProperties, portVlanAssignmentBatchVlanAssignmentsInner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, _native, state, vlan);
+    return Objects.hash(id, _native, state, vlan, additionalProperties);
   }
 
   @Override
@@ -237,6 +273,7 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
     sb.append("    _native: ").append(toIndentedString(_native)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    vlan: ").append(toIndentedString(vlan)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -282,18 +319,10 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortVlanAssignmentBatchVlanAssignmentsInner is not found in the empty JSON string", PortVlanAssignmentBatchVlanAssignmentsInner.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortVlanAssignmentBatchVlanAssignmentsInner.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortVlanAssignmentBatchVlanAssignmentsInner` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
   }
@@ -313,6 +342,23 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
            @Override
            public void write(JsonWriter out, PortVlanAssignmentBatchVlanAssignmentsInner value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -320,7 +366,25 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
            public PortVlanAssignmentBatchVlanAssignmentsInner read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortVlanAssignmentBatchVlanAssignmentsInner instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentList.java
@@ -56,7 +56,7 @@ public class PortVlanAssignmentList {
   @SerializedName(SERIALIZED_NAME_VLAN_ASSIGNMENTS)
   private List<PortVlanAssignment> vlanAssignments = null;
 
-  public PortVlanAssignmentList() { 
+  public PortVlanAssignmentList() {
   }
 
   public PortVlanAssignmentList vlanAssignments(List<PortVlanAssignment> vlanAssignments) {
@@ -89,6 +89,41 @@ public class PortVlanAssignmentList {
     this.vlanAssignments = vlanAssignments;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public PortVlanAssignmentList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class PortVlanAssignmentList {
       return false;
     }
     PortVlanAssignmentList portVlanAssignmentList = (PortVlanAssignmentList) o;
-    return Objects.equals(this.vlanAssignments, portVlanAssignmentList.vlanAssignments);
+    return Objects.equals(this.vlanAssignments, portVlanAssignmentList.vlanAssignments)&&
+        Objects.equals(this.additionalProperties, portVlanAssignmentList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(vlanAssignments);
+    return Objects.hash(vlanAssignments, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class PortVlanAssignmentList {
     StringBuilder sb = new StringBuilder();
     sb.append("class PortVlanAssignmentList {\n");
     sb.append("    vlanAssignments: ").append(toIndentedString(vlanAssignments)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class PortVlanAssignmentList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PortVlanAssignmentList is not found in the empty JSON string", PortVlanAssignmentList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!PortVlanAssignmentList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PortVlanAssignmentList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayvlanAssignments = jsonObj.getAsJsonArray("vlan_assignments");
       if (jsonArrayvlanAssignments != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class PortVlanAssignmentList {
            @Override
            public void write(JsonWriter out, PortVlanAssignmentList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class PortVlanAssignmentList {
            public PortVlanAssignmentList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             PortVlanAssignmentList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Project.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Project.java
@@ -114,7 +114,7 @@ public class Project {
   @SerializedName(SERIALIZED_NAME_VOLUMES)
   private List<Href> volumes = null;
 
-  public Project() { 
+  public Project() {
   }
 
   public Project bgpConfig(Href bgpConfig) {
@@ -509,6 +509,41 @@ public class Project {
     this.volumes = volumes;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Project putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -534,12 +569,13 @@ public class Project {
         Objects.equals(this.paymentMethod, project.paymentMethod) &&
         Objects.equals(this.sshKeys, project.sshKeys) &&
         Objects.equals(this.updatedAt, project.updatedAt) &&
-        Objects.equals(this.volumes, project.volumes);
+        Objects.equals(this.volumes, project.volumes)&&
+        Objects.equals(this.additionalProperties, project.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bgpConfig, createdAt, customdata, devices, id, invitations, maxDevices, members, memberships, name, networkStatus, paymentMethod, sshKeys, updatedAt, volumes);
+    return Objects.hash(bgpConfig, createdAt, customdata, devices, id, invitations, maxDevices, members, memberships, name, networkStatus, paymentMethod, sshKeys, updatedAt, volumes, additionalProperties);
   }
 
   @Override
@@ -561,6 +597,7 @@ public class Project {
     sb.append("    sshKeys: ").append(toIndentedString(sshKeys)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    volumes: ").append(toIndentedString(volumes)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -617,16 +654,8 @@ public class Project {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Project is not found in the empty JSON string", Project.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Project.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Project` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `bgp_config`
-      if (jsonObj.getAsJsonObject("bgp_config") != null) {
+      if (jsonObj.get("bgp_config") != null && !jsonObj.get("bgp_config").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("bgp_config"));
       }
       JsonArray jsonArraydevices = jsonObj.getAsJsonArray("devices");
@@ -641,7 +670,7 @@ public class Project {
           Href.validateJsonObject(jsonArraydevices.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       JsonArray jsonArrayinvitations = jsonObj.getAsJsonArray("invitations");
@@ -680,11 +709,11 @@ public class Project {
           Href.validateJsonObject(jsonArraymemberships.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       // validate the optional field `payment_method`
-      if (jsonObj.getAsJsonObject("payment_method") != null) {
+      if (jsonObj.get("payment_method") != null && !jsonObj.get("payment_method").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("payment_method"));
       }
       JsonArray jsonArraysshKeys = jsonObj.getAsJsonArray("ssh_keys");
@@ -728,6 +757,23 @@ public class Project {
            @Override
            public void write(JsonWriter out, Project value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -735,7 +781,25 @@ public class Project {
            public Project read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Project instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateFromRootInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateFromRootInput.java
@@ -66,7 +66,7 @@ public class ProjectCreateFromRootInput {
   @SerializedName(SERIALIZED_NAME_PAYMENT_METHOD_ID)
   private UUID paymentMethodId;
 
-  public ProjectCreateFromRootInput() { 
+  public ProjectCreateFromRootInput() {
   }
 
   public ProjectCreateFromRootInput customdata(Object customdata) {
@@ -160,6 +160,41 @@ public class ProjectCreateFromRootInput {
     this.paymentMethodId = paymentMethodId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ProjectCreateFromRootInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -174,12 +209,13 @@ public class ProjectCreateFromRootInput {
     return Objects.equals(this.customdata, projectCreateFromRootInput.customdata) &&
         Objects.equals(this.name, projectCreateFromRootInput.name) &&
         Objects.equals(this.organizationId, projectCreateFromRootInput.organizationId) &&
-        Objects.equals(this.paymentMethodId, projectCreateFromRootInput.paymentMethodId);
+        Objects.equals(this.paymentMethodId, projectCreateFromRootInput.paymentMethodId)&&
+        Objects.equals(this.additionalProperties, projectCreateFromRootInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(customdata, name, organizationId, paymentMethodId);
+    return Objects.hash(customdata, name, organizationId, paymentMethodId, additionalProperties);
   }
 
   @Override
@@ -190,6 +226,7 @@ public class ProjectCreateFromRootInput {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    organizationId: ").append(toIndentedString(organizationId)).append("\n");
     sb.append("    paymentMethodId: ").append(toIndentedString(paymentMethodId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -237,27 +274,19 @@ public class ProjectCreateFromRootInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ProjectCreateFromRootInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ProjectCreateFromRootInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ProjectCreateFromRootInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("organization_id") != null && !jsonObj.get("organization_id").isJsonPrimitive()) {
+      if ((jsonObj.get("organization_id") != null && !jsonObj.get("organization_id").isJsonNull()) && !jsonObj.get("organization_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `organization_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("organization_id").toString()));
       }
-      if (jsonObj.get("payment_method_id") != null && !jsonObj.get("payment_method_id").isJsonPrimitive()) {
+      if ((jsonObj.get("payment_method_id") != null && !jsonObj.get("payment_method_id").isJsonNull()) && !jsonObj.get("payment_method_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `payment_method_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("payment_method_id").toString()));
       }
   }
@@ -277,6 +306,23 @@ public class ProjectCreateFromRootInput {
            @Override
            public void write(JsonWriter out, ProjectCreateFromRootInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -284,7 +330,25 @@ public class ProjectCreateFromRootInput {
            public ProjectCreateFromRootInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ProjectCreateFromRootInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateInput.java
@@ -62,7 +62,7 @@ public class ProjectCreateInput {
   @SerializedName(SERIALIZED_NAME_PAYMENT_METHOD_ID)
   private UUID paymentMethodId;
 
-  public ProjectCreateInput() { 
+  public ProjectCreateInput() {
   }
 
   public ProjectCreateInput customdata(Object customdata) {
@@ -133,6 +133,41 @@ public class ProjectCreateInput {
     this.paymentMethodId = paymentMethodId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ProjectCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -146,12 +181,13 @@ public class ProjectCreateInput {
     ProjectCreateInput projectCreateInput = (ProjectCreateInput) o;
     return Objects.equals(this.customdata, projectCreateInput.customdata) &&
         Objects.equals(this.name, projectCreateInput.name) &&
-        Objects.equals(this.paymentMethodId, projectCreateInput.paymentMethodId);
+        Objects.equals(this.paymentMethodId, projectCreateInput.paymentMethodId)&&
+        Objects.equals(this.additionalProperties, projectCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(customdata, name, paymentMethodId);
+    return Objects.hash(customdata, name, paymentMethodId, additionalProperties);
   }
 
   @Override
@@ -161,6 +197,7 @@ public class ProjectCreateInput {
     sb.append("    customdata: ").append(toIndentedString(customdata)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    paymentMethodId: ").append(toIndentedString(paymentMethodId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -207,24 +244,16 @@ public class ProjectCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ProjectCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ProjectCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ProjectCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("payment_method_id") != null && !jsonObj.get("payment_method_id").isJsonPrimitive()) {
+      if ((jsonObj.get("payment_method_id") != null && !jsonObj.get("payment_method_id").isJsonNull()) && !jsonObj.get("payment_method_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `payment_method_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("payment_method_id").toString()));
       }
   }
@@ -244,6 +273,23 @@ public class ProjectCreateInput {
            @Override
            public void write(JsonWriter out, ProjectCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -251,7 +297,25 @@ public class ProjectCreateInput {
            public ProjectCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ProjectCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectList.java
@@ -61,7 +61,7 @@ public class ProjectList {
   @SerializedName(SERIALIZED_NAME_PROJECTS)
   private List<Project> projects = null;
 
-  public ProjectList() { 
+  public ProjectList() {
   }
 
   public ProjectList meta(Meta meta) {
@@ -117,6 +117,41 @@ public class ProjectList {
     this.projects = projects;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ProjectList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -129,12 +164,13 @@ public class ProjectList {
     }
     ProjectList projectList = (ProjectList) o;
     return Objects.equals(this.meta, projectList.meta) &&
-        Objects.equals(this.projects, projectList.projects);
+        Objects.equals(this.projects, projectList.projects)&&
+        Objects.equals(this.additionalProperties, projectList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(meta, projects);
+    return Objects.hash(meta, projects, additionalProperties);
   }
 
   @Override
@@ -143,6 +179,7 @@ public class ProjectList {
     sb.append("class ProjectList {\n");
     sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
     sb.append("    projects: ").append(toIndentedString(projects)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -186,16 +223,8 @@ public class ProjectList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in ProjectList is not found in the empty JSON string", ProjectList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ProjectList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ProjectList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `meta`
-      if (jsonObj.getAsJsonObject("meta") != null) {
+      if (jsonObj.get("meta") != null && !jsonObj.get("meta").isJsonNull()) {
         Meta.validateJsonObject(jsonObj.getAsJsonObject("meta"));
       }
       JsonArray jsonArrayprojects = jsonObj.getAsJsonArray("projects");
@@ -227,6 +256,23 @@ public class ProjectList {
            @Override
            public void write(JsonWriter out, ProjectList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -234,7 +280,25 @@ public class ProjectList {
            public ProjectList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ProjectList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectUpdateInput.java
@@ -66,7 +66,7 @@ public class ProjectUpdateInput {
   @SerializedName(SERIALIZED_NAME_PAYMENT_METHOD_ID)
   private UUID paymentMethodId;
 
-  public ProjectUpdateInput() { 
+  public ProjectUpdateInput() {
   }
 
   public ProjectUpdateInput backendTransferEnabled(Boolean backendTransferEnabled) {
@@ -160,6 +160,41 @@ public class ProjectUpdateInput {
     this.paymentMethodId = paymentMethodId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ProjectUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -174,12 +209,13 @@ public class ProjectUpdateInput {
     return Objects.equals(this.backendTransferEnabled, projectUpdateInput.backendTransferEnabled) &&
         Objects.equals(this.customdata, projectUpdateInput.customdata) &&
         Objects.equals(this.name, projectUpdateInput.name) &&
-        Objects.equals(this.paymentMethodId, projectUpdateInput.paymentMethodId);
+        Objects.equals(this.paymentMethodId, projectUpdateInput.paymentMethodId)&&
+        Objects.equals(this.additionalProperties, projectUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(backendTransferEnabled, customdata, name, paymentMethodId);
+    return Objects.hash(backendTransferEnabled, customdata, name, paymentMethodId, additionalProperties);
   }
 
   @Override
@@ -190,6 +226,7 @@ public class ProjectUpdateInput {
     sb.append("    customdata: ").append(toIndentedString(customdata)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    paymentMethodId: ").append(toIndentedString(paymentMethodId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -235,18 +272,10 @@ public class ProjectUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in ProjectUpdateInput is not found in the empty JSON string", ProjectUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ProjectUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ProjectUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("payment_method_id") != null && !jsonObj.get("payment_method_id").isJsonPrimitive()) {
+      if ((jsonObj.get("payment_method_id") != null && !jsonObj.get("payment_method_id").isJsonNull()) && !jsonObj.get("payment_method_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `payment_method_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("payment_method_id").toString()));
       }
   }
@@ -266,6 +295,23 @@ public class ProjectUpdateInput {
            @Override
            public void write(JsonWriter out, ProjectUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -273,7 +319,25 @@ public class ProjectUpdateInput {
            public ProjectUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ProjectUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectUsage.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectUsage.java
@@ -85,7 +85,7 @@ public class ProjectUsage {
   @SerializedName(SERIALIZED_NAME_UNIT)
   private String unit;
 
-  public ProjectUsage() { 
+  public ProjectUsage() {
   }
 
   public ProjectUsage facility(String facility) {
@@ -294,6 +294,41 @@ public class ProjectUsage {
     this.unit = unit;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ProjectUsage putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -313,12 +348,13 @@ public class ProjectUsage {
         Objects.equals(this.quantity, projectUsage.quantity) &&
         Objects.equals(this.total, projectUsage.total) &&
         Objects.equals(this.type, projectUsage.type) &&
-        Objects.equals(this.unit, projectUsage.unit);
+        Objects.equals(this.unit, projectUsage.unit)&&
+        Objects.equals(this.additionalProperties, projectUsage.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(facility, name, plan, planVersion, price, quantity, total, type, unit);
+    return Objects.hash(facility, name, plan, planVersion, price, quantity, total, type, unit, additionalProperties);
   }
 
   @Override
@@ -334,6 +370,7 @@ public class ProjectUsage {
     sb.append("    total: ").append(toIndentedString(total)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    unit: ").append(toIndentedString(unit)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -384,39 +421,31 @@ public class ProjectUsage {
           throw new IllegalArgumentException(String.format("The required field(s) %s in ProjectUsage is not found in the empty JSON string", ProjectUsage.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ProjectUsage.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ProjectUsage` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonPrimitive()) {
+      if ((jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) && !jsonObj.get("facility").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `facility` to be a primitive type in the JSON string but got `%s`", jsonObj.get("facility").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
-      if (jsonObj.get("plan_version") != null && !jsonObj.get("plan_version").isJsonPrimitive()) {
+      if ((jsonObj.get("plan_version") != null && !jsonObj.get("plan_version").isJsonNull()) && !jsonObj.get("plan_version").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan_version` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan_version").toString()));
       }
-      if (jsonObj.get("price") != null && !jsonObj.get("price").isJsonPrimitive()) {
+      if ((jsonObj.get("price") != null && !jsonObj.get("price").isJsonNull()) && !jsonObj.get("price").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `price` to be a primitive type in the JSON string but got `%s`", jsonObj.get("price").toString()));
       }
-      if (jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonPrimitive()) {
+      if ((jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonNull()) && !jsonObj.get("quantity").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `quantity` to be a primitive type in the JSON string but got `%s`", jsonObj.get("quantity").toString()));
       }
-      if (jsonObj.get("total") != null && !jsonObj.get("total").isJsonPrimitive()) {
+      if ((jsonObj.get("total") != null && !jsonObj.get("total").isJsonNull()) && !jsonObj.get("total").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `total` to be a primitive type in the JSON string but got `%s`", jsonObj.get("total").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
-      if (jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonPrimitive()) {
+      if ((jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonNull()) && !jsonObj.get("unit").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `unit` to be a primitive type in the JSON string but got `%s`", jsonObj.get("unit").toString()));
       }
   }
@@ -436,6 +465,23 @@ public class ProjectUsage {
            @Override
            public void write(JsonWriter out, ProjectUsage value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -443,7 +489,25 @@ public class ProjectUsage {
            public ProjectUsage read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ProjectUsage instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectUsageList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectUsageList.java
@@ -56,7 +56,7 @@ public class ProjectUsageList {
   @SerializedName(SERIALIZED_NAME_USAGES)
   private List<ProjectUsage> usages = null;
 
-  public ProjectUsageList() { 
+  public ProjectUsageList() {
   }
 
   public ProjectUsageList usages(List<ProjectUsage> usages) {
@@ -89,6 +89,41 @@ public class ProjectUsageList {
     this.usages = usages;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ProjectUsageList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class ProjectUsageList {
       return false;
     }
     ProjectUsageList projectUsageList = (ProjectUsageList) o;
-    return Objects.equals(this.usages, projectUsageList.usages);
+    return Objects.equals(this.usages, projectUsageList.usages)&&
+        Objects.equals(this.additionalProperties, projectUsageList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(usages);
+    return Objects.hash(usages, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class ProjectUsageList {
     StringBuilder sb = new StringBuilder();
     sb.append("class ProjectUsageList {\n");
     sb.append("    usages: ").append(toIndentedString(usages)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class ProjectUsageList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in ProjectUsageList is not found in the empty JSON string", ProjectUsageList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ProjectUsageList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ProjectUsageList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayusages = jsonObj.getAsJsonArray("usages");
       if (jsonArrayusages != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class ProjectUsageList {
            @Override
            public void write(JsonWriter out, ProjectUsageList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class ProjectUsageList {
            public ProjectUsageList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ProjectUsageList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/RecoveryCodeList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/RecoveryCodeList.java
@@ -55,7 +55,7 @@ public class RecoveryCodeList {
   @SerializedName(SERIALIZED_NAME_RECOVERY_CODES)
   private List<String> recoveryCodes = null;
 
-  public RecoveryCodeList() { 
+  public RecoveryCodeList() {
   }
 
   public RecoveryCodeList recoveryCodes(List<String> recoveryCodes) {
@@ -88,6 +88,41 @@ public class RecoveryCodeList {
     this.recoveryCodes = recoveryCodes;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public RecoveryCodeList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -99,12 +134,13 @@ public class RecoveryCodeList {
       return false;
     }
     RecoveryCodeList recoveryCodeList = (RecoveryCodeList) o;
-    return Objects.equals(this.recoveryCodes, recoveryCodeList.recoveryCodes);
+    return Objects.equals(this.recoveryCodes, recoveryCodeList.recoveryCodes)&&
+        Objects.equals(this.additionalProperties, recoveryCodeList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(recoveryCodes);
+    return Objects.hash(recoveryCodes, additionalProperties);
   }
 
   @Override
@@ -112,6 +148,7 @@ public class RecoveryCodeList {
     StringBuilder sb = new StringBuilder();
     sb.append("class RecoveryCodeList {\n");
     sb.append("    recoveryCodes: ").append(toIndentedString(recoveryCodes)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -154,16 +191,8 @@ public class RecoveryCodeList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in RecoveryCodeList is not found in the empty JSON string", RecoveryCodeList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!RecoveryCodeList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `RecoveryCodeList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("recovery_codes") != null && !jsonObj.get("recovery_codes").isJsonArray()) {
+      if ((jsonObj.get("recovery_codes") != null && !jsonObj.get("recovery_codes").isJsonNull()) && !jsonObj.get("recovery_codes").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `recovery_codes` to be an array in the JSON string but got `%s`", jsonObj.get("recovery_codes").toString()));
       }
   }
@@ -183,6 +212,23 @@ public class RecoveryCodeList {
            @Override
            public void write(JsonWriter out, RecoveryCodeList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -190,7 +236,25 @@ public class RecoveryCodeList {
            public RecoveryCodeList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             RecoveryCodeList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKey.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKey.java
@@ -84,7 +84,7 @@ public class SSHKey {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public SSHKey() { 
+  public SSHKey() {
   }
 
   public SSHKey createdAt(OffsetDateTime createdAt) {
@@ -270,6 +270,41 @@ public class SSHKey {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SSHKey putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -288,12 +323,13 @@ public class SSHKey {
         Objects.equals(this.id, ssHKey.id) &&
         Objects.equals(this.key, ssHKey.key) &&
         Objects.equals(this.label, ssHKey.label) &&
-        Objects.equals(this.updatedAt, ssHKey.updatedAt);
+        Objects.equals(this.updatedAt, ssHKey.updatedAt)&&
+        Objects.equals(this.additionalProperties, ssHKey.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, entity, fingerprint, href, id, key, label, updatedAt);
+    return Objects.hash(createdAt, entity, fingerprint, href, id, key, label, updatedAt, additionalProperties);
   }
 
   @Override
@@ -308,6 +344,7 @@ public class SSHKey {
     sb.append("    key: ").append(toIndentedString(key)).append("\n");
     sb.append("    label: ").append(toIndentedString(label)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -357,31 +394,23 @@ public class SSHKey {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SSHKey is not found in the empty JSON string", SSHKey.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SSHKey.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SSHKey` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `entity`
-      if (jsonObj.getAsJsonObject("entity") != null) {
+      if (jsonObj.get("entity") != null && !jsonObj.get("entity").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("entity"));
       }
-      if (jsonObj.get("fingerprint") != null && !jsonObj.get("fingerprint").isJsonPrimitive()) {
+      if ((jsonObj.get("fingerprint") != null && !jsonObj.get("fingerprint").isJsonNull()) && !jsonObj.get("fingerprint").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `fingerprint` to be a primitive type in the JSON string but got `%s`", jsonObj.get("fingerprint").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("key") != null && !jsonObj.get("key").isJsonPrimitive()) {
+      if ((jsonObj.get("key") != null && !jsonObj.get("key").isJsonNull()) && !jsonObj.get("key").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `key` to be a primitive type in the JSON string but got `%s`", jsonObj.get("key").toString()));
       }
-      if (jsonObj.get("label") != null && !jsonObj.get("label").isJsonPrimitive()) {
+      if ((jsonObj.get("label") != null && !jsonObj.get("label").isJsonNull()) && !jsonObj.get("label").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `label` to be a primitive type in the JSON string but got `%s`", jsonObj.get("label").toString()));
       }
   }
@@ -401,6 +430,23 @@ public class SSHKey {
            @Override
            public void write(JsonWriter out, SSHKey value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -408,7 +454,25 @@ public class SSHKey {
            public SSHKey read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SSHKey instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKeyCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKeyCreateInput.java
@@ -64,7 +64,7 @@ public class SSHKeyCreateInput {
   @SerializedName(SERIALIZED_NAME_LABEL)
   private String label;
 
-  public SSHKeyCreateInput() { 
+  public SSHKeyCreateInput() {
   }
 
   public SSHKeyCreateInput instancesIds(List<UUID> instancesIds) {
@@ -143,6 +143,41 @@ public class SSHKeyCreateInput {
     this.label = label;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SSHKeyCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -156,12 +191,13 @@ public class SSHKeyCreateInput {
     SSHKeyCreateInput ssHKeyCreateInput = (SSHKeyCreateInput) o;
     return Objects.equals(this.instancesIds, ssHKeyCreateInput.instancesIds) &&
         Objects.equals(this.key, ssHKeyCreateInput.key) &&
-        Objects.equals(this.label, ssHKeyCreateInput.label);
+        Objects.equals(this.label, ssHKeyCreateInput.label)&&
+        Objects.equals(this.additionalProperties, ssHKeyCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(instancesIds, key, label);
+    return Objects.hash(instancesIds, key, label, additionalProperties);
   }
 
   @Override
@@ -171,6 +207,7 @@ public class SSHKeyCreateInput {
     sb.append("    instancesIds: ").append(toIndentedString(instancesIds)).append("\n");
     sb.append("    key: ").append(toIndentedString(key)).append("\n");
     sb.append("    label: ").append(toIndentedString(label)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -215,22 +252,14 @@ public class SSHKeyCreateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SSHKeyCreateInput is not found in the empty JSON string", SSHKeyCreateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SSHKeyCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SSHKeyCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("instances_ids") != null && !jsonObj.get("instances_ids").isJsonArray()) {
+      if ((jsonObj.get("instances_ids") != null && !jsonObj.get("instances_ids").isJsonNull()) && !jsonObj.get("instances_ids").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `instances_ids` to be an array in the JSON string but got `%s`", jsonObj.get("instances_ids").toString()));
       }
-      if (jsonObj.get("key") != null && !jsonObj.get("key").isJsonPrimitive()) {
+      if ((jsonObj.get("key") != null && !jsonObj.get("key").isJsonNull()) && !jsonObj.get("key").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `key` to be a primitive type in the JSON string but got `%s`", jsonObj.get("key").toString()));
       }
-      if (jsonObj.get("label") != null && !jsonObj.get("label").isJsonPrimitive()) {
+      if ((jsonObj.get("label") != null && !jsonObj.get("label").isJsonNull()) && !jsonObj.get("label").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `label` to be a primitive type in the JSON string but got `%s`", jsonObj.get("label").toString()));
       }
   }
@@ -250,6 +279,23 @@ public class SSHKeyCreateInput {
            @Override
            public void write(JsonWriter out, SSHKeyCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -257,7 +303,25 @@ public class SSHKeyCreateInput {
            public SSHKeyCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SSHKeyCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKeyInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKeyInput.java
@@ -57,7 +57,7 @@ public class SSHKeyInput {
   @SerializedName(SERIALIZED_NAME_LABEL)
   private String label;
 
-  public SSHKeyInput() { 
+  public SSHKeyInput() {
   }
 
   public SSHKeyInput key(String key) {
@@ -105,6 +105,41 @@ public class SSHKeyInput {
     this.label = label;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SSHKeyInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -117,12 +152,13 @@ public class SSHKeyInput {
     }
     SSHKeyInput ssHKeyInput = (SSHKeyInput) o;
     return Objects.equals(this.key, ssHKeyInput.key) &&
-        Objects.equals(this.label, ssHKeyInput.label);
+        Objects.equals(this.label, ssHKeyInput.label)&&
+        Objects.equals(this.additionalProperties, ssHKeyInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(key, label);
+    return Objects.hash(key, label, additionalProperties);
   }
 
   @Override
@@ -131,6 +167,7 @@ public class SSHKeyInput {
     sb.append("class SSHKeyInput {\n");
     sb.append("    key: ").append(toIndentedString(key)).append("\n");
     sb.append("    label: ").append(toIndentedString(label)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -174,18 +211,10 @@ public class SSHKeyInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SSHKeyInput is not found in the empty JSON string", SSHKeyInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SSHKeyInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SSHKeyInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("key") != null && !jsonObj.get("key").isJsonPrimitive()) {
+      if ((jsonObj.get("key") != null && !jsonObj.get("key").isJsonNull()) && !jsonObj.get("key").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `key` to be a primitive type in the JSON string but got `%s`", jsonObj.get("key").toString()));
       }
-      if (jsonObj.get("label") != null && !jsonObj.get("label").isJsonPrimitive()) {
+      if ((jsonObj.get("label") != null && !jsonObj.get("label").isJsonNull()) && !jsonObj.get("label").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `label` to be a primitive type in the JSON string but got `%s`", jsonObj.get("label").toString()));
       }
   }
@@ -205,6 +234,23 @@ public class SSHKeyInput {
            @Override
            public void write(JsonWriter out, SSHKeyInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -212,7 +258,25 @@ public class SSHKeyInput {
            public SSHKeyInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SSHKeyInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKeyList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SSHKeyList.java
@@ -56,7 +56,7 @@ public class SSHKeyList {
   @SerializedName(SERIALIZED_NAME_SSH_KEYS)
   private List<SSHKey> sshKeys = null;
 
-  public SSHKeyList() { 
+  public SSHKeyList() {
   }
 
   public SSHKeyList sshKeys(List<SSHKey> sshKeys) {
@@ -89,6 +89,41 @@ public class SSHKeyList {
     this.sshKeys = sshKeys;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SSHKeyList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class SSHKeyList {
       return false;
     }
     SSHKeyList ssHKeyList = (SSHKeyList) o;
-    return Objects.equals(this.sshKeys, ssHKeyList.sshKeys);
+    return Objects.equals(this.sshKeys, ssHKeyList.sshKeys)&&
+        Objects.equals(this.additionalProperties, ssHKeyList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sshKeys);
+    return Objects.hash(sshKeys, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class SSHKeyList {
     StringBuilder sb = new StringBuilder();
     sb.append("class SSHKeyList {\n");
     sb.append("    sshKeys: ").append(toIndentedString(sshKeys)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class SSHKeyList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SSHKeyList is not found in the empty JSON string", SSHKeyList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SSHKeyList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SSHKeyList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraysshKeys = jsonObj.getAsJsonArray("ssh_keys");
       if (jsonArraysshKeys != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class SSHKeyList {
            @Override
            public void write(JsonWriter out, SSHKeyList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class SSHKeyList {
            public SSHKeyList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SSHKeyList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationItemRequest.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationItemRequest.java
@@ -70,7 +70,7 @@ public class SelfServiceReservationItemRequest {
   @SerializedName(SERIALIZED_NAME_TERM)
   private String term;
 
-  public SelfServiceReservationItemRequest() { 
+  public SelfServiceReservationItemRequest() {
   }
 
   public SelfServiceReservationItemRequest amount(Float amount) {
@@ -187,6 +187,41 @@ public class SelfServiceReservationItemRequest {
     this.term = term;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SelfServiceReservationItemRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -202,12 +237,13 @@ public class SelfServiceReservationItemRequest {
         Objects.equals(this.metroId, selfServiceReservationItemRequest.metroId) &&
         Objects.equals(this.planId, selfServiceReservationItemRequest.planId) &&
         Objects.equals(this.quantity, selfServiceReservationItemRequest.quantity) &&
-        Objects.equals(this.term, selfServiceReservationItemRequest.term);
+        Objects.equals(this.term, selfServiceReservationItemRequest.term)&&
+        Objects.equals(this.additionalProperties, selfServiceReservationItemRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(amount, metroId, planId, quantity, term);
+    return Objects.hash(amount, metroId, planId, quantity, term, additionalProperties);
   }
 
   @Override
@@ -219,6 +255,7 @@ public class SelfServiceReservationItemRequest {
     sb.append("    planId: ").append(toIndentedString(planId)).append("\n");
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
     sb.append("    term: ").append(toIndentedString(term)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -265,21 +302,13 @@ public class SelfServiceReservationItemRequest {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SelfServiceReservationItemRequest is not found in the empty JSON string", SelfServiceReservationItemRequest.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SelfServiceReservationItemRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SelfServiceReservationItemRequest` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("metro_id") != null && !jsonObj.get("metro_id").isJsonPrimitive()) {
+      if ((jsonObj.get("metro_id") != null && !jsonObj.get("metro_id").isJsonNull()) && !jsonObj.get("metro_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro_id").toString()));
       }
-      if (jsonObj.get("plan_id") != null && !jsonObj.get("plan_id").isJsonPrimitive()) {
+      if ((jsonObj.get("plan_id") != null && !jsonObj.get("plan_id").isJsonNull()) && !jsonObj.get("plan_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan_id").toString()));
       }
-      if (jsonObj.get("term") != null && !jsonObj.get("term").isJsonPrimitive()) {
+      if ((jsonObj.get("term") != null && !jsonObj.get("term").isJsonNull()) && !jsonObj.get("term").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `term` to be a primitive type in the JSON string but got `%s`", jsonObj.get("term").toString()));
       }
   }
@@ -299,6 +328,23 @@ public class SelfServiceReservationItemRequest {
            @Override
            public void write(JsonWriter out, SelfServiceReservationItemRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -306,7 +352,25 @@ public class SelfServiceReservationItemRequest {
            public SelfServiceReservationItemRequest read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SelfServiceReservationItemRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationItemResponse.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationItemResponse.java
@@ -90,7 +90,7 @@ public class SelfServiceReservationItemResponse {
   @SerializedName(SERIALIZED_NAME_TERM)
   private String term;
 
-  public SelfServiceReservationItemResponse() { 
+  public SelfServiceReservationItemResponse() {
   }
 
   public SelfServiceReservationItemResponse amount(Float amount) {
@@ -322,6 +322,41 @@ public class SelfServiceReservationItemResponse {
     this.term = term;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SelfServiceReservationItemResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -342,12 +377,13 @@ public class SelfServiceReservationItemResponse {
         Objects.equals(this.planName, selfServiceReservationItemResponse.planName) &&
         Objects.equals(this.planSlug, selfServiceReservationItemResponse.planSlug) &&
         Objects.equals(this.quantity, selfServiceReservationItemResponse.quantity) &&
-        Objects.equals(this.term, selfServiceReservationItemResponse.term);
+        Objects.equals(this.term, selfServiceReservationItemResponse.term)&&
+        Objects.equals(this.additionalProperties, selfServiceReservationItemResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(amount, id, metroCode, metroId, metroName, planId, planName, planSlug, quantity, term);
+    return Objects.hash(amount, id, metroCode, metroId, metroName, planId, planName, planSlug, quantity, term, additionalProperties);
   }
 
   @Override
@@ -364,6 +400,7 @@ public class SelfServiceReservationItemResponse {
     sb.append("    planSlug: ").append(toIndentedString(planSlug)).append("\n");
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
     sb.append("    term: ").append(toIndentedString(term)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -415,36 +452,28 @@ public class SelfServiceReservationItemResponse {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SelfServiceReservationItemResponse is not found in the empty JSON string", SelfServiceReservationItemResponse.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SelfServiceReservationItemResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SelfServiceReservationItemResponse` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("metro_code") != null && !jsonObj.get("metro_code").isJsonPrimitive()) {
+      if ((jsonObj.get("metro_code") != null && !jsonObj.get("metro_code").isJsonNull()) && !jsonObj.get("metro_code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro_code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro_code").toString()));
       }
-      if (jsonObj.get("metro_id") != null && !jsonObj.get("metro_id").isJsonPrimitive()) {
+      if ((jsonObj.get("metro_id") != null && !jsonObj.get("metro_id").isJsonNull()) && !jsonObj.get("metro_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro_id").toString()));
       }
-      if (jsonObj.get("metro_name") != null && !jsonObj.get("metro_name").isJsonPrimitive()) {
+      if ((jsonObj.get("metro_name") != null && !jsonObj.get("metro_name").isJsonNull()) && !jsonObj.get("metro_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro_name").toString()));
       }
-      if (jsonObj.get("plan_id") != null && !jsonObj.get("plan_id").isJsonPrimitive()) {
+      if ((jsonObj.get("plan_id") != null && !jsonObj.get("plan_id").isJsonNull()) && !jsonObj.get("plan_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan_id").toString()));
       }
-      if (jsonObj.get("plan_name") != null && !jsonObj.get("plan_name").isJsonPrimitive()) {
+      if ((jsonObj.get("plan_name") != null && !jsonObj.get("plan_name").isJsonNull()) && !jsonObj.get("plan_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan_name").toString()));
       }
-      if (jsonObj.get("plan_slug") != null && !jsonObj.get("plan_slug").isJsonPrimitive()) {
+      if ((jsonObj.get("plan_slug") != null && !jsonObj.get("plan_slug").isJsonNull()) && !jsonObj.get("plan_slug").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan_slug` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan_slug").toString()));
       }
-      if (jsonObj.get("term") != null && !jsonObj.get("term").isJsonPrimitive()) {
+      if ((jsonObj.get("term") != null && !jsonObj.get("term").isJsonNull()) && !jsonObj.get("term").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `term` to be a primitive type in the JSON string but got `%s`", jsonObj.get("term").toString()));
       }
   }
@@ -464,6 +493,23 @@ public class SelfServiceReservationItemResponse {
            @Override
            public void write(JsonWriter out, SelfServiceReservationItemResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -471,7 +517,25 @@ public class SelfServiceReservationItemResponse {
            public SelfServiceReservationItemResponse read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SelfServiceReservationItemResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationList.java
@@ -56,7 +56,7 @@ public class SelfServiceReservationList {
   @SerializedName(SERIALIZED_NAME_RESERVATIONS)
   private List<SelfServiceReservationResponse> reservations = null;
 
-  public SelfServiceReservationList() { 
+  public SelfServiceReservationList() {
   }
 
   public SelfServiceReservationList reservations(List<SelfServiceReservationResponse> reservations) {
@@ -89,6 +89,41 @@ public class SelfServiceReservationList {
     this.reservations = reservations;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SelfServiceReservationList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class SelfServiceReservationList {
       return false;
     }
     SelfServiceReservationList selfServiceReservationList = (SelfServiceReservationList) o;
-    return Objects.equals(this.reservations, selfServiceReservationList.reservations);
+    return Objects.equals(this.reservations, selfServiceReservationList.reservations)&&
+        Objects.equals(this.additionalProperties, selfServiceReservationList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(reservations);
+    return Objects.hash(reservations, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class SelfServiceReservationList {
     StringBuilder sb = new StringBuilder();
     sb.append("class SelfServiceReservationList {\n");
     sb.append("    reservations: ").append(toIndentedString(reservations)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class SelfServiceReservationList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SelfServiceReservationList is not found in the empty JSON string", SelfServiceReservationList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SelfServiceReservationList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SelfServiceReservationList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayreservations = jsonObj.getAsJsonArray("reservations");
       if (jsonArrayreservations != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class SelfServiceReservationList {
            @Override
            public void write(JsonWriter out, SelfServiceReservationList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class SelfServiceReservationList {
            public SelfServiceReservationList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SelfServiceReservationList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationResponse.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SelfServiceReservationResponse.java
@@ -99,7 +99,7 @@ public class SelfServiceReservationResponse {
   @SerializedName(SERIALIZED_NAME_TOTAL_COST)
   private Integer totalCost;
 
-  public SelfServiceReservationResponse() { 
+  public SelfServiceReservationResponse() {
   }
 
   public SelfServiceReservationResponse createdAt(OffsetDateTime createdAt) {
@@ -362,6 +362,41 @@ public class SelfServiceReservationResponse {
     this.totalCost = totalCost;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SelfServiceReservationResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -383,12 +418,13 @@ public class SelfServiceReservationResponse {
         Objects.equals(this.projectId, selfServiceReservationResponse.projectId) &&
         Objects.equals(this.startDate, selfServiceReservationResponse.startDate) &&
         Objects.equals(this.status, selfServiceReservationResponse.status) &&
-        Objects.equals(this.totalCost, selfServiceReservationResponse.totalCost);
+        Objects.equals(this.totalCost, selfServiceReservationResponse.totalCost)&&
+        Objects.equals(this.additionalProperties, selfServiceReservationResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, item, notes, organization, organizationId, period, project, projectId, startDate, status, totalCost);
+    return Objects.hash(createdAt, item, notes, organization, organizationId, period, project, projectId, startDate, status, totalCost, additionalProperties);
   }
 
   @Override
@@ -406,6 +442,7 @@ public class SelfServiceReservationResponse {
     sb.append("    startDate: ").append(toIndentedString(startDate)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    totalCost: ").append(toIndentedString(totalCost)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -458,14 +495,6 @@ public class SelfServiceReservationResponse {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SelfServiceReservationResponse is not found in the empty JSON string", SelfServiceReservationResponse.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SelfServiceReservationResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SelfServiceReservationResponse` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayitem = jsonObj.getAsJsonArray("item");
       if (jsonArrayitem != null) {
         // ensure the json data is an array
@@ -478,26 +507,26 @@ public class SelfServiceReservationResponse {
           SelfServiceReservationItemResponse.validateJsonObject(jsonArrayitem.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("notes") != null && !jsonObj.get("notes").isJsonPrimitive()) {
+      if ((jsonObj.get("notes") != null && !jsonObj.get("notes").isJsonNull()) && !jsonObj.get("notes").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `notes` to be a primitive type in the JSON string but got `%s`", jsonObj.get("notes").toString()));
       }
-      if (jsonObj.get("organization") != null && !jsonObj.get("organization").isJsonPrimitive()) {
+      if ((jsonObj.get("organization") != null && !jsonObj.get("organization").isJsonNull()) && !jsonObj.get("organization").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `organization` to be a primitive type in the JSON string but got `%s`", jsonObj.get("organization").toString()));
       }
-      if (jsonObj.get("organization_id") != null && !jsonObj.get("organization_id").isJsonPrimitive()) {
+      if ((jsonObj.get("organization_id") != null && !jsonObj.get("organization_id").isJsonNull()) && !jsonObj.get("organization_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `organization_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("organization_id").toString()));
       }
       // validate the optional field `period`
-      if (jsonObj.getAsJsonObject("period") != null) {
+      if (jsonObj.get("period") != null && !jsonObj.get("period").isJsonNull()) {
         CreateSelfServiceReservationRequestPeriod.validateJsonObject(jsonObj.getAsJsonObject("period"));
       }
-      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonPrimitive()) {
+      if ((jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) && !jsonObj.get("project").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project").toString()));
       }
-      if (jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonPrimitive()) {
+      if ((jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonNull()) && !jsonObj.get("project_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project_id").toString()));
       }
-      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonPrimitive()) {
+      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
   }
@@ -517,6 +546,23 @@ public class SelfServiceReservationResponse {
            @Override
            public void write(JsonWriter out, SelfServiceReservationResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -524,7 +570,25 @@ public class SelfServiceReservationResponse {
            public SelfServiceReservationResponse read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SelfServiceReservationResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ServerInfo.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ServerInfo.java
@@ -61,7 +61,7 @@ public class ServerInfo {
   @SerializedName(SERIALIZED_NAME_QUANTITY)
   private String quantity;
 
-  public ServerInfo() { 
+  public ServerInfo() {
   }
 
   public ServerInfo facility(String facility) {
@@ -132,6 +132,41 @@ public class ServerInfo {
     this.quantity = quantity;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public ServerInfo putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -145,12 +180,13 @@ public class ServerInfo {
     ServerInfo serverInfo = (ServerInfo) o;
     return Objects.equals(this.facility, serverInfo.facility) &&
         Objects.equals(this.plan, serverInfo.plan) &&
-        Objects.equals(this.quantity, serverInfo.quantity);
+        Objects.equals(this.quantity, serverInfo.quantity)&&
+        Objects.equals(this.additionalProperties, serverInfo.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(facility, plan, quantity);
+    return Objects.hash(facility, plan, quantity, additionalProperties);
   }
 
   @Override
@@ -160,6 +196,7 @@ public class ServerInfo {
     sb.append("    facility: ").append(toIndentedString(facility)).append("\n");
     sb.append("    plan: ").append(toIndentedString(plan)).append("\n");
     sb.append("    quantity: ").append(toIndentedString(quantity)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -204,21 +241,13 @@ public class ServerInfo {
           throw new IllegalArgumentException(String.format("The required field(s) %s in ServerInfo is not found in the empty JSON string", ServerInfo.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!ServerInfo.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ServerInfo` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonPrimitive()) {
+      if ((jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) && !jsonObj.get("facility").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `facility` to be a primitive type in the JSON string but got `%s`", jsonObj.get("facility").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
-      if (jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonPrimitive()) {
+      if ((jsonObj.get("quantity") != null && !jsonObj.get("quantity").isJsonNull()) && !jsonObj.get("quantity").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `quantity` to be a primitive type in the JSON string but got `%s`", jsonObj.get("quantity").toString()));
       }
   }
@@ -238,6 +267,23 @@ public class ServerInfo {
            @Override
            public void write(JsonWriter out, ServerInfo value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -245,7 +291,25 @@ public class ServerInfo {
            public ServerInfo read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             ServerInfo instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketPricesList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketPricesList.java
@@ -54,7 +54,7 @@ public class SpotMarketPricesList {
   @SerializedName(SERIALIZED_NAME_SPOT_MARKET_PRICES)
   private SpotPricesReport spotMarketPrices;
 
-  public SpotMarketPricesList() { 
+  public SpotMarketPricesList() {
   }
 
   public SpotMarketPricesList spotMarketPrices(SpotPricesReport spotMarketPrices) {
@@ -79,6 +79,41 @@ public class SpotMarketPricesList {
     this.spotMarketPrices = spotMarketPrices;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketPricesList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class SpotMarketPricesList {
       return false;
     }
     SpotMarketPricesList spotMarketPricesList = (SpotMarketPricesList) o;
-    return Objects.equals(this.spotMarketPrices, spotMarketPricesList.spotMarketPrices);
+    return Objects.equals(this.spotMarketPrices, spotMarketPricesList.spotMarketPrices)&&
+        Objects.equals(this.additionalProperties, spotMarketPricesList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(spotMarketPrices);
+    return Objects.hash(spotMarketPrices, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class SpotMarketPricesList {
     StringBuilder sb = new StringBuilder();
     sb.append("class SpotMarketPricesList {\n");
     sb.append("    spotMarketPrices: ").append(toIndentedString(spotMarketPrices)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,16 +182,8 @@ public class SpotMarketPricesList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketPricesList is not found in the empty JSON string", SpotMarketPricesList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketPricesList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketPricesList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `spot_market_prices`
-      if (jsonObj.getAsJsonObject("spot_market_prices") != null) {
+      if (jsonObj.get("spot_market_prices") != null && !jsonObj.get("spot_market_prices").isJsonNull()) {
         SpotPricesReport.validateJsonObject(jsonObj.getAsJsonObject("spot_market_prices"));
       }
   }
@@ -174,6 +203,23 @@ public class SpotMarketPricesList {
            @Override
            public void write(JsonWriter out, SpotMarketPricesList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -181,7 +227,25 @@ public class SpotMarketPricesList {
            public SpotMarketPricesList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketPricesList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketPricesPerMetroList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketPricesPerMetroList.java
@@ -54,7 +54,7 @@ public class SpotMarketPricesPerMetroList {
   @SerializedName(SERIALIZED_NAME_SPOT_MARKET_PRICES)
   private SpotMarketPricesPerMetroReport spotMarketPrices;
 
-  public SpotMarketPricesPerMetroList() { 
+  public SpotMarketPricesPerMetroList() {
   }
 
   public SpotMarketPricesPerMetroList spotMarketPrices(SpotMarketPricesPerMetroReport spotMarketPrices) {
@@ -79,6 +79,41 @@ public class SpotMarketPricesPerMetroList {
     this.spotMarketPrices = spotMarketPrices;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketPricesPerMetroList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class SpotMarketPricesPerMetroList {
       return false;
     }
     SpotMarketPricesPerMetroList spotMarketPricesPerMetroList = (SpotMarketPricesPerMetroList) o;
-    return Objects.equals(this.spotMarketPrices, spotMarketPricesPerMetroList.spotMarketPrices);
+    return Objects.equals(this.spotMarketPrices, spotMarketPricesPerMetroList.spotMarketPrices)&&
+        Objects.equals(this.additionalProperties, spotMarketPricesPerMetroList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(spotMarketPrices);
+    return Objects.hash(spotMarketPrices, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class SpotMarketPricesPerMetroList {
     StringBuilder sb = new StringBuilder();
     sb.append("class SpotMarketPricesPerMetroList {\n");
     sb.append("    spotMarketPrices: ").append(toIndentedString(spotMarketPrices)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,16 +182,8 @@ public class SpotMarketPricesPerMetroList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketPricesPerMetroList is not found in the empty JSON string", SpotMarketPricesPerMetroList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketPricesPerMetroList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketPricesPerMetroList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `spot_market_prices`
-      if (jsonObj.getAsJsonObject("spot_market_prices") != null) {
+      if (jsonObj.get("spot_market_prices") != null && !jsonObj.get("spot_market_prices").isJsonNull()) {
         SpotMarketPricesPerMetroReport.validateJsonObject(jsonObj.getAsJsonObject("spot_market_prices"));
       }
   }
@@ -174,6 +203,23 @@ public class SpotMarketPricesPerMetroList {
            @Override
            public void write(JsonWriter out, SpotMarketPricesPerMetroList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -181,7 +227,25 @@ public class SpotMarketPricesPerMetroList {
            public SpotMarketPricesPerMetroList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketPricesPerMetroList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketPricesPerMetroReport.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketPricesPerMetroReport.java
@@ -78,7 +78,7 @@ public class SpotMarketPricesPerMetroReport {
   @SerializedName(SERIALIZED_NAME_SV)
   private SpotPricesPerFacility sv;
 
-  public SpotMarketPricesPerMetroReport() { 
+  public SpotMarketPricesPerMetroReport() {
   }
 
   public SpotMarketPricesPerMetroReport am(SpotPricesPerFacility am) {
@@ -241,6 +241,41 @@ public class SpotMarketPricesPerMetroReport {
     this.sv = sv;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketPricesPerMetroReport putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -258,12 +293,13 @@ public class SpotMarketPricesPerMetroReport {
         Objects.equals(this.la, spotMarketPricesPerMetroReport.la) &&
         Objects.equals(this.ny, spotMarketPricesPerMetroReport.ny) &&
         Objects.equals(this.sg, spotMarketPricesPerMetroReport.sg) &&
-        Objects.equals(this.sv, spotMarketPricesPerMetroReport.sv);
+        Objects.equals(this.sv, spotMarketPricesPerMetroReport.sv)&&
+        Objects.equals(this.additionalProperties, spotMarketPricesPerMetroReport.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(am, ch, da, la, ny, sg, sv);
+    return Objects.hash(am, ch, da, la, ny, sg, sv, additionalProperties);
   }
 
   @Override
@@ -277,6 +313,7 @@ public class SpotMarketPricesPerMetroReport {
     sb.append("    ny: ").append(toIndentedString(ny)).append("\n");
     sb.append("    sg: ").append(toIndentedString(sg)).append("\n");
     sb.append("    sv: ").append(toIndentedString(sv)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -325,40 +362,32 @@ public class SpotMarketPricesPerMetroReport {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketPricesPerMetroReport is not found in the empty JSON string", SpotMarketPricesPerMetroReport.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketPricesPerMetroReport.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketPricesPerMetroReport` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `am`
-      if (jsonObj.getAsJsonObject("am") != null) {
+      if (jsonObj.get("am") != null && !jsonObj.get("am").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("am"));
       }
       // validate the optional field `ch`
-      if (jsonObj.getAsJsonObject("ch") != null) {
+      if (jsonObj.get("ch") != null && !jsonObj.get("ch").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ch"));
       }
       // validate the optional field `da`
-      if (jsonObj.getAsJsonObject("da") != null) {
+      if (jsonObj.get("da") != null && !jsonObj.get("da").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("da"));
       }
       // validate the optional field `la`
-      if (jsonObj.getAsJsonObject("la") != null) {
+      if (jsonObj.get("la") != null && !jsonObj.get("la").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("la"));
       }
       // validate the optional field `ny`
-      if (jsonObj.getAsJsonObject("ny") != null) {
+      if (jsonObj.get("ny") != null && !jsonObj.get("ny").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ny"));
       }
       // validate the optional field `sg`
-      if (jsonObj.getAsJsonObject("sg") != null) {
+      if (jsonObj.get("sg") != null && !jsonObj.get("sg").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sg"));
       }
       // validate the optional field `sv`
-      if (jsonObj.getAsJsonObject("sv") != null) {
+      if (jsonObj.get("sv") != null && !jsonObj.get("sv").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sv"));
       }
   }
@@ -378,6 +407,23 @@ public class SpotMarketPricesPerMetroReport {
            @Override
            public void write(JsonWriter out, SpotMarketPricesPerMetroReport value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -385,7 +431,25 @@ public class SpotMarketPricesPerMetroReport {
            public SpotMarketPricesPerMetroReport read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketPricesPerMetroReport instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequest.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequest.java
@@ -97,7 +97,7 @@ public class SpotMarketRequest {
   @SerializedName(SERIALIZED_NAME_PROJECT)
   private Href project;
 
-  public SpotMarketRequest() { 
+  public SpotMarketRequest() {
   }
 
   public SpotMarketRequest createdAt(OffsetDateTime createdAt) {
@@ -352,6 +352,41 @@ public class SpotMarketRequest {
     this.project = project;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -373,12 +408,13 @@ public class SpotMarketRequest {
         Objects.equals(this.instances, spotMarketRequest.instances) &&
         Objects.equals(this.maxBidPrice, spotMarketRequest.maxBidPrice) &&
         Objects.equals(this.metro, spotMarketRequest.metro) &&
-        Objects.equals(this.project, spotMarketRequest.project);
+        Objects.equals(this.project, spotMarketRequest.project)&&
+        Objects.equals(this.additionalProperties, spotMarketRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, devicesMax, devicesMin, endAt, facilities, href, id, instances, maxBidPrice, metro, project);
+    return Objects.hash(createdAt, devicesMax, devicesMin, endAt, facilities, href, id, instances, maxBidPrice, metro, project, additionalProperties);
   }
 
   @Override
@@ -396,6 +432,7 @@ public class SpotMarketRequest {
     sb.append("    maxBidPrice: ").append(toIndentedString(maxBidPrice)).append("\n");
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    project: ").append(toIndentedString(project)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -448,34 +485,26 @@ public class SpotMarketRequest {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketRequest is not found in the empty JSON string", SpotMarketRequest.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketRequest` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `facilities`
-      if (jsonObj.getAsJsonObject("facilities") != null) {
+      if (jsonObj.get("facilities") != null && !jsonObj.get("facilities").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("facilities"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `instances`
-      if (jsonObj.getAsJsonObject("instances") != null) {
+      if (jsonObj.get("instances") != null && !jsonObj.get("instances").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("instances"));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         SpotMarketRequestMetro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
   }
@@ -495,6 +524,23 @@ public class SpotMarketRequest {
            @Override
            public void write(JsonWriter out, SpotMarketRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -502,7 +548,25 @@ public class SpotMarketRequest {
            public SpotMarketRequest read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestCreateInput.java
@@ -82,7 +82,7 @@ public class SpotMarketRequestCreateInput {
   @SerializedName(SERIALIZED_NAME_METRO)
   private String metro;
 
-  public SpotMarketRequestCreateInput() { 
+  public SpotMarketRequestCreateInput() {
   }
 
   public SpotMarketRequestCreateInput devicesMax(Integer devicesMax) {
@@ -253,6 +253,41 @@ public class SpotMarketRequestCreateInput {
     this.metro = metro;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketRequestCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -270,12 +305,13 @@ public class SpotMarketRequestCreateInput {
         Objects.equals(this.facilities, spotMarketRequestCreateInput.facilities) &&
         Objects.equals(this.instanceAttributes, spotMarketRequestCreateInput.instanceAttributes) &&
         Objects.equals(this.maxBidPrice, spotMarketRequestCreateInput.maxBidPrice) &&
-        Objects.equals(this.metro, spotMarketRequestCreateInput.metro);
+        Objects.equals(this.metro, spotMarketRequestCreateInput.metro)&&
+        Objects.equals(this.additionalProperties, spotMarketRequestCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(devicesMax, devicesMin, endAt, facilities, instanceAttributes, maxBidPrice, metro);
+    return Objects.hash(devicesMax, devicesMin, endAt, facilities, instanceAttributes, maxBidPrice, metro, additionalProperties);
   }
 
   @Override
@@ -289,6 +325,7 @@ public class SpotMarketRequestCreateInput {
     sb.append("    instanceAttributes: ").append(toIndentedString(instanceAttributes)).append("\n");
     sb.append("    maxBidPrice: ").append(toIndentedString(maxBidPrice)).append("\n");
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -337,23 +374,15 @@ public class SpotMarketRequestCreateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketRequestCreateInput is not found in the empty JSON string", SpotMarketRequestCreateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketRequestCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketRequestCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("facilities") != null && !jsonObj.get("facilities").isJsonArray()) {
+      if ((jsonObj.get("facilities") != null && !jsonObj.get("facilities").isJsonNull()) && !jsonObj.get("facilities").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `facilities` to be an array in the JSON string but got `%s`", jsonObj.get("facilities").toString()));
       }
       // validate the optional field `instance_attributes`
-      if (jsonObj.getAsJsonObject("instance_attributes") != null) {
+      if (jsonObj.get("instance_attributes") != null && !jsonObj.get("instance_attributes").isJsonNull()) {
         SpotMarketRequestCreateInputInstanceAttributes.validateJsonObject(jsonObj.getAsJsonObject("instance_attributes"));
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
   }
@@ -373,6 +402,23 @@ public class SpotMarketRequestCreateInput {
            @Override
            public void write(JsonWriter out, SpotMarketRequestCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -380,7 +426,25 @@ public class SpotMarketRequestCreateInput {
            public SpotMarketRequestCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketRequestCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestCreateInputInstanceAttributes.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestCreateInputInstanceAttributes.java
@@ -125,7 +125,7 @@ public class SpotMarketRequestCreateInputInstanceAttributes {
   @SerializedName(SERIALIZED_NAME_USERDATA)
   private String userdata;
 
-  public SpotMarketRequestCreateInputInstanceAttributes() { 
+  public SpotMarketRequestCreateInputInstanceAttributes() {
   }
 
   public SpotMarketRequestCreateInputInstanceAttributes alwaysPxe(Boolean alwaysPxe) {
@@ -581,6 +581,41 @@ public class SpotMarketRequestCreateInputInstanceAttributes {
     this.userdata = userdata;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketRequestCreateInputInstanceAttributes putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -609,12 +644,13 @@ public class SpotMarketRequestCreateInputInstanceAttributes {
         Objects.equals(this.tags, spotMarketRequestCreateInputInstanceAttributes.tags) &&
         Objects.equals(this.terminationTime, spotMarketRequestCreateInputInstanceAttributes.terminationTime) &&
         Objects.equals(this.userSshKeys, spotMarketRequestCreateInputInstanceAttributes.userSshKeys) &&
-        Objects.equals(this.userdata, spotMarketRequestCreateInputInstanceAttributes.userdata);
+        Objects.equals(this.userdata, spotMarketRequestCreateInputInstanceAttributes.userdata)&&
+        Objects.equals(this.additionalProperties, spotMarketRequestCreateInputInstanceAttributes.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alwaysPxe, billingCycle, customdata, description, features, hostname, hostnames, locked, noSshKeys, operatingSystem, plan, privateIpv4SubnetSize, projectSshKeys, publicIpv4SubnetSize, tags, terminationTime, userSshKeys, userdata);
+    return Objects.hash(alwaysPxe, billingCycle, customdata, description, features, hostname, hostnames, locked, noSshKeys, operatingSystem, plan, privateIpv4SubnetSize, projectSshKeys, publicIpv4SubnetSize, tags, terminationTime, userSshKeys, userdata, additionalProperties);
   }
 
   @Override
@@ -639,6 +675,7 @@ public class SpotMarketRequestCreateInputInstanceAttributes {
     sb.append("    terminationTime: ").append(toIndentedString(terminationTime)).append("\n");
     sb.append("    userSshKeys: ").append(toIndentedString(userSshKeys)).append("\n");
     sb.append("    userdata: ").append(toIndentedString(userdata)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -698,50 +735,42 @@ public class SpotMarketRequestCreateInputInstanceAttributes {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketRequestCreateInputInstanceAttributes is not found in the empty JSON string", SpotMarketRequestCreateInputInstanceAttributes.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketRequestCreateInputInstanceAttributes.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketRequestCreateInputInstanceAttributes` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
+      if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("features") != null && !jsonObj.get("features").isJsonArray()) {
+      if ((jsonObj.get("features") != null && !jsonObj.get("features").isJsonNull()) && !jsonObj.get("features").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `features` to be an array in the JSON string but got `%s`", jsonObj.get("features").toString()));
       }
-      if (jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonPrimitive()) {
+      if ((jsonObj.get("hostname") != null && !jsonObj.get("hostname").isJsonNull()) && !jsonObj.get("hostname").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `hostname` to be a primitive type in the JSON string but got `%s`", jsonObj.get("hostname").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("hostnames") != null && !jsonObj.get("hostnames").isJsonArray()) {
+      if ((jsonObj.get("hostnames") != null && !jsonObj.get("hostnames").isJsonNull()) && !jsonObj.get("hostnames").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `hostnames` to be an array in the JSON string but got `%s`", jsonObj.get("hostnames").toString()));
       }
-      if (jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonPrimitive()) {
+      if ((jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonNull()) && !jsonObj.get("operating_system").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `operating_system` to be a primitive type in the JSON string but got `%s`", jsonObj.get("operating_system").toString()));
       }
-      if (jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonPrimitive()) {
+      if ((jsonObj.get("plan") != null && !jsonObj.get("plan").isJsonNull()) && !jsonObj.get("plan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `plan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("plan").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("project_ssh_keys") != null && !jsonObj.get("project_ssh_keys").isJsonArray()) {
+      if ((jsonObj.get("project_ssh_keys") != null && !jsonObj.get("project_ssh_keys").isJsonNull()) && !jsonObj.get("project_ssh_keys").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_ssh_keys` to be an array in the JSON string but got `%s`", jsonObj.get("project_ssh_keys").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("user_ssh_keys") != null && !jsonObj.get("user_ssh_keys").isJsonArray()) {
+      if ((jsonObj.get("user_ssh_keys") != null && !jsonObj.get("user_ssh_keys").isJsonNull()) && !jsonObj.get("user_ssh_keys").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `user_ssh_keys` to be an array in the JSON string but got `%s`", jsonObj.get("user_ssh_keys").toString()));
       }
-      if (jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonPrimitive()) {
+      if ((jsonObj.get("userdata") != null && !jsonObj.get("userdata").isJsonNull()) && !jsonObj.get("userdata").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `userdata` to be a primitive type in the JSON string but got `%s`", jsonObj.get("userdata").toString()));
       }
   }
@@ -761,6 +790,23 @@ public class SpotMarketRequestCreateInputInstanceAttributes {
            @Override
            public void write(JsonWriter out, SpotMarketRequestCreateInputInstanceAttributes value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -768,7 +814,25 @@ public class SpotMarketRequestCreateInputInstanceAttributes {
            public SpotMarketRequestCreateInputInstanceAttributes read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketRequestCreateInputInstanceAttributes instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestList.java
@@ -56,7 +56,7 @@ public class SpotMarketRequestList {
   @SerializedName(SERIALIZED_NAME_SPOT_MARKET_REQUESTS)
   private List<SpotMarketRequest> spotMarketRequests = null;
 
-  public SpotMarketRequestList() { 
+  public SpotMarketRequestList() {
   }
 
   public SpotMarketRequestList spotMarketRequests(List<SpotMarketRequest> spotMarketRequests) {
@@ -89,6 +89,41 @@ public class SpotMarketRequestList {
     this.spotMarketRequests = spotMarketRequests;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketRequestList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class SpotMarketRequestList {
       return false;
     }
     SpotMarketRequestList spotMarketRequestList = (SpotMarketRequestList) o;
-    return Objects.equals(this.spotMarketRequests, spotMarketRequestList.spotMarketRequests);
+    return Objects.equals(this.spotMarketRequests, spotMarketRequestList.spotMarketRequests)&&
+        Objects.equals(this.additionalProperties, spotMarketRequestList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(spotMarketRequests);
+    return Objects.hash(spotMarketRequests, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class SpotMarketRequestList {
     StringBuilder sb = new StringBuilder();
     sb.append("class SpotMarketRequestList {\n");
     sb.append("    spotMarketRequests: ").append(toIndentedString(spotMarketRequests)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class SpotMarketRequestList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketRequestList is not found in the empty JSON string", SpotMarketRequestList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketRequestList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketRequestList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayspotMarketRequests = jsonObj.getAsJsonArray("spot_market_requests");
       if (jsonArrayspotMarketRequests != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class SpotMarketRequestList {
            @Override
            public void write(JsonWriter out, SpotMarketRequestList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class SpotMarketRequestList {
            public SpotMarketRequestList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketRequestList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestMetro.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestMetro.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import java.util.Objects;
 import java.util.Arrays;
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -67,7 +66,7 @@ public class SpotMarketRequestMetro {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public SpotMarketRequestMetro() { 
+  public SpotMarketRequestMetro() {
   }
 
   public SpotMarketRequestMetro code(String code) {
@@ -161,6 +160,41 @@ public class SpotMarketRequestMetro {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotMarketRequestMetro putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -175,12 +209,13 @@ public class SpotMarketRequestMetro {
     return Objects.equals(this.code, spotMarketRequestMetro.code) &&
         Objects.equals(this.country, spotMarketRequestMetro.country) &&
         Objects.equals(this.id, spotMarketRequestMetro.id) &&
-        Objects.equals(this.name, spotMarketRequestMetro.name);
+        Objects.equals(this.name, spotMarketRequestMetro.name)&&
+        Objects.equals(this.additionalProperties, spotMarketRequestMetro.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(code, country, id, name);
+    return Objects.hash(code, country, id, name, additionalProperties);
   }
 
   @Override
@@ -191,6 +226,7 @@ public class SpotMarketRequestMetro {
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -236,24 +272,16 @@ public class SpotMarketRequestMetro {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotMarketRequestMetro is not found in the empty JSON string", SpotMarketRequestMetro.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotMarketRequestMetro.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotMarketRequestMetro` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("code") != null && !jsonObj.get("code").isJsonPrimitive()) {
+      if ((jsonObj.get("code") != null && !jsonObj.get("code").isJsonNull()) && !jsonObj.get("code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("code").toString()));
       }
-      if (jsonObj.get("country") != null && !jsonObj.get("country").isJsonPrimitive()) {
+      if ((jsonObj.get("country") != null && !jsonObj.get("country").isJsonNull()) && !jsonObj.get("country").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `country` to be a primitive type in the JSON string but got `%s`", jsonObj.get("country").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -273,6 +301,23 @@ public class SpotMarketRequestMetro {
            @Override
            public void write(JsonWriter out, SpotMarketRequestMetro value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -280,7 +325,25 @@ public class SpotMarketRequestMetro {
            public SpotMarketRequestMetro read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotMarketRequestMetro instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesDatapoints.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesDatapoints.java
@@ -56,7 +56,7 @@ public class SpotPricesDatapoints {
   @SerializedName(SERIALIZED_NAME_DATAPOINTS)
   private List<List<BigDecimal>> datapoints = null;
 
-  public SpotPricesDatapoints() { 
+  public SpotPricesDatapoints() {
   }
 
   public SpotPricesDatapoints datapoints(List<List<BigDecimal>> datapoints) {
@@ -89,6 +89,41 @@ public class SpotPricesDatapoints {
     this.datapoints = datapoints;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotPricesDatapoints putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class SpotPricesDatapoints {
       return false;
     }
     SpotPricesDatapoints spotPricesDatapoints = (SpotPricesDatapoints) o;
-    return Objects.equals(this.datapoints, spotPricesDatapoints.datapoints);
+    return Objects.equals(this.datapoints, spotPricesDatapoints.datapoints)&&
+        Objects.equals(this.additionalProperties, spotPricesDatapoints.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(datapoints);
+    return Objects.hash(datapoints, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class SpotPricesDatapoints {
     StringBuilder sb = new StringBuilder();
     sb.append("class SpotPricesDatapoints {\n");
     sb.append("    datapoints: ").append(toIndentedString(datapoints)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,16 +192,8 @@ public class SpotPricesDatapoints {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotPricesDatapoints is not found in the empty JSON string", SpotPricesDatapoints.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotPricesDatapoints.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotPricesDatapoints` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // ensure the json data is an array
-      if (jsonObj.get("datapoints") != null && !jsonObj.get("datapoints").isJsonArray()) {
+      if ((jsonObj.get("datapoints") != null && !jsonObj.get("datapoints").isJsonNull()) && !jsonObj.get("datapoints").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `datapoints` to be an array in the JSON string but got `%s`", jsonObj.get("datapoints").toString()));
       }
   }
@@ -184,6 +213,23 @@ public class SpotPricesDatapoints {
            @Override
            public void write(JsonWriter out, SpotPricesDatapoints value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -191,7 +237,25 @@ public class SpotPricesDatapoints {
            public SpotPricesDatapoints read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotPricesDatapoints instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesHistoryReport.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesHistoryReport.java
@@ -54,7 +54,7 @@ public class SpotPricesHistoryReport {
   @SerializedName(SERIALIZED_NAME_PRICES_HISTORY)
   private SpotPricesDatapoints pricesHistory;
 
-  public SpotPricesHistoryReport() { 
+  public SpotPricesHistoryReport() {
   }
 
   public SpotPricesHistoryReport pricesHistory(SpotPricesDatapoints pricesHistory) {
@@ -79,6 +79,41 @@ public class SpotPricesHistoryReport {
     this.pricesHistory = pricesHistory;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotPricesHistoryReport putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class SpotPricesHistoryReport {
       return false;
     }
     SpotPricesHistoryReport spotPricesHistoryReport = (SpotPricesHistoryReport) o;
-    return Objects.equals(this.pricesHistory, spotPricesHistoryReport.pricesHistory);
+    return Objects.equals(this.pricesHistory, spotPricesHistoryReport.pricesHistory)&&
+        Objects.equals(this.additionalProperties, spotPricesHistoryReport.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pricesHistory);
+    return Objects.hash(pricesHistory, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class SpotPricesHistoryReport {
     StringBuilder sb = new StringBuilder();
     sb.append("class SpotPricesHistoryReport {\n");
     sb.append("    pricesHistory: ").append(toIndentedString(pricesHistory)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,16 +182,8 @@ public class SpotPricesHistoryReport {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotPricesHistoryReport is not found in the empty JSON string", SpotPricesHistoryReport.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotPricesHistoryReport.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotPricesHistoryReport` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `prices_history`
-      if (jsonObj.getAsJsonObject("prices_history") != null) {
+      if (jsonObj.get("prices_history") != null && !jsonObj.get("prices_history").isJsonNull()) {
         SpotPricesDatapoints.validateJsonObject(jsonObj.getAsJsonObject("prices_history"));
       }
   }
@@ -174,6 +203,23 @@ public class SpotPricesHistoryReport {
            @Override
            public void write(JsonWriter out, SpotPricesHistoryReport value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -181,7 +227,25 @@ public class SpotPricesHistoryReport {
            public SpotPricesHistoryReport read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotPricesHistoryReport instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesPerBaremetal.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesPerBaremetal.java
@@ -53,7 +53,7 @@ public class SpotPricesPerBaremetal {
   @SerializedName(SERIALIZED_NAME_PRICE)
   private Float price;
 
-  public SpotPricesPerBaremetal() { 
+  public SpotPricesPerBaremetal() {
   }
 
   public SpotPricesPerBaremetal price(Float price) {
@@ -78,6 +78,41 @@ public class SpotPricesPerBaremetal {
     this.price = price;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotPricesPerBaremetal putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -89,12 +124,13 @@ public class SpotPricesPerBaremetal {
       return false;
     }
     SpotPricesPerBaremetal spotPricesPerBaremetal = (SpotPricesPerBaremetal) o;
-    return Objects.equals(this.price, spotPricesPerBaremetal.price);
+    return Objects.equals(this.price, spotPricesPerBaremetal.price)&&
+        Objects.equals(this.additionalProperties, spotPricesPerBaremetal.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(price);
+    return Objects.hash(price, additionalProperties);
   }
 
   @Override
@@ -102,6 +138,7 @@ public class SpotPricesPerBaremetal {
     StringBuilder sb = new StringBuilder();
     sb.append("class SpotPricesPerBaremetal {\n");
     sb.append("    price: ").append(toIndentedString(price)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -144,14 +181,6 @@ public class SpotPricesPerBaremetal {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotPricesPerBaremetal is not found in the empty JSON string", SpotPricesPerBaremetal.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotPricesPerBaremetal.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotPricesPerBaremetal` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
@@ -169,6 +198,23 @@ public class SpotPricesPerBaremetal {
            @Override
            public void write(JsonWriter out, SpotPricesPerBaremetal value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -176,7 +222,25 @@ public class SpotPricesPerBaremetal {
            public SpotPricesPerBaremetal read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotPricesPerBaremetal instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesPerFacility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesPerFacility.java
@@ -86,7 +86,7 @@ public class SpotPricesPerFacility {
   @SerializedName(SERIALIZED_NAME_M2_XLARGE_X86)
   private SpotPricesPerBaremetal m2XlargeX86;
 
-  public SpotPricesPerFacility() { 
+  public SpotPricesPerFacility() {
   }
 
   public SpotPricesPerFacility baremetal0(SpotPricesPerBaremetal baremetal0) {
@@ -295,6 +295,41 @@ public class SpotPricesPerFacility {
     this.m2XlargeX86 = m2XlargeX86;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotPricesPerFacility putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -314,12 +349,13 @@ public class SpotPricesPerFacility {
         Objects.equals(this.baremetal3, spotPricesPerFacility.baremetal3) &&
         Objects.equals(this.baremetalS, spotPricesPerFacility.baremetalS) &&
         Objects.equals(this.c2MediumX86, spotPricesPerFacility.c2MediumX86) &&
-        Objects.equals(this.m2XlargeX86, spotPricesPerFacility.m2XlargeX86);
+        Objects.equals(this.m2XlargeX86, spotPricesPerFacility.m2XlargeX86)&&
+        Objects.equals(this.additionalProperties, spotPricesPerFacility.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baremetal0, baremetal1, baremetal2, baremetal2a, baremetal2a2, baremetal3, baremetalS, c2MediumX86, m2XlargeX86);
+    return Objects.hash(baremetal0, baremetal1, baremetal2, baremetal2a, baremetal2a2, baremetal3, baremetalS, c2MediumX86, m2XlargeX86, additionalProperties);
   }
 
   @Override
@@ -335,6 +371,7 @@ public class SpotPricesPerFacility {
     sb.append("    baremetalS: ").append(toIndentedString(baremetalS)).append("\n");
     sb.append("    c2MediumX86: ").append(toIndentedString(c2MediumX86)).append("\n");
     sb.append("    m2XlargeX86: ").append(toIndentedString(m2XlargeX86)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -385,48 +422,40 @@ public class SpotPricesPerFacility {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotPricesPerFacility is not found in the empty JSON string", SpotPricesPerFacility.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotPricesPerFacility.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotPricesPerFacility` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `baremetal_0`
-      if (jsonObj.getAsJsonObject("baremetal_0") != null) {
+      if (jsonObj.get("baremetal_0") != null && !jsonObj.get("baremetal_0").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_0"));
       }
       // validate the optional field `baremetal_1`
-      if (jsonObj.getAsJsonObject("baremetal_1") != null) {
+      if (jsonObj.get("baremetal_1") != null && !jsonObj.get("baremetal_1").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_1"));
       }
       // validate the optional field `baremetal_2`
-      if (jsonObj.getAsJsonObject("baremetal_2") != null) {
+      if (jsonObj.get("baremetal_2") != null && !jsonObj.get("baremetal_2").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_2"));
       }
       // validate the optional field `baremetal_2a`
-      if (jsonObj.getAsJsonObject("baremetal_2a") != null) {
+      if (jsonObj.get("baremetal_2a") != null && !jsonObj.get("baremetal_2a").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_2a"));
       }
       // validate the optional field `baremetal_2a2`
-      if (jsonObj.getAsJsonObject("baremetal_2a2") != null) {
+      if (jsonObj.get("baremetal_2a2") != null && !jsonObj.get("baremetal_2a2").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_2a2"));
       }
       // validate the optional field `baremetal_3`
-      if (jsonObj.getAsJsonObject("baremetal_3") != null) {
+      if (jsonObj.get("baremetal_3") != null && !jsonObj.get("baremetal_3").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_3"));
       }
       // validate the optional field `baremetal_s`
-      if (jsonObj.getAsJsonObject("baremetal_s") != null) {
+      if (jsonObj.get("baremetal_s") != null && !jsonObj.get("baremetal_s").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_s"));
       }
       // validate the optional field `c2.medium.x86`
-      if (jsonObj.getAsJsonObject("c2.medium.x86") != null) {
+      if (jsonObj.get("c2.medium.x86") != null && !jsonObj.get("c2.medium.x86").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("c2.medium.x86"));
       }
       // validate the optional field `m2.xlarge.x86`
-      if (jsonObj.getAsJsonObject("m2.xlarge.x86") != null) {
+      if (jsonObj.get("m2.xlarge.x86") != null && !jsonObj.get("m2.xlarge.x86").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("m2.xlarge.x86"));
       }
   }
@@ -446,6 +475,23 @@ public class SpotPricesPerFacility {
            @Override
            public void write(JsonWriter out, SpotPricesPerFacility value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -453,7 +499,25 @@ public class SpotPricesPerFacility {
            public SpotPricesPerFacility read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotPricesPerFacility instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesPerNewFacility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesPerNewFacility.java
@@ -54,7 +54,7 @@ public class SpotPricesPerNewFacility {
   @SerializedName(SERIALIZED_NAME_BAREMETAL1E)
   private SpotPricesPerBaremetal baremetal1e;
 
-  public SpotPricesPerNewFacility() { 
+  public SpotPricesPerNewFacility() {
   }
 
   public SpotPricesPerNewFacility baremetal1e(SpotPricesPerBaremetal baremetal1e) {
@@ -79,6 +79,41 @@ public class SpotPricesPerNewFacility {
     this.baremetal1e = baremetal1e;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotPricesPerNewFacility putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class SpotPricesPerNewFacility {
       return false;
     }
     SpotPricesPerNewFacility spotPricesPerNewFacility = (SpotPricesPerNewFacility) o;
-    return Objects.equals(this.baremetal1e, spotPricesPerNewFacility.baremetal1e);
+    return Objects.equals(this.baremetal1e, spotPricesPerNewFacility.baremetal1e)&&
+        Objects.equals(this.additionalProperties, spotPricesPerNewFacility.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baremetal1e);
+    return Objects.hash(baremetal1e, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class SpotPricesPerNewFacility {
     StringBuilder sb = new StringBuilder();
     sb.append("class SpotPricesPerNewFacility {\n");
     sb.append("    baremetal1e: ").append(toIndentedString(baremetal1e)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,16 +182,8 @@ public class SpotPricesPerNewFacility {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotPricesPerNewFacility is not found in the empty JSON string", SpotPricesPerNewFacility.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotPricesPerNewFacility.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotPricesPerNewFacility` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `baremetal_1e`
-      if (jsonObj.getAsJsonObject("baremetal_1e") != null) {
+      if (jsonObj.get("baremetal_1e") != null && !jsonObj.get("baremetal_1e").isJsonNull()) {
         SpotPricesPerBaremetal.validateJsonObject(jsonObj.getAsJsonObject("baremetal_1e"));
       }
   }
@@ -174,6 +203,23 @@ public class SpotPricesPerNewFacility {
            @Override
            public void write(JsonWriter out, SpotPricesPerNewFacility value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -181,7 +227,25 @@ public class SpotPricesPerNewFacility {
            public SpotPricesPerNewFacility read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotPricesPerNewFacility instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesReport.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SpotPricesReport.java
@@ -107,7 +107,7 @@ public class SpotPricesReport {
   @SerializedName(SERIALIZED_NAME_YYZ1)
   private SpotPricesPerNewFacility yyz1;
 
-  public SpotPricesReport() { 
+  public SpotPricesReport() {
   }
 
   public SpotPricesReport ams1(SpotPricesPerFacility ams1) {
@@ -431,6 +431,41 @@ public class SpotPricesReport {
     this.yyz1 = yyz1;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SpotPricesReport putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -455,12 +490,13 @@ public class SpotPricesReport {
         Objects.equals(this.sin1, spotPricesReport.sin1) &&
         Objects.equals(this.sjc1, spotPricesReport.sjc1) &&
         Objects.equals(this.syd1, spotPricesReport.syd1) &&
-        Objects.equals(this.yyz1, spotPricesReport.yyz1);
+        Objects.equals(this.yyz1, spotPricesReport.yyz1)&&
+        Objects.equals(this.additionalProperties, spotPricesReport.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ams1, atl1, dfw1, ewr1, fra1, iad1, lax1, nrt1, ord1, sea1, sin1, sjc1, syd1, yyz1);
+    return Objects.hash(ams1, atl1, dfw1, ewr1, fra1, iad1, lax1, nrt1, ord1, sea1, sin1, sjc1, syd1, yyz1, additionalProperties);
   }
 
   @Override
@@ -481,6 +517,7 @@ public class SpotPricesReport {
     sb.append("    sjc1: ").append(toIndentedString(sjc1)).append("\n");
     sb.append("    syd1: ").append(toIndentedString(syd1)).append("\n");
     sb.append("    yyz1: ").append(toIndentedString(yyz1)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -536,68 +573,60 @@ public class SpotPricesReport {
           throw new IllegalArgumentException(String.format("The required field(s) %s in SpotPricesReport is not found in the empty JSON string", SpotPricesReport.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SpotPricesReport.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SpotPricesReport` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `ams1`
-      if (jsonObj.getAsJsonObject("ams1") != null) {
+      if (jsonObj.get("ams1") != null && !jsonObj.get("ams1").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ams1"));
       }
       // validate the optional field `atl1`
-      if (jsonObj.getAsJsonObject("atl1") != null) {
+      if (jsonObj.get("atl1") != null && !jsonObj.get("atl1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("atl1"));
       }
       // validate the optional field `dfw1`
-      if (jsonObj.getAsJsonObject("dfw1") != null) {
+      if (jsonObj.get("dfw1") != null && !jsonObj.get("dfw1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("dfw1"));
       }
       // validate the optional field `ewr1`
-      if (jsonObj.getAsJsonObject("ewr1") != null) {
+      if (jsonObj.get("ewr1") != null && !jsonObj.get("ewr1").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("ewr1"));
       }
       // validate the optional field `fra1`
-      if (jsonObj.getAsJsonObject("fra1") != null) {
+      if (jsonObj.get("fra1") != null && !jsonObj.get("fra1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("fra1"));
       }
       // validate the optional field `iad1`
-      if (jsonObj.getAsJsonObject("iad1") != null) {
+      if (jsonObj.get("iad1") != null && !jsonObj.get("iad1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("iad1"));
       }
       // validate the optional field `lax1`
-      if (jsonObj.getAsJsonObject("lax1") != null) {
+      if (jsonObj.get("lax1") != null && !jsonObj.get("lax1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("lax1"));
       }
       // validate the optional field `nrt1`
-      if (jsonObj.getAsJsonObject("nrt1") != null) {
+      if (jsonObj.get("nrt1") != null && !jsonObj.get("nrt1").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("nrt1"));
       }
       // validate the optional field `ord1`
-      if (jsonObj.getAsJsonObject("ord1") != null) {
+      if (jsonObj.get("ord1") != null && !jsonObj.get("ord1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("ord1"));
       }
       // validate the optional field `sea1`
-      if (jsonObj.getAsJsonObject("sea1") != null) {
+      if (jsonObj.get("sea1") != null && !jsonObj.get("sea1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("sea1"));
       }
       // validate the optional field `sin1`
-      if (jsonObj.getAsJsonObject("sin1") != null) {
+      if (jsonObj.get("sin1") != null && !jsonObj.get("sin1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("sin1"));
       }
       // validate the optional field `sjc1`
-      if (jsonObj.getAsJsonObject("sjc1") != null) {
+      if (jsonObj.get("sjc1") != null && !jsonObj.get("sjc1").isJsonNull()) {
         SpotPricesPerFacility.validateJsonObject(jsonObj.getAsJsonObject("sjc1"));
       }
       // validate the optional field `syd1`
-      if (jsonObj.getAsJsonObject("syd1") != null) {
+      if (jsonObj.get("syd1") != null && !jsonObj.get("syd1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("syd1"));
       }
       // validate the optional field `yyz1`
-      if (jsonObj.getAsJsonObject("yyz1") != null) {
+      if (jsonObj.get("yyz1") != null && !jsonObj.get("yyz1").isJsonNull()) {
         SpotPricesPerNewFacility.validateJsonObject(jsonObj.getAsJsonObject("yyz1"));
       }
   }
@@ -617,6 +646,23 @@ public class SpotPricesReport {
            @Override
            public void write(JsonWriter out, SpotPricesReport value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -624,7 +670,25 @@ public class SpotPricesReport {
            public SpotPricesReport read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SpotPricesReport instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SupportRequestInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SupportRequestInput.java
@@ -120,7 +120,7 @@ public class SupportRequestInput {
   @SerializedName(SERIALIZED_NAME_SUBJECT)
   private String subject;
 
-  public SupportRequestInput() { 
+  public SupportRequestInput() {
   }
 
   public SupportRequestInput deviceId(String deviceId) {
@@ -237,6 +237,41 @@ public class SupportRequestInput {
     this.subject = subject;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public SupportRequestInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -252,12 +287,13 @@ public class SupportRequestInput {
         Objects.equals(this.message, supportRequestInput.message) &&
         Objects.equals(this.priority, supportRequestInput.priority) &&
         Objects.equals(this.projectId, supportRequestInput.projectId) &&
-        Objects.equals(this.subject, supportRequestInput.subject);
+        Objects.equals(this.subject, supportRequestInput.subject)&&
+        Objects.equals(this.additionalProperties, supportRequestInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(deviceId, message, priority, projectId, subject);
+    return Objects.hash(deviceId, message, priority, projectId, subject, additionalProperties);
   }
 
   @Override
@@ -269,6 +305,7 @@ public class SupportRequestInput {
     sb.append("    priority: ").append(toIndentedString(priority)).append("\n");
     sb.append("    projectId: ").append(toIndentedString(projectId)).append("\n");
     sb.append("    subject: ").append(toIndentedString(subject)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -318,33 +355,25 @@ public class SupportRequestInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!SupportRequestInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SupportRequestInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : SupportRequestInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("device_id") != null && !jsonObj.get("device_id").isJsonPrimitive()) {
+      if ((jsonObj.get("device_id") != null && !jsonObj.get("device_id").isJsonNull()) && !jsonObj.get("device_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `device_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("device_id").toString()));
       }
-      if (jsonObj.get("message") != null && !jsonObj.get("message").isJsonPrimitive()) {
+      if ((jsonObj.get("message") != null && !jsonObj.get("message").isJsonNull()) && !jsonObj.get("message").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `message` to be a primitive type in the JSON string but got `%s`", jsonObj.get("message").toString()));
       }
-      if (jsonObj.get("priority") != null && !jsonObj.get("priority").isJsonPrimitive()) {
+      if ((jsonObj.get("priority") != null && !jsonObj.get("priority").isJsonNull()) && !jsonObj.get("priority").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `priority` to be a primitive type in the JSON string but got `%s`", jsonObj.get("priority").toString()));
       }
-      if (jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonPrimitive()) {
+      if ((jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonNull()) && !jsonObj.get("project_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project_id").toString()));
       }
-      if (jsonObj.get("subject") != null && !jsonObj.get("subject").isJsonPrimitive()) {
+      if ((jsonObj.get("subject") != null && !jsonObj.get("subject").isJsonNull()) && !jsonObj.get("subject").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `subject` to be a primitive type in the JSON string but got `%s`", jsonObj.get("subject").toString()));
       }
   }
@@ -364,6 +393,23 @@ public class SupportRequestInput {
            @Override
            public void write(JsonWriter out, SupportRequestInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -371,7 +417,25 @@ public class SupportRequestInput {
            public SupportRequestInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             SupportRequestInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Timeframe.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Timeframe.java
@@ -58,7 +58,7 @@ public class Timeframe {
   @SerializedName(SERIALIZED_NAME_STARTED_AT)
   private OffsetDateTime startedAt;
 
-  public Timeframe() { 
+  public Timeframe() {
   }
 
   public Timeframe endedAt(OffsetDateTime endedAt) {
@@ -106,6 +106,41 @@ public class Timeframe {
     this.startedAt = startedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Timeframe putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -118,12 +153,13 @@ public class Timeframe {
     }
     Timeframe timeframe = (Timeframe) o;
     return Objects.equals(this.endedAt, timeframe.endedAt) &&
-        Objects.equals(this.startedAt, timeframe.startedAt);
+        Objects.equals(this.startedAt, timeframe.startedAt)&&
+        Objects.equals(this.additionalProperties, timeframe.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(endedAt, startedAt);
+    return Objects.hash(endedAt, startedAt, additionalProperties);
   }
 
   @Override
@@ -132,6 +168,7 @@ public class Timeframe {
     sb.append("class Timeframe {\n");
     sb.append("    endedAt: ").append(toIndentedString(endedAt)).append("\n");
     sb.append("    startedAt: ").append(toIndentedString(startedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -178,14 +215,6 @@ public class Timeframe {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Timeframe.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Timeframe` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : Timeframe.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
@@ -209,6 +238,23 @@ public class Timeframe {
            @Override
            public void write(JsonWriter out, Timeframe value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -216,7 +262,25 @@ public class Timeframe {
            public Timeframe read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Timeframe instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/TransferRequest.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/TransferRequest.java
@@ -76,7 +76,7 @@ public class TransferRequest {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public TransferRequest() { 
+  public TransferRequest() {
   }
 
   public TransferRequest createdAt(OffsetDateTime createdAt) {
@@ -216,6 +216,41 @@ public class TransferRequest {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public TransferRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -232,12 +267,13 @@ public class TransferRequest {
         Objects.equals(this.id, transferRequest.id) &&
         Objects.equals(this.project, transferRequest.project) &&
         Objects.equals(this.targetOrganization, transferRequest.targetOrganization) &&
-        Objects.equals(this.updatedAt, transferRequest.updatedAt);
+        Objects.equals(this.updatedAt, transferRequest.updatedAt)&&
+        Objects.equals(this.additionalProperties, transferRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, href, id, project, targetOrganization, updatedAt);
+    return Objects.hash(createdAt, href, id, project, targetOrganization, updatedAt, additionalProperties);
   }
 
   @Override
@@ -250,6 +286,7 @@ public class TransferRequest {
     sb.append("    project: ").append(toIndentedString(project)).append("\n");
     sb.append("    targetOrganization: ").append(toIndentedString(targetOrganization)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -297,26 +334,18 @@ public class TransferRequest {
           throw new IllegalArgumentException(String.format("The required field(s) %s in TransferRequest is not found in the empty JSON string", TransferRequest.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!TransferRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `TransferRequest` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
       // validate the optional field `target_organization`
-      if (jsonObj.getAsJsonObject("target_organization") != null) {
+      if (jsonObj.get("target_organization") != null && !jsonObj.get("target_organization").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("target_organization"));
       }
   }
@@ -336,6 +365,23 @@ public class TransferRequest {
            @Override
            public void write(JsonWriter out, TransferRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -343,7 +389,25 @@ public class TransferRequest {
            public TransferRequest read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             TransferRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/TransferRequestInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/TransferRequestInput.java
@@ -54,7 +54,7 @@ public class TransferRequestInput {
   @SerializedName(SERIALIZED_NAME_TARGET_ORGANIZATION_ID)
   private UUID targetOrganizationId;
 
-  public TransferRequestInput() { 
+  public TransferRequestInput() {
   }
 
   public TransferRequestInput targetOrganizationId(UUID targetOrganizationId) {
@@ -79,6 +79,41 @@ public class TransferRequestInput {
     this.targetOrganizationId = targetOrganizationId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public TransferRequestInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +125,13 @@ public class TransferRequestInput {
       return false;
     }
     TransferRequestInput transferRequestInput = (TransferRequestInput) o;
-    return Objects.equals(this.targetOrganizationId, transferRequestInput.targetOrganizationId);
+    return Objects.equals(this.targetOrganizationId, transferRequestInput.targetOrganizationId)&&
+        Objects.equals(this.additionalProperties, transferRequestInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(targetOrganizationId);
+    return Objects.hash(targetOrganizationId, additionalProperties);
   }
 
   @Override
@@ -103,6 +139,7 @@ public class TransferRequestInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransferRequestInput {\n");
     sb.append("    targetOrganizationId: ").append(toIndentedString(targetOrganizationId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,15 +182,7 @@ public class TransferRequestInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in TransferRequestInput is not found in the empty JSON string", TransferRequestInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!TransferRequestInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `TransferRequestInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("target_organization_id") != null && !jsonObj.get("target_organization_id").isJsonPrimitive()) {
+      if ((jsonObj.get("target_organization_id") != null && !jsonObj.get("target_organization_id").isJsonNull()) && !jsonObj.get("target_organization_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `target_organization_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("target_organization_id").toString()));
       }
   }
@@ -173,6 +202,23 @@ public class TransferRequestInput {
            @Override
            public void write(JsonWriter out, TransferRequestInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -180,7 +226,25 @@ public class TransferRequestInput {
            public TransferRequestInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             TransferRequestInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/TransferRequestList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/TransferRequestList.java
@@ -56,7 +56,7 @@ public class TransferRequestList {
   @SerializedName(SERIALIZED_NAME_TRANSFERS)
   private List<TransferRequest> transfers = null;
 
-  public TransferRequestList() { 
+  public TransferRequestList() {
   }
 
   public TransferRequestList transfers(List<TransferRequest> transfers) {
@@ -89,6 +89,41 @@ public class TransferRequestList {
     this.transfers = transfers;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public TransferRequestList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class TransferRequestList {
       return false;
     }
     TransferRequestList transferRequestList = (TransferRequestList) o;
-    return Objects.equals(this.transfers, transferRequestList.transfers);
+    return Objects.equals(this.transfers, transferRequestList.transfers)&&
+        Objects.equals(this.additionalProperties, transferRequestList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(transfers);
+    return Objects.hash(transfers, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class TransferRequestList {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransferRequestList {\n");
     sb.append("    transfers: ").append(toIndentedString(transfers)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class TransferRequestList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in TransferRequestList is not found in the empty JSON string", TransferRequestList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!TransferRequestList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `TransferRequestList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArraytransfers = jsonObj.getAsJsonArray("transfers");
       if (jsonArraytransfers != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class TransferRequestList {
            @Override
            public void write(JsonWriter out, TransferRequestList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class TransferRequestList {
            public TransferRequestList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             TransferRequestList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UpdateEmailInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UpdateEmailInput.java
@@ -53,7 +53,7 @@ public class UpdateEmailInput {
   @SerializedName(SERIALIZED_NAME_DEFAULT)
   private Boolean _default;
 
-  public UpdateEmailInput() { 
+  public UpdateEmailInput() {
   }
 
   public UpdateEmailInput _default(Boolean _default) {
@@ -78,6 +78,41 @@ public class UpdateEmailInput {
     this._default = _default;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public UpdateEmailInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -89,12 +124,13 @@ public class UpdateEmailInput {
       return false;
     }
     UpdateEmailInput updateEmailInput = (UpdateEmailInput) o;
-    return Objects.equals(this._default, updateEmailInput._default);
+    return Objects.equals(this._default, updateEmailInput._default)&&
+        Objects.equals(this.additionalProperties, updateEmailInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_default);
+    return Objects.hash(_default, additionalProperties);
   }
 
   @Override
@@ -102,6 +138,7 @@ public class UpdateEmailInput {
     StringBuilder sb = new StringBuilder();
     sb.append("class UpdateEmailInput {\n");
     sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -144,14 +181,6 @@ public class UpdateEmailInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in UpdateEmailInput is not found in the empty JSON string", UpdateEmailInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!UpdateEmailInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UpdateEmailInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
@@ -169,6 +198,23 @@ public class UpdateEmailInput {
            @Override
            public void write(JsonWriter out, UpdateEmailInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -176,7 +222,25 @@ public class UpdateEmailInput {
            public UpdateEmailInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             UpdateEmailInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/User.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/User.java
@@ -134,7 +134,7 @@ public class User {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public User() { 
+  public User() {
   }
 
   public User avatarThumbUrl(String avatarThumbUrl) {
@@ -604,6 +604,41 @@ public class User {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public User putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -634,12 +669,13 @@ public class User {
         Objects.equals(this.shortId, user.shortId) &&
         Objects.equals(this.timezone, user.timezone) &&
         Objects.equals(this.twoFactorAuth, user.twoFactorAuth) &&
-        Objects.equals(this.updatedAt, user.updatedAt);
+        Objects.equals(this.updatedAt, user.updatedAt)&&
+        Objects.equals(this.additionalProperties, user.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(avatarThumbUrl, avatarUrl, createdAt, customdata, email, emails, firstName, fraudScore, fullName, href, id, lastLoginAt, lastName, maxOrganizations, maxProjects, phoneNumber, shortId, timezone, twoFactorAuth, updatedAt);
+    return Objects.hash(avatarThumbUrl, avatarUrl, createdAt, customdata, email, emails, firstName, fraudScore, fullName, href, id, lastLoginAt, lastName, maxOrganizations, maxProjects, phoneNumber, shortId, timezone, twoFactorAuth, updatedAt, additionalProperties);
   }
 
   @Override
@@ -666,6 +702,7 @@ public class User {
     sb.append("    timezone: ").append(toIndentedString(timezone)).append("\n");
     sb.append("    twoFactorAuth: ").append(toIndentedString(twoFactorAuth)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -727,21 +764,13 @@ public class User {
           throw new IllegalArgumentException(String.format("The required field(s) %s in User is not found in the empty JSON string", User.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!User.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `User` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
+      if ((jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonNull()) && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `avatar_thumb_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("avatar_thumb_url").toString()));
       }
-      if (jsonObj.get("avatar_url") != null && !jsonObj.get("avatar_url").isJsonPrimitive()) {
+      if ((jsonObj.get("avatar_url") != null && !jsonObj.get("avatar_url").isJsonNull()) && !jsonObj.get("avatar_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `avatar_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("avatar_url").toString()));
       }
-      if (jsonObj.get("email") != null && !jsonObj.get("email").isJsonPrimitive()) {
+      if ((jsonObj.get("email") != null && !jsonObj.get("email").isJsonNull()) && !jsonObj.get("email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
       }
       JsonArray jsonArrayemails = jsonObj.getAsJsonArray("emails");
@@ -756,34 +785,34 @@ public class User {
           Href.validateJsonObject(jsonArrayemails.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonPrimitive()) {
+      if ((jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonNull()) && !jsonObj.get("first_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `first_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("first_name").toString()));
       }
-      if (jsonObj.get("fraud_score") != null && !jsonObj.get("fraud_score").isJsonPrimitive()) {
+      if ((jsonObj.get("fraud_score") != null && !jsonObj.get("fraud_score").isJsonNull()) && !jsonObj.get("fraud_score").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `fraud_score` to be a primitive type in the JSON string but got `%s`", jsonObj.get("fraud_score").toString()));
       }
-      if (jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonPrimitive()) {
+      if ((jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonNull()) && !jsonObj.get("full_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `full_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("full_name").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonPrimitive()) {
+      if ((jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonNull()) && !jsonObj.get("last_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `last_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("last_name").toString()));
       }
-      if (jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonPrimitive()) {
+      if ((jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonNull()) && !jsonObj.get("phone_number").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `phone_number` to be a primitive type in the JSON string but got `%s`", jsonObj.get("phone_number").toString()));
       }
-      if (jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonPrimitive()) {
+      if ((jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonNull()) && !jsonObj.get("short_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `short_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("short_id").toString()));
       }
-      if (jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonPrimitive()) {
+      if ((jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonNull()) && !jsonObj.get("timezone").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `timezone` to be a primitive type in the JSON string but got `%s`", jsonObj.get("timezone").toString()));
       }
-      if (jsonObj.get("two_factor_auth") != null && !jsonObj.get("two_factor_auth").isJsonPrimitive()) {
+      if ((jsonObj.get("two_factor_auth") != null && !jsonObj.get("two_factor_auth").isJsonNull()) && !jsonObj.get("two_factor_auth").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `two_factor_auth` to be a primitive type in the JSON string but got `%s`", jsonObj.get("two_factor_auth").toString()));
       }
   }
@@ -803,6 +832,23 @@ public class User {
            @Override
            public void write(JsonWriter out, User value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -810,7 +856,25 @@ public class User {
            public User read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             User instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserCreateInput.java
@@ -118,7 +118,7 @@ public class UserCreateInput {
   @SerializedName(SERIALIZED_NAME_VERIFIED_AT)
   private OffsetDateTime verifiedAt;
 
-  public UserCreateInput() { 
+  public UserCreateInput() {
   }
 
   public UserCreateInput avatar(File avatar) {
@@ -493,6 +493,41 @@ public class UserCreateInput {
     this.verifiedAt = verifiedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public UserCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -519,12 +554,13 @@ public class UserCreateInput {
         Objects.equals(this.timezone, userCreateInput.timezone) &&
         Objects.equals(this.title, userCreateInput.title) &&
         Objects.equals(this.twoFactorAuth, userCreateInput.twoFactorAuth) &&
-        Objects.equals(this.verifiedAt, userCreateInput.verifiedAt);
+        Objects.equals(this.verifiedAt, userCreateInput.verifiedAt)&&
+        Objects.equals(this.additionalProperties, userCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(avatar, companyName, companyUrl, customdata, emails, firstName, lastName, level, locked, password, phoneNumber, socialAccounts, timezone, title, twoFactorAuth, verifiedAt);
+    return Objects.hash(avatar, companyName, companyUrl, customdata, emails, firstName, lastName, level, locked, password, phoneNumber, socialAccounts, timezone, title, twoFactorAuth, verifiedAt, additionalProperties);
   }
 
   @Override
@@ -547,6 +583,7 @@ public class UserCreateInput {
     sb.append("    title: ").append(toIndentedString(title)).append("\n");
     sb.append("    twoFactorAuth: ").append(toIndentedString(twoFactorAuth)).append("\n");
     sb.append("    verifiedAt: ").append(toIndentedString(verifiedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -608,24 +645,16 @@ public class UserCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!UserCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UserCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : UserCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("company_name") != null && !jsonObj.get("company_name").isJsonPrimitive()) {
+      if ((jsonObj.get("company_name") != null && !jsonObj.get("company_name").isJsonNull()) && !jsonObj.get("company_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `company_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("company_name").toString()));
       }
-      if (jsonObj.get("company_url") != null && !jsonObj.get("company_url").isJsonPrimitive()) {
+      if ((jsonObj.get("company_url") != null && !jsonObj.get("company_url").isJsonNull()) && !jsonObj.get("company_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `company_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("company_url").toString()));
       }
       JsonArray jsonArrayemails = jsonObj.getAsJsonArray("emails");
@@ -640,28 +669,28 @@ public class UserCreateInput {
           EmailInput.validateJsonObject(jsonArrayemails.get(i).getAsJsonObject());
         };
       }
-      if (jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonPrimitive()) {
+      if ((jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonNull()) && !jsonObj.get("first_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `first_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("first_name").toString()));
       }
-      if (jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonPrimitive()) {
+      if ((jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonNull()) && !jsonObj.get("last_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `last_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("last_name").toString()));
       }
-      if (jsonObj.get("level") != null && !jsonObj.get("level").isJsonPrimitive()) {
+      if ((jsonObj.get("level") != null && !jsonObj.get("level").isJsonNull()) && !jsonObj.get("level").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `level` to be a primitive type in the JSON string but got `%s`", jsonObj.get("level").toString()));
       }
-      if (jsonObj.get("password") != null && !jsonObj.get("password").isJsonPrimitive()) {
+      if ((jsonObj.get("password") != null && !jsonObj.get("password").isJsonNull()) && !jsonObj.get("password").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `password` to be a primitive type in the JSON string but got `%s`", jsonObj.get("password").toString()));
       }
-      if (jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonPrimitive()) {
+      if ((jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonNull()) && !jsonObj.get("phone_number").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `phone_number` to be a primitive type in the JSON string but got `%s`", jsonObj.get("phone_number").toString()));
       }
-      if (jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonPrimitive()) {
+      if ((jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonNull()) && !jsonObj.get("timezone").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `timezone` to be a primitive type in the JSON string but got `%s`", jsonObj.get("timezone").toString()));
       }
-      if (jsonObj.get("title") != null && !jsonObj.get("title").isJsonPrimitive()) {
+      if ((jsonObj.get("title") != null && !jsonObj.get("title").isJsonNull()) && !jsonObj.get("title").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `title` to be a primitive type in the JSON string but got `%s`", jsonObj.get("title").toString()));
       }
-      if (jsonObj.get("two_factor_auth") != null && !jsonObj.get("two_factor_auth").isJsonPrimitive()) {
+      if ((jsonObj.get("two_factor_auth") != null && !jsonObj.get("two_factor_auth").isJsonNull()) && !jsonObj.get("two_factor_auth").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `two_factor_auth` to be a primitive type in the JSON string but got `%s`", jsonObj.get("two_factor_auth").toString()));
       }
   }
@@ -681,6 +710,23 @@ public class UserCreateInput {
            @Override
            public void write(JsonWriter out, UserCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -688,7 +734,25 @@ public class UserCreateInput {
            public UserCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             UserCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserList.java
@@ -61,7 +61,7 @@ public class UserList {
   @SerializedName(SERIALIZED_NAME_USERS)
   private List<User> users = null;
 
-  public UserList() { 
+  public UserList() {
   }
 
   public UserList meta(Meta meta) {
@@ -117,6 +117,41 @@ public class UserList {
     this.users = users;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public UserList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -129,12 +164,13 @@ public class UserList {
     }
     UserList userList = (UserList) o;
     return Objects.equals(this.meta, userList.meta) &&
-        Objects.equals(this.users, userList.users);
+        Objects.equals(this.users, userList.users)&&
+        Objects.equals(this.additionalProperties, userList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(meta, users);
+    return Objects.hash(meta, users, additionalProperties);
   }
 
   @Override
@@ -143,6 +179,7 @@ public class UserList {
     sb.append("class UserList {\n");
     sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
     sb.append("    users: ").append(toIndentedString(users)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -186,16 +223,8 @@ public class UserList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in UserList is not found in the empty JSON string", UserList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!UserList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UserList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `meta`
-      if (jsonObj.getAsJsonObject("meta") != null) {
+      if (jsonObj.get("meta") != null && !jsonObj.get("meta").isJsonNull()) {
         Meta.validateJsonObject(jsonObj.getAsJsonObject("meta"));
       }
       JsonArray jsonArrayusers = jsonObj.getAsJsonArray("users");
@@ -227,6 +256,23 @@ public class UserList {
            @Override
            public void write(JsonWriter out, UserList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -234,7 +280,25 @@ public class UserList {
            public UserList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             UserList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserLite.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserLite.java
@@ -91,7 +91,7 @@ public class UserLite {
   @SerializedName(SERIALIZED_NAME_UPDATED_AT)
   private OffsetDateTime updatedAt;
 
-  public UserLite() { 
+  public UserLite() {
   }
 
   public UserLite avatarThumbUrl(String avatarThumbUrl) {
@@ -323,6 +323,41 @@ public class UserLite {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public UserLite putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -343,12 +378,13 @@ public class UserLite {
         Objects.equals(this.id, userLite.id) &&
         Objects.equals(this.lastName, userLite.lastName) &&
         Objects.equals(this.shortId, userLite.shortId) &&
-        Objects.equals(this.updatedAt, userLite.updatedAt);
+        Objects.equals(this.updatedAt, userLite.updatedAt)&&
+        Objects.equals(this.additionalProperties, userLite.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(avatarThumbUrl, createdAt, email, firstName, fullName, href, id, lastName, shortId, updatedAt);
+    return Objects.hash(avatarThumbUrl, createdAt, email, firstName, fullName, href, id, lastName, shortId, updatedAt, additionalProperties);
   }
 
   @Override
@@ -365,6 +401,7 @@ public class UserLite {
     sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
     sb.append("    shortId: ").append(toIndentedString(shortId)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -419,42 +456,34 @@ public class UserLite {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!UserLite.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UserLite` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : UserLite.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
+      if ((jsonObj.get("avatar_thumb_url") != null && !jsonObj.get("avatar_thumb_url").isJsonNull()) && !jsonObj.get("avatar_thumb_url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `avatar_thumb_url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("avatar_thumb_url").toString()));
       }
-      if (jsonObj.get("email") != null && !jsonObj.get("email").isJsonPrimitive()) {
+      if ((jsonObj.get("email") != null && !jsonObj.get("email").isJsonNull()) && !jsonObj.get("email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
       }
-      if (jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonPrimitive()) {
+      if ((jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonNull()) && !jsonObj.get("first_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `first_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("first_name").toString()));
       }
-      if (jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonPrimitive()) {
+      if ((jsonObj.get("full_name") != null && !jsonObj.get("full_name").isJsonNull()) && !jsonObj.get("full_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `full_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("full_name").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonPrimitive()) {
+      if ((jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonNull()) && !jsonObj.get("last_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `last_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("last_name").toString()));
       }
-      if (jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonPrimitive()) {
+      if ((jsonObj.get("short_id") != null && !jsonObj.get("short_id").isJsonNull()) && !jsonObj.get("short_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `short_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("short_id").toString()));
       }
   }
@@ -474,6 +503,23 @@ public class UserLite {
            @Override
            public void write(JsonWriter out, UserLite value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -481,7 +527,25 @@ public class UserLite {
            public UserLite read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             UserLite instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/UserUpdateInput.java
@@ -73,7 +73,7 @@ public class UserUpdateInput {
   @SerializedName(SERIALIZED_NAME_TIMEZONE)
   private String timezone;
 
-  public UserUpdateInput() { 
+  public UserUpdateInput() {
   }
 
   public UserUpdateInput customdata(Object customdata) {
@@ -213,6 +213,41 @@ public class UserUpdateInput {
     this.timezone = timezone;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public UserUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -229,12 +264,13 @@ public class UserUpdateInput {
         Objects.equals(this.lastName, userUpdateInput.lastName) &&
         Objects.equals(this.password, userUpdateInput.password) &&
         Objects.equals(this.phoneNumber, userUpdateInput.phoneNumber) &&
-        Objects.equals(this.timezone, userUpdateInput.timezone);
+        Objects.equals(this.timezone, userUpdateInput.timezone)&&
+        Objects.equals(this.additionalProperties, userUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(customdata, firstName, lastName, password, phoneNumber, timezone);
+    return Objects.hash(customdata, firstName, lastName, password, phoneNumber, timezone, additionalProperties);
   }
 
   @Override
@@ -247,6 +283,7 @@ public class UserUpdateInput {
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    phoneNumber: ").append(toIndentedString(phoneNumber)).append("\n");
     sb.append("    timezone: ").append(toIndentedString(timezone)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -294,27 +331,19 @@ public class UserUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in UserUpdateInput is not found in the empty JSON string", UserUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!UserUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UserUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonPrimitive()) {
+      if ((jsonObj.get("first_name") != null && !jsonObj.get("first_name").isJsonNull()) && !jsonObj.get("first_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `first_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("first_name").toString()));
       }
-      if (jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonPrimitive()) {
+      if ((jsonObj.get("last_name") != null && !jsonObj.get("last_name").isJsonNull()) && !jsonObj.get("last_name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `last_name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("last_name").toString()));
       }
-      if (jsonObj.get("password") != null && !jsonObj.get("password").isJsonPrimitive()) {
+      if ((jsonObj.get("password") != null && !jsonObj.get("password").isJsonNull()) && !jsonObj.get("password").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `password` to be a primitive type in the JSON string but got `%s`", jsonObj.get("password").toString()));
       }
-      if (jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonPrimitive()) {
+      if ((jsonObj.get("phone_number") != null && !jsonObj.get("phone_number").isJsonNull()) && !jsonObj.get("phone_number").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `phone_number` to be a primitive type in the JSON string but got `%s`", jsonObj.get("phone_number").toString()));
       }
-      if (jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonPrimitive()) {
+      if ((jsonObj.get("timezone") != null && !jsonObj.get("timezone").isJsonNull()) && !jsonObj.get("timezone").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `timezone` to be a primitive type in the JSON string but got `%s`", jsonObj.get("timezone").toString()));
       }
   }
@@ -334,6 +363,23 @@ public class UserUpdateInput {
            @Override
            public void write(JsonWriter out, UserUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -341,7 +387,25 @@ public class UserUpdateInput {
            public UserUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             UserUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuit.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuit.java
@@ -101,7 +101,7 @@ public class VirtualCircuit {
   @SerializedName(SERIALIZED_NAME_VNID)
   private Integer vnid;
 
-  public VirtualCircuit() { 
+  public VirtualCircuit() {
   }
 
   public VirtualCircuit bill(Boolean bill) {
@@ -384,6 +384,41 @@ public class VirtualCircuit {
     this.vnid = vnid;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VirtualCircuit putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -406,12 +441,13 @@ public class VirtualCircuit {
         Objects.equals(this.status, virtualCircuit.status) &&
         Objects.equals(this.tags, virtualCircuit.tags) &&
         Objects.equals(this.virtualNetwork, virtualCircuit.virtualNetwork) &&
-        Objects.equals(this.vnid, virtualCircuit.vnid);
+        Objects.equals(this.vnid, virtualCircuit.vnid)&&
+        Objects.equals(this.additionalProperties, virtualCircuit.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bill, description, id, name, nniVlan, port, project, speed, status, tags, virtualNetwork, vnid);
+    return Objects.hash(bill, description, id, name, nniVlan, port, project, speed, status, tags, virtualNetwork, vnid, additionalProperties);
   }
 
   @Override
@@ -430,6 +466,7 @@ public class VirtualCircuit {
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    virtualNetwork: ").append(toIndentedString(virtualNetwork)).append("\n");
     sb.append("    vnid: ").append(toIndentedString(vnid)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -495,46 +532,38 @@ public class VirtualCircuit {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VirtualCircuit.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VirtualCircuit` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : VirtualCircuit.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       // validate the optional field `port`
-      if (jsonObj.getAsJsonObject("port") != null) {
+      if (jsonObj.get("port") != null && !jsonObj.get("port").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("port"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonPrimitive()) {
+      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       // validate the optional field `virtual_network`
-      if (jsonObj.getAsJsonObject("virtual_network") != null) {
+      if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("virtual_network"));
       }
   }
@@ -554,6 +583,23 @@ public class VirtualCircuit {
            @Override
            public void write(JsonWriter out, VirtualCircuit value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -561,7 +607,25 @@ public class VirtualCircuit {
            public VirtualCircuit read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VirtualCircuit instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuitCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuitCreateInput.java
@@ -80,7 +80,7 @@ public class VirtualCircuitCreateInput {
   @SerializedName(SERIALIZED_NAME_VNID)
   private UUID vnid;
 
-  public VirtualCircuitCreateInput() { 
+  public VirtualCircuitCreateInput() {
   }
 
   public VirtualCircuitCreateInput description(String description) {
@@ -253,6 +253,41 @@ public class VirtualCircuitCreateInput {
     this.vnid = vnid;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VirtualCircuitCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -270,12 +305,13 @@ public class VirtualCircuitCreateInput {
         Objects.equals(this.project, virtualCircuitCreateInput.project) &&
         Objects.equals(this.speed, virtualCircuitCreateInput.speed) &&
         Objects.equals(this.tags, virtualCircuitCreateInput.tags) &&
-        Objects.equals(this.vnid, virtualCircuitCreateInput.vnid);
+        Objects.equals(this.vnid, virtualCircuitCreateInput.vnid)&&
+        Objects.equals(this.additionalProperties, virtualCircuitCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, name, nniVlan, project, speed, tags, vnid);
+    return Objects.hash(description, name, nniVlan, project, speed, tags, vnid, additionalProperties);
   }
 
   @Override
@@ -289,6 +325,7 @@ public class VirtualCircuitCreateInput {
     sb.append("    speed: ").append(toIndentedString(speed)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    vnid: ").append(toIndentedString(vnid)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -337,28 +374,20 @@ public class VirtualCircuitCreateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VirtualCircuitCreateInput is not found in the empty JSON string", VirtualCircuitCreateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VirtualCircuitCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VirtualCircuitCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonPrimitive()) {
+      if ((jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) && !jsonObj.get("project").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("vnid") != null && !jsonObj.get("vnid").isJsonPrimitive()) {
+      if ((jsonObj.get("vnid") != null && !jsonObj.get("vnid").isJsonNull()) && !jsonObj.get("vnid").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `vnid` to be a primitive type in the JSON string but got `%s`", jsonObj.get("vnid").toString()));
       }
   }
@@ -378,6 +407,23 @@ public class VirtualCircuitCreateInput {
            @Override
            public void write(JsonWriter out, VirtualCircuitCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -385,7 +431,25 @@ public class VirtualCircuitCreateInput {
            public VirtualCircuitCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VirtualCircuitCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuitList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuitList.java
@@ -56,7 +56,7 @@ public class VirtualCircuitList {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_CIRCUITS)
   private List<VirtualCircuitListVirtualCircuitsInner> virtualCircuits = null;
 
-  public VirtualCircuitList() { 
+  public VirtualCircuitList() {
   }
 
   public VirtualCircuitList virtualCircuits(List<VirtualCircuitListVirtualCircuitsInner> virtualCircuits) {
@@ -89,6 +89,41 @@ public class VirtualCircuitList {
     this.virtualCircuits = virtualCircuits;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VirtualCircuitList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class VirtualCircuitList {
       return false;
     }
     VirtualCircuitList virtualCircuitList = (VirtualCircuitList) o;
-    return Objects.equals(this.virtualCircuits, virtualCircuitList.virtualCircuits);
+    return Objects.equals(this.virtualCircuits, virtualCircuitList.virtualCircuits)&&
+        Objects.equals(this.additionalProperties, virtualCircuitList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(virtualCircuits);
+    return Objects.hash(virtualCircuits, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class VirtualCircuitList {
     StringBuilder sb = new StringBuilder();
     sb.append("class VirtualCircuitList {\n");
     sb.append("    virtualCircuits: ").append(toIndentedString(virtualCircuits)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class VirtualCircuitList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VirtualCircuitList is not found in the empty JSON string", VirtualCircuitList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VirtualCircuitList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VirtualCircuitList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayvirtualCircuits = jsonObj.getAsJsonArray("virtual_circuits");
       if (jsonArrayvirtualCircuits != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class VirtualCircuitList {
            @Override
            public void write(JsonWriter out, VirtualCircuitList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class VirtualCircuitList {
            public VirtualCircuitList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VirtualCircuitList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuitUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualCircuitUpdateInput.java
@@ -71,7 +71,7 @@ public class VirtualCircuitUpdateInput {
   @SerializedName(SERIALIZED_NAME_VNID)
   private String vnid;
 
-  public VirtualCircuitUpdateInput() { 
+  public VirtualCircuitUpdateInput() {
   }
 
   public VirtualCircuitUpdateInput description(String description) {
@@ -196,6 +196,41 @@ public class VirtualCircuitUpdateInput {
     this.vnid = vnid;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VirtualCircuitUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -211,12 +246,13 @@ public class VirtualCircuitUpdateInput {
         Objects.equals(this.name, virtualCircuitUpdateInput.name) &&
         Objects.equals(this.speed, virtualCircuitUpdateInput.speed) &&
         Objects.equals(this.tags, virtualCircuitUpdateInput.tags) &&
-        Objects.equals(this.vnid, virtualCircuitUpdateInput.vnid);
+        Objects.equals(this.vnid, virtualCircuitUpdateInput.vnid)&&
+        Objects.equals(this.additionalProperties, virtualCircuitUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, name, speed, tags, vnid);
+    return Objects.hash(description, name, speed, tags, vnid, additionalProperties);
   }
 
   @Override
@@ -228,6 +264,7 @@ public class VirtualCircuitUpdateInput {
     sb.append("    speed: ").append(toIndentedString(speed)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    vnid: ").append(toIndentedString(vnid)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -274,28 +311,20 @@ public class VirtualCircuitUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VirtualCircuitUpdateInput is not found in the empty JSON string", VirtualCircuitUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VirtualCircuitUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VirtualCircuitUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("speed") != null && !jsonObj.get("speed").isJsonPrimitive()) {
+      if ((jsonObj.get("speed") != null && !jsonObj.get("speed").isJsonNull()) && !jsonObj.get("speed").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `speed` to be a primitive type in the JSON string but got `%s`", jsonObj.get("speed").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("vnid") != null && !jsonObj.get("vnid").isJsonPrimitive()) {
+      if ((jsonObj.get("vnid") != null && !jsonObj.get("vnid").isJsonNull()) && !jsonObj.get("vnid").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `vnid` to be a primitive type in the JSON string but got `%s`", jsonObj.get("vnid").toString()));
       }
   }
@@ -315,6 +344,23 @@ public class VirtualCircuitUpdateInput {
            @Override
            public void write(JsonWriter out, VirtualCircuitUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -322,7 +368,25 @@ public class VirtualCircuitUpdateInput {
            public VirtualCircuitUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VirtualCircuitUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualNetwork.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualNetwork.java
@@ -98,7 +98,7 @@ public class VirtualNetwork {
   @SerializedName(SERIALIZED_NAME_VXLAN)
   private Integer vxlan;
 
-  public VirtualNetwork() { 
+  public VirtualNetwork() {
   }
 
   public VirtualNetwork assignedTo(Href assignedTo) {
@@ -361,6 +361,41 @@ public class VirtualNetwork {
     this.vxlan = vxlan;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VirtualNetwork putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -382,12 +417,13 @@ public class VirtualNetwork {
         Objects.equals(this.metalGateway, virtualNetwork.metalGateway) &&
         Objects.equals(this.metro, virtualNetwork.metro) &&
         Objects.equals(this.metroCode, virtualNetwork.metroCode) &&
-        Objects.equals(this.vxlan, virtualNetwork.vxlan);
+        Objects.equals(this.vxlan, virtualNetwork.vxlan)&&
+        Objects.equals(this.additionalProperties, virtualNetwork.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(assignedTo, assignedToVirtualCircuit, description, facility, href, id, instances, metalGateway, metro, metroCode, vxlan);
+    return Objects.hash(assignedTo, assignedToVirtualCircuit, description, facility, href, id, instances, metalGateway, metro, metroCode, vxlan, additionalProperties);
   }
 
   @Override
@@ -405,6 +441,7 @@ public class VirtualNetwork {
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    metroCode: ").append(toIndentedString(metroCode)).append("\n");
     sb.append("    vxlan: ").append(toIndentedString(vxlan)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -457,29 +494,21 @@ public class VirtualNetwork {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VirtualNetwork is not found in the empty JSON string", VirtualNetwork.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VirtualNetwork.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VirtualNetwork` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `assigned_to`
-      if (jsonObj.getAsJsonObject("assigned_to") != null) {
+      if (jsonObj.get("assigned_to") != null && !jsonObj.get("assigned_to").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("assigned_to"));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // validate the optional field `facility`
-      if (jsonObj.getAsJsonObject("facility") != null) {
+      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("facility"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       JsonArray jsonArrayinstances = jsonObj.getAsJsonArray("instances");
@@ -495,14 +524,14 @@ public class VirtualNetwork {
         };
       }
       // validate the optional field `metal_gateway`
-      if (jsonObj.getAsJsonObject("metal_gateway") != null) {
+      if (jsonObj.get("metal_gateway") != null && !jsonObj.get("metal_gateway").isJsonNull()) {
         MetalGatewayLite.validateJsonObject(jsonObj.getAsJsonObject("metal_gateway"));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
-      if (jsonObj.get("metro_code") != null && !jsonObj.get("metro_code").isJsonPrimitive()) {
+      if ((jsonObj.get("metro_code") != null && !jsonObj.get("metro_code").isJsonNull()) && !jsonObj.get("metro_code").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro_code` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro_code").toString()));
       }
   }
@@ -522,6 +551,23 @@ public class VirtualNetwork {
            @Override
            public void write(JsonWriter out, VirtualNetwork value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -529,7 +575,25 @@ public class VirtualNetwork {
            public VirtualNetwork read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VirtualNetwork instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualNetworkCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualNetworkCreateInput.java
@@ -70,7 +70,7 @@ public class VirtualNetworkCreateInput {
   @SerializedName(SERIALIZED_NAME_VXLAN)
   private Integer vxlan;
 
-  public VirtualNetworkCreateInput() { 
+  public VirtualNetworkCreateInput() {
   }
 
   public VirtualNetworkCreateInput description(String description) {
@@ -187,6 +187,41 @@ public class VirtualNetworkCreateInput {
     this.vxlan = vxlan;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VirtualNetworkCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -202,12 +237,13 @@ public class VirtualNetworkCreateInput {
         Objects.equals(this.facility, virtualNetworkCreateInput.facility) &&
         Objects.equals(this.metro, virtualNetworkCreateInput.metro) &&
         Objects.equals(this.projectId, virtualNetworkCreateInput.projectId) &&
-        Objects.equals(this.vxlan, virtualNetworkCreateInput.vxlan);
+        Objects.equals(this.vxlan, virtualNetworkCreateInput.vxlan)&&
+        Objects.equals(this.additionalProperties, virtualNetworkCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, facility, metro, projectId, vxlan);
+    return Objects.hash(description, facility, metro, projectId, vxlan, additionalProperties);
   }
 
   @Override
@@ -219,6 +255,7 @@ public class VirtualNetworkCreateInput {
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    projectId: ").append(toIndentedString(projectId)).append("\n");
     sb.append("    vxlan: ").append(toIndentedString(vxlan)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -267,30 +304,22 @@ public class VirtualNetworkCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VirtualNetworkCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VirtualNetworkCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : VirtualNetworkCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonPrimitive()) {
+      if ((jsonObj.get("facility") != null && !jsonObj.get("facility").isJsonNull()) && !jsonObj.get("facility").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `facility` to be a primitive type in the JSON string but got `%s`", jsonObj.get("facility").toString()));
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonPrimitive()) {
+      if ((jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonNull()) && !jsonObj.get("project_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project_id").toString()));
       }
   }
@@ -310,6 +339,23 @@ public class VirtualNetworkCreateInput {
            @Override
            public void write(JsonWriter out, VirtualNetworkCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -317,7 +363,25 @@ public class VirtualNetworkCreateInput {
            public VirtualNetworkCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VirtualNetworkCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualNetworkList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VirtualNetworkList.java
@@ -56,7 +56,7 @@ public class VirtualNetworkList {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_NETWORKS)
   private List<VirtualNetwork> virtualNetworks = null;
 
-  public VirtualNetworkList() { 
+  public VirtualNetworkList() {
   }
 
   public VirtualNetworkList virtualNetworks(List<VirtualNetwork> virtualNetworks) {
@@ -89,6 +89,41 @@ public class VirtualNetworkList {
     this.virtualNetworks = virtualNetworks;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VirtualNetworkList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class VirtualNetworkList {
       return false;
     }
     VirtualNetworkList virtualNetworkList = (VirtualNetworkList) o;
-    return Objects.equals(this.virtualNetworks, virtualNetworkList.virtualNetworks);
+    return Objects.equals(this.virtualNetworks, virtualNetworkList.virtualNetworks)&&
+        Objects.equals(this.additionalProperties, virtualNetworkList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(virtualNetworks);
+    return Objects.hash(virtualNetworks, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class VirtualNetworkList {
     StringBuilder sb = new StringBuilder();
     sb.append("class VirtualNetworkList {\n");
     sb.append("    virtualNetworks: ").append(toIndentedString(virtualNetworks)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class VirtualNetworkList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VirtualNetworkList is not found in the empty JSON string", VirtualNetworkList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VirtualNetworkList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VirtualNetworkList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayvirtualNetworks = jsonObj.getAsJsonArray("virtual_networks");
       if (jsonArrayvirtualNetworks != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class VirtualNetworkList {
            @Override
            public void write(JsonWriter out, VirtualNetworkList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class VirtualNetworkList {
            public VirtualNetworkList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VirtualNetworkList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Vrf.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Vrf.java
@@ -91,7 +91,7 @@ public class Vrf {
   @SerializedName(SERIALIZED_NAME_HREF)
   private String href;
 
-  public Vrf() { 
+  public Vrf() {
   }
 
   public Vrf id(UUID id) {
@@ -308,6 +308,41 @@ public class Vrf {
     this.href = href;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public Vrf putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -327,12 +362,13 @@ public class Vrf {
         Objects.equals(this.project, vrf.project) &&
         Objects.equals(this.metro, vrf.metro) &&
         Objects.equals(this.createdBy, vrf.createdBy) &&
-        Objects.equals(this.href, vrf.href);
+        Objects.equals(this.href, vrf.href)&&
+        Objects.equals(this.additionalProperties, vrf.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, localAsn, ipRanges, project, metro, createdBy, href);
+    return Objects.hash(id, name, description, localAsn, ipRanges, project, metro, createdBy, href, additionalProperties);
   }
 
   @Override
@@ -348,6 +384,7 @@ public class Vrf {
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    createdBy: ").append(toIndentedString(createdBy)).append("\n");
     sb.append("    href: ").append(toIndentedString(href)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -398,40 +435,32 @@ public class Vrf {
           throw new IllegalArgumentException(String.format("The required field(s) %s in Vrf is not found in the empty JSON string", Vrf.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!Vrf.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Vrf` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonArray()) {
+      if ((jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonNull()) && !jsonObj.get("ip_ranges").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_ranges` to be an array in the JSON string but got `%s`", jsonObj.get("ip_ranges").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Project.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
       // validate the optional field `metro`
-      if (jsonObj.getAsJsonObject("metro") != null) {
+      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) {
         Metro.validateJsonObject(jsonObj.getAsJsonObject("metro"));
       }
       // validate the optional field `created_by`
-      if (jsonObj.getAsJsonObject("created_by") != null) {
+      if (jsonObj.get("created_by") != null && !jsonObj.get("created_by").isJsonNull()) {
         User.validateJsonObject(jsonObj.getAsJsonObject("created_by"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
   }
@@ -451,6 +480,23 @@ public class Vrf {
            @Override
            public void write(JsonWriter out, Vrf value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -458,7 +504,25 @@ public class Vrf {
            public Vrf read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             Vrf instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfCreateInput.java
@@ -76,7 +76,7 @@ public class VrfCreateInput {
   @SerializedName(SERIALIZED_NAME_PROJECT_ID)
   private UUID projectId;
 
-  public VrfCreateInput() { 
+  public VrfCreateInput() {
   }
 
   public VrfCreateInput description(String description) {
@@ -224,6 +224,41 @@ public class VrfCreateInput {
     this.projectId = projectId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -240,12 +275,13 @@ public class VrfCreateInput {
         Objects.equals(this.localAsn, vrfCreateInput.localAsn) &&
         Objects.equals(this.metro, vrfCreateInput.metro) &&
         Objects.equals(this.name, vrfCreateInput.name) &&
-        Objects.equals(this.projectId, vrfCreateInput.projectId);
+        Objects.equals(this.projectId, vrfCreateInput.projectId)&&
+        Objects.equals(this.additionalProperties, vrfCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, ipRanges, localAsn, metro, name, projectId);
+    return Objects.hash(description, ipRanges, localAsn, metro, name, projectId, additionalProperties);
   }
 
   @Override
@@ -258,6 +294,7 @@ public class VrfCreateInput {
     sb.append("    metro: ").append(toIndentedString(metro)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    projectId: ").append(toIndentedString(projectId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -309,34 +346,26 @@ public class VrfCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : VrfCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonArray()) {
+      if ((jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonNull()) && !jsonObj.get("ip_ranges").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_ranges` to be an array in the JSON string but got `%s`", jsonObj.get("ip_ranges").toString()));
       }
-      if (jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonPrimitive()) {
+      if ((jsonObj.get("metro") != null && !jsonObj.get("metro").isJsonNull()) && !jsonObj.get("metro").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metro` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metro").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonPrimitive()) {
+      if ((jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonNull()) && !jsonObj.get("project_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project_id").toString()));
       }
   }
@@ -356,6 +385,23 @@ public class VrfCreateInput {
            @Override
            public void write(JsonWriter out, VrfCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -363,7 +409,25 @@ public class VrfCreateInput {
            public VrfCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservation.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservation.java
@@ -117,7 +117,7 @@ public class VrfIpReservation {
   @SerializedName(SERIALIZED_NAME_VRF)
   private Vrf vrf;
 
-  public VrfIpReservation() { 
+  public VrfIpReservation() {
   }
 
   public VrfIpReservation addressFamily(Integer addressFamily) {
@@ -472,6 +472,41 @@ public class VrfIpReservation {
     this.vrf = vrf;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfIpReservation putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -497,12 +532,13 @@ public class VrfIpReservation {
         Objects.equals(this.state, vrfIpReservation.state) &&
         Objects.equals(this.tags, vrfIpReservation.tags) &&
         Objects.equals(this.type, vrfIpReservation.type) &&
-        Objects.equals(this.vrf, vrfIpReservation.vrf);
+        Objects.equals(this.vrf, vrfIpReservation.vrf)&&
+        Objects.equals(this.additionalProperties, vrfIpReservation.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressFamily, cidr, createdAt, createdBy, details, href, id, metalGateway, netmask, network, project, state, tags, type, vrf);
+    return Objects.hash(addressFamily, cidr, createdAt, createdBy, details, href, id, metalGateway, netmask, network, project, state, tags, type, vrf, additionalProperties);
   }
 
   @Override
@@ -524,6 +560,7 @@ public class VrfIpReservation {
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    vrf: ").append(toIndentedString(vrf)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -580,53 +617,45 @@ public class VrfIpReservation {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VrfIpReservation is not found in the empty JSON string", VrfIpReservation.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfIpReservation.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfIpReservation` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `created_by`
-      if (jsonObj.getAsJsonObject("created_by") != null) {
+      if (jsonObj.get("created_by") != null && !jsonObj.get("created_by").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("created_by"));
       }
-      if (jsonObj.get("details") != null && !jsonObj.get("details").isJsonPrimitive()) {
+      if ((jsonObj.get("details") != null && !jsonObj.get("details").isJsonNull()) && !jsonObj.get("details").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `details` to be a primitive type in the JSON string but got `%s`", jsonObj.get("details").toString()));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `metal_gateway`
-      if (jsonObj.getAsJsonObject("metal_gateway") != null) {
+      if (jsonObj.get("metal_gateway") != null && !jsonObj.get("metal_gateway").isJsonNull()) {
         MetalGatewayLite.validateJsonObject(jsonObj.getAsJsonObject("metal_gateway"));
       }
-      if (jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonPrimitive()) {
+      if ((jsonObj.get("netmask") != null && !jsonObj.get("netmask").isJsonNull()) && !jsonObj.get("netmask").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `netmask` to be a primitive type in the JSON string but got `%s`", jsonObj.get("netmask").toString()));
       }
-      if (jsonObj.get("network") != null && !jsonObj.get("network").isJsonPrimitive()) {
+      if ((jsonObj.get("network") != null && !jsonObj.get("network").isJsonNull()) && !jsonObj.get("network").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `network` to be a primitive type in the JSON string but got `%s`", jsonObj.get("network").toString()));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Project.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
       // validate the optional field `vrf`
-      if (jsonObj.getAsJsonObject("vrf") != null) {
+      if (jsonObj.get("vrf") != null && !jsonObj.get("vrf").isJsonNull()) {
         Vrf.validateJsonObject(jsonObj.getAsJsonObject("vrf"));
       }
   }
@@ -646,6 +675,23 @@ public class VrfIpReservation {
            @Override
            public void write(JsonWriter out, VrfIpReservation value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -653,7 +699,25 @@ public class VrfIpReservation {
            public VrfIpReservation read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfIpReservation instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservationCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservationCreateInput.java
@@ -80,7 +80,7 @@ public class VrfIpReservationCreateInput {
   @SerializedName(SERIALIZED_NAME_VRF_ID)
   private UUID vrfId;
 
-  public VrfIpReservationCreateInput() { 
+  public VrfIpReservationCreateInput() {
   }
 
   public VrfIpReservationCreateInput cidr(Integer cidr) {
@@ -251,6 +251,41 @@ public class VrfIpReservationCreateInput {
     this.vrfId = vrfId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfIpReservationCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -268,12 +303,13 @@ public class VrfIpReservationCreateInput {
         Objects.equals(this.network, vrfIpReservationCreateInput.network) &&
         Objects.equals(this.tags, vrfIpReservationCreateInput.tags) &&
         Objects.equals(this.type, vrfIpReservationCreateInput.type) &&
-        Objects.equals(this.vrfId, vrfIpReservationCreateInput.vrfId);
+        Objects.equals(this.vrfId, vrfIpReservationCreateInput.vrfId)&&
+        Objects.equals(this.additionalProperties, vrfIpReservationCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(cidr, customdata, details, network, tags, type, vrfId);
+    return Objects.hash(cidr, customdata, details, network, tags, type, vrfId, additionalProperties);
   }
 
   @Override
@@ -287,6 +323,7 @@ public class VrfIpReservationCreateInput {
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    vrfId: ").append(toIndentedString(vrfId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -340,34 +377,26 @@ public class VrfIpReservationCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfIpReservationCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfIpReservationCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : VrfIpReservationCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("details") != null && !jsonObj.get("details").isJsonPrimitive()) {
+      if ((jsonObj.get("details") != null && !jsonObj.get("details").isJsonNull()) && !jsonObj.get("details").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `details` to be a primitive type in the JSON string but got `%s`", jsonObj.get("details").toString()));
       }
-      if (jsonObj.get("network") != null && !jsonObj.get("network").isJsonPrimitive()) {
+      if ((jsonObj.get("network") != null && !jsonObj.get("network").isJsonNull()) && !jsonObj.get("network").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `network` to be a primitive type in the JSON string but got `%s`", jsonObj.get("network").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonPrimitive()) {
+      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
-      if (jsonObj.get("vrf_id") != null && !jsonObj.get("vrf_id").isJsonPrimitive()) {
+      if ((jsonObj.get("vrf_id") != null && !jsonObj.get("vrf_id").isJsonNull()) && !jsonObj.get("vrf_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `vrf_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("vrf_id").toString()));
       }
   }
@@ -387,6 +416,23 @@ public class VrfIpReservationCreateInput {
            @Override
            public void write(JsonWriter out, VrfIpReservationCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -394,7 +440,25 @@ public class VrfIpReservationCreateInput {
            public VrfIpReservationCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfIpReservationCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservationList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservationList.java
@@ -56,7 +56,7 @@ public class VrfIpReservationList {
   @SerializedName(SERIALIZED_NAME_IP_ADDRESSES)
   private List<VrfIpReservation> ipAddresses = null;
 
-  public VrfIpReservationList() { 
+  public VrfIpReservationList() {
   }
 
   public VrfIpReservationList ipAddresses(List<VrfIpReservation> ipAddresses) {
@@ -89,6 +89,41 @@ public class VrfIpReservationList {
     this.ipAddresses = ipAddresses;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfIpReservationList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class VrfIpReservationList {
       return false;
     }
     VrfIpReservationList vrfIpReservationList = (VrfIpReservationList) o;
-    return Objects.equals(this.ipAddresses, vrfIpReservationList.ipAddresses);
+    return Objects.equals(this.ipAddresses, vrfIpReservationList.ipAddresses)&&
+        Objects.equals(this.additionalProperties, vrfIpReservationList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ipAddresses);
+    return Objects.hash(ipAddresses, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class VrfIpReservationList {
     StringBuilder sb = new StringBuilder();
     sb.append("class VrfIpReservationList {\n");
     sb.append("    ipAddresses: ").append(toIndentedString(ipAddresses)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class VrfIpReservationList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VrfIpReservationList is not found in the empty JSON string", VrfIpReservationList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfIpReservationList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfIpReservationList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayipAddresses = jsonObj.getAsJsonArray("ip_addresses");
       if (jsonArrayipAddresses != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class VrfIpReservationList {
            @Override
            public void write(JsonWriter out, VrfIpReservationList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class VrfIpReservationList {
            public VrfIpReservationList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfIpReservationList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfList.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfList.java
@@ -56,7 +56,7 @@ public class VrfList {
   @SerializedName(SERIALIZED_NAME_VRFS)
   private List<Vrf> vrfs = null;
 
-  public VrfList() { 
+  public VrfList() {
   }
 
   public VrfList vrfs(List<Vrf> vrfs) {
@@ -89,6 +89,41 @@ public class VrfList {
     this.vrfs = vrfs;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +135,13 @@ public class VrfList {
       return false;
     }
     VrfList vrfList = (VrfList) o;
-    return Objects.equals(this.vrfs, vrfList.vrfs);
+    return Objects.equals(this.vrfs, vrfList.vrfs)&&
+        Objects.equals(this.additionalProperties, vrfList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(vrfs);
+    return Objects.hash(vrfs, additionalProperties);
   }
 
   @Override
@@ -113,6 +149,7 @@ public class VrfList {
     StringBuilder sb = new StringBuilder();
     sb.append("class VrfList {\n");
     sb.append("    vrfs: ").append(toIndentedString(vrfs)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -155,14 +192,6 @@ public class VrfList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VrfList is not found in the empty JSON string", VrfList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfList` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       JsonArray jsonArrayvrfs = jsonObj.getAsJsonArray("vrfs");
       if (jsonArrayvrfs != null) {
         // ensure the json data is an array
@@ -192,6 +221,23 @@ public class VrfList {
            @Override
            public void write(JsonWriter out, VrfList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -199,7 +245,25 @@ public class VrfList {
            public VrfList read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfMetalGateway.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfMetalGateway.java
@@ -145,7 +145,7 @@ public class VrfMetalGateway {
   @SerializedName(SERIALIZED_NAME_VRF)
   private Vrf vrf;
 
-  public VrfMetalGateway() { 
+  public VrfMetalGateway() {
   }
 
   public VrfMetalGateway createdAt(OffsetDateTime createdAt) {
@@ -377,6 +377,41 @@ public class VrfMetalGateway {
     this.vrf = vrf;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfMetalGateway putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -397,12 +432,13 @@ public class VrfMetalGateway {
         Objects.equals(this.state, vrfMetalGateway.state) &&
         Objects.equals(this.updatedAt, vrfMetalGateway.updatedAt) &&
         Objects.equals(this.virtualNetwork, vrfMetalGateway.virtualNetwork) &&
-        Objects.equals(this.vrf, vrfMetalGateway.vrf);
+        Objects.equals(this.vrf, vrfMetalGateway.vrf)&&
+        Objects.equals(this.additionalProperties, vrfMetalGateway.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(createdAt, createdBy, href, id, ipReservation, project, state, updatedAt, virtualNetwork, vrf);
+    return Objects.hash(createdAt, createdBy, href, id, ipReservation, project, state, updatedAt, virtualNetwork, vrf, additionalProperties);
   }
 
   @Override
@@ -419,6 +455,7 @@ public class VrfMetalGateway {
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    virtualNetwork: ").append(toIndentedString(virtualNetwork)).append("\n");
     sb.append("    vrf: ").append(toIndentedString(vrf)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -470,41 +507,33 @@ public class VrfMetalGateway {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VrfMetalGateway is not found in the empty JSON string", VrfMetalGateway.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfMetalGateway.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfMetalGateway` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
       // validate the optional field `created_by`
-      if (jsonObj.getAsJsonObject("created_by") != null) {
+      if (jsonObj.get("created_by") != null && !jsonObj.get("created_by").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("created_by"));
       }
-      if (jsonObj.get("href") != null && !jsonObj.get("href").isJsonPrimitive()) {
+      if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
       // validate the optional field `ip_reservation`
-      if (jsonObj.getAsJsonObject("ip_reservation") != null) {
+      if (jsonObj.get("ip_reservation") != null && !jsonObj.get("ip_reservation").isJsonNull()) {
         VrfIpReservation.validateJsonObject(jsonObj.getAsJsonObject("ip_reservation"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Project.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonPrimitive()) {
+      if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
       }
       // validate the optional field `virtual_network`
-      if (jsonObj.getAsJsonObject("virtual_network") != null) {
+      if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {
         VirtualNetwork.validateJsonObject(jsonObj.getAsJsonObject("virtual_network"));
       }
       // validate the optional field `vrf`
-      if (jsonObj.getAsJsonObject("vrf") != null) {
+      if (jsonObj.get("vrf") != null && !jsonObj.get("vrf").isJsonNull()) {
         Vrf.validateJsonObject(jsonObj.getAsJsonObject("vrf"));
       }
   }
@@ -524,6 +553,23 @@ public class VrfMetalGateway {
            @Override
            public void write(JsonWriter out, VrfMetalGateway value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -531,7 +577,25 @@ public class VrfMetalGateway {
            public VrfMetalGateway read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfMetalGateway instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfMetalGatewayCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfMetalGatewayCreateInput.java
@@ -58,7 +58,7 @@ public class VrfMetalGatewayCreateInput {
   @SerializedName(SERIALIZED_NAME_VIRTUAL_NETWORK_ID)
   private UUID virtualNetworkId;
 
-  public VrfMetalGatewayCreateInput() { 
+  public VrfMetalGatewayCreateInput() {
   }
 
   public VrfMetalGatewayCreateInput ipReservationId(UUID ipReservationId) {
@@ -106,6 +106,41 @@ public class VrfMetalGatewayCreateInput {
     this.virtualNetworkId = virtualNetworkId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfMetalGatewayCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -118,12 +153,13 @@ public class VrfMetalGatewayCreateInput {
     }
     VrfMetalGatewayCreateInput vrfMetalGatewayCreateInput = (VrfMetalGatewayCreateInput) o;
     return Objects.equals(this.ipReservationId, vrfMetalGatewayCreateInput.ipReservationId) &&
-        Objects.equals(this.virtualNetworkId, vrfMetalGatewayCreateInput.virtualNetworkId);
+        Objects.equals(this.virtualNetworkId, vrfMetalGatewayCreateInput.virtualNetworkId)&&
+        Objects.equals(this.additionalProperties, vrfMetalGatewayCreateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ipReservationId, virtualNetworkId);
+    return Objects.hash(ipReservationId, virtualNetworkId, additionalProperties);
   }
 
   @Override
@@ -132,6 +168,7 @@ public class VrfMetalGatewayCreateInput {
     sb.append("class VrfMetalGatewayCreateInput {\n");
     sb.append("    ipReservationId: ").append(toIndentedString(ipReservationId)).append("\n");
     sb.append("    virtualNetworkId: ").append(toIndentedString(virtualNetworkId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -178,24 +215,16 @@ public class VrfMetalGatewayCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfMetalGatewayCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfMetalGatewayCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : VrfMetalGatewayCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("ip_reservation_id") != null && !jsonObj.get("ip_reservation_id").isJsonPrimitive()) {
+      if ((jsonObj.get("ip_reservation_id") != null && !jsonObj.get("ip_reservation_id").isJsonNull()) && !jsonObj.get("ip_reservation_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_reservation_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("ip_reservation_id").toString()));
       }
-      if (jsonObj.get("virtual_network_id") != null && !jsonObj.get("virtual_network_id").isJsonPrimitive()) {
+      if ((jsonObj.get("virtual_network_id") != null && !jsonObj.get("virtual_network_id").isJsonNull()) && !jsonObj.get("virtual_network_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `virtual_network_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("virtual_network_id").toString()));
       }
   }
@@ -215,6 +244,23 @@ public class VrfMetalGatewayCreateInput {
            @Override
            public void write(JsonWriter out, VrfMetalGatewayCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -222,7 +268,25 @@ public class VrfMetalGatewayCreateInput {
            public VrfMetalGatewayCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfMetalGatewayCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfUpdateInput.java
@@ -67,7 +67,7 @@ public class VrfUpdateInput {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
-  public VrfUpdateInput() { 
+  public VrfUpdateInput() {
   }
 
   public VrfUpdateInput description(String description) {
@@ -169,6 +169,41 @@ public class VrfUpdateInput {
     this.name = name;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -183,12 +218,13 @@ public class VrfUpdateInput {
     return Objects.equals(this.description, vrfUpdateInput.description) &&
         Objects.equals(this.ipRanges, vrfUpdateInput.ipRanges) &&
         Objects.equals(this.localAsn, vrfUpdateInput.localAsn) &&
-        Objects.equals(this.name, vrfUpdateInput.name);
+        Objects.equals(this.name, vrfUpdateInput.name)&&
+        Objects.equals(this.additionalProperties, vrfUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, ipRanges, localAsn, name);
+    return Objects.hash(description, ipRanges, localAsn, name, additionalProperties);
   }
 
   @Override
@@ -199,6 +235,7 @@ public class VrfUpdateInput {
     sb.append("    ipRanges: ").append(toIndentedString(ipRanges)).append("\n");
     sb.append("    localAsn: ").append(toIndentedString(localAsn)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -244,22 +281,14 @@ public class VrfUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VrfUpdateInput is not found in the empty JSON string", VrfUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonArray()) {
+      if ((jsonObj.get("ip_ranges") != null && !jsonObj.get("ip_ranges").isJsonNull()) && !jsonObj.get("ip_ranges").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_ranges` to be an array in the JSON string but got `%s`", jsonObj.get("ip_ranges").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
   }
@@ -279,6 +308,23 @@ public class VrfUpdateInput {
            @Override
            public void write(JsonWriter out, VrfUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -286,7 +332,25 @@ public class VrfUpdateInput {
            public VrfUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuit.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuit.java
@@ -114,7 +114,7 @@ public class VrfVirtualCircuit {
   @SerializedName(SERIALIZED_NAME_VRF)
   private Vrf vrf;
 
-  public VrfVirtualCircuit() { 
+  public VrfVirtualCircuit() {
   }
 
   public VrfVirtualCircuit customerIp(String customerIp) {
@@ -469,6 +469,41 @@ public class VrfVirtualCircuit {
     this.vrf = vrf;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfVirtualCircuit putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -494,12 +529,13 @@ public class VrfVirtualCircuit {
         Objects.equals(this.status, vrfVirtualCircuit.status) &&
         Objects.equals(this.subnet, vrfVirtualCircuit.subnet) &&
         Objects.equals(this.tags, vrfVirtualCircuit.tags) &&
-        Objects.equals(this.vrf, vrfVirtualCircuit.vrf);
+        Objects.equals(this.vrf, vrfVirtualCircuit.vrf)&&
+        Objects.equals(this.additionalProperties, vrfVirtualCircuit.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(customerIp, description, id, md5, metalIp, name, port, nniVlan, peerAsn, project, speed, status, subnet, tags, vrf);
+    return Objects.hash(customerIp, description, id, md5, metalIp, name, port, nniVlan, peerAsn, project, speed, status, subnet, tags, vrf, additionalProperties);
   }
 
   @Override
@@ -521,6 +557,7 @@ public class VrfVirtualCircuit {
     sb.append("    subnet: ").append(toIndentedString(subnet)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    vrf: ").append(toIndentedString(vrf)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -577,52 +614,44 @@ public class VrfVirtualCircuit {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VrfVirtualCircuit is not found in the empty JSON string", VrfVirtualCircuit.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfVirtualCircuit.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfVirtualCircuit` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("customer_ip") != null && !jsonObj.get("customer_ip").isJsonPrimitive()) {
+      if ((jsonObj.get("customer_ip") != null && !jsonObj.get("customer_ip").isJsonNull()) && !jsonObj.get("customer_ip").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `customer_ip` to be a primitive type in the JSON string but got `%s`", jsonObj.get("customer_ip").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("id") != null && !jsonObj.get("id").isJsonPrimitive()) {
+      if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("id").toString()));
       }
-      if (jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonPrimitive()) {
+      if ((jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonNull()) && !jsonObj.get("md5").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `md5` to be a primitive type in the JSON string but got `%s`", jsonObj.get("md5").toString()));
       }
-      if (jsonObj.get("metal_ip") != null && !jsonObj.get("metal_ip").isJsonPrimitive()) {
+      if ((jsonObj.get("metal_ip") != null && !jsonObj.get("metal_ip").isJsonNull()) && !jsonObj.get("metal_ip").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metal_ip` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metal_ip").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
       // validate the optional field `port`
-      if (jsonObj.getAsJsonObject("port") != null) {
+      if (jsonObj.get("port") != null && !jsonObj.get("port").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("port"));
       }
       // validate the optional field `project`
-      if (jsonObj.getAsJsonObject("project") != null) {
+      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) {
         Href.validateJsonObject(jsonObj.getAsJsonObject("project"));
       }
-      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonPrimitive()) {
+      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
-      if (jsonObj.get("subnet") != null && !jsonObj.get("subnet").isJsonPrimitive()) {
+      if ((jsonObj.get("subnet") != null && !jsonObj.get("subnet").isJsonNull()) && !jsonObj.get("subnet").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `subnet` to be a primitive type in the JSON string but got `%s`", jsonObj.get("subnet").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       // validate the optional field `vrf`
-      if (jsonObj.getAsJsonObject("vrf") != null) {
+      if (jsonObj.get("vrf") != null && !jsonObj.get("vrf").isJsonNull()) {
         Vrf.validateJsonObject(jsonObj.getAsJsonObject("vrf"));
       }
   }
@@ -642,6 +671,23 @@ public class VrfVirtualCircuit {
            @Override
            public void write(JsonWriter out, VrfVirtualCircuit value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -649,7 +695,25 @@ public class VrfVirtualCircuit {
            public VrfVirtualCircuit read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfVirtualCircuit instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuitCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuitCreateInput.java
@@ -101,7 +101,7 @@ public class VrfVirtualCircuitCreateInput {
   @SerializedName(SERIALIZED_NAME_VRF)
   private UUID vrf;
 
-  public VrfVirtualCircuitCreateInput() { 
+  public VrfVirtualCircuitCreateInput() {
   }
 
   public VrfVirtualCircuitCreateInput customerIp(String customerIp) {
@@ -389,6 +389,41 @@ public class VrfVirtualCircuitCreateInput {
     this.vrf = vrf;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfVirtualCircuitCreateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -411,7 +446,8 @@ public class VrfVirtualCircuitCreateInput {
         Objects.equals(this.speed, vrfVirtualCircuitCreateInput.speed) &&
         Objects.equals(this.subnet, vrfVirtualCircuitCreateInput.subnet) &&
         Objects.equals(this.tags, vrfVirtualCircuitCreateInput.tags) &&
-        Objects.equals(this.vrf, vrfVirtualCircuitCreateInput.vrf);
+        Objects.equals(this.vrf, vrfVirtualCircuitCreateInput.vrf)&&
+        Objects.equals(this.additionalProperties, vrfVirtualCircuitCreateInput.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -420,7 +456,7 @@ public class VrfVirtualCircuitCreateInput {
 
   @Override
   public int hashCode() {
-    return Objects.hash(customerIp, description, md5, metalIp, name, nniVlan, peerAsn, project, speed, subnet, tags, vrf);
+    return Objects.hash(customerIp, description, md5, metalIp, name, nniVlan, peerAsn, project, speed, subnet, tags, vrf, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -446,6 +482,7 @@ public class VrfVirtualCircuitCreateInput {
     sb.append("    subnet: ").append(toIndentedString(subnet)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    vrf: ").append(toIndentedString(vrf)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -505,46 +542,38 @@ public class VrfVirtualCircuitCreateInput {
         }
       }
 
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfVirtualCircuitCreateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfVirtualCircuitCreateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : VrfVirtualCircuitCreateInput.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
       }
-      if (jsonObj.get("customer_ip") != null && !jsonObj.get("customer_ip").isJsonPrimitive()) {
+      if ((jsonObj.get("customer_ip") != null && !jsonObj.get("customer_ip").isJsonNull()) && !jsonObj.get("customer_ip").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `customer_ip` to be a primitive type in the JSON string but got `%s`", jsonObj.get("customer_ip").toString()));
       }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonPrimitive()) {
+      if ((jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonNull()) && !jsonObj.get("md5").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `md5` to be a primitive type in the JSON string but got `%s`", jsonObj.get("md5").toString()));
       }
-      if (jsonObj.get("metal_ip") != null && !jsonObj.get("metal_ip").isJsonPrimitive()) {
+      if ((jsonObj.get("metal_ip") != null && !jsonObj.get("metal_ip").isJsonNull()) && !jsonObj.get("metal_ip").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `metal_ip` to be a primitive type in the JSON string but got `%s`", jsonObj.get("metal_ip").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("project") != null && !jsonObj.get("project").isJsonPrimitive()) {
+      if ((jsonObj.get("project") != null && !jsonObj.get("project").isJsonNull()) && !jsonObj.get("project").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project").toString()));
       }
-      if (jsonObj.get("subnet") != null && !jsonObj.get("subnet").isJsonPrimitive()) {
+      if ((jsonObj.get("subnet") != null && !jsonObj.get("subnet").isJsonNull()) && !jsonObj.get("subnet").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `subnet` to be a primitive type in the JSON string but got `%s`", jsonObj.get("subnet").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
-      if (jsonObj.get("vrf") != null && !jsonObj.get("vrf").isJsonPrimitive()) {
+      if ((jsonObj.get("vrf") != null && !jsonObj.get("vrf").isJsonNull()) && !jsonObj.get("vrf").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `vrf` to be a primitive type in the JSON string but got `%s`", jsonObj.get("vrf").toString()));
       }
   }
@@ -564,6 +593,23 @@ public class VrfVirtualCircuitCreateInput {
            @Override
            public void write(JsonWriter out, VrfVirtualCircuitCreateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -571,7 +617,25 @@ public class VrfVirtualCircuitCreateInput {
            public VrfVirtualCircuitCreateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfVirtualCircuitCreateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuitUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuitUpdateInput.java
@@ -67,7 +67,7 @@ public class VrfVirtualCircuitUpdateInput {
   @SerializedName(SERIALIZED_NAME_TAGS)
   private List<String> tags = null;
 
-  public VrfVirtualCircuitUpdateInput() { 
+  public VrfVirtualCircuitUpdateInput() {
   }
 
   public VrfVirtualCircuitUpdateInput description(String description) {
@@ -169,6 +169,41 @@ public class VrfVirtualCircuitUpdateInput {
     this.tags = tags;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   */
+  public VrfVirtualCircuitUpdateInput putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -183,12 +218,13 @@ public class VrfVirtualCircuitUpdateInput {
     return Objects.equals(this.description, vrfVirtualCircuitUpdateInput.description) &&
         Objects.equals(this.name, vrfVirtualCircuitUpdateInput.name) &&
         Objects.equals(this.speed, vrfVirtualCircuitUpdateInput.speed) &&
-        Objects.equals(this.tags, vrfVirtualCircuitUpdateInput.tags);
+        Objects.equals(this.tags, vrfVirtualCircuitUpdateInput.tags)&&
+        Objects.equals(this.additionalProperties, vrfVirtualCircuitUpdateInput.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, name, speed, tags);
+    return Objects.hash(description, name, speed, tags, additionalProperties);
   }
 
   @Override
@@ -199,6 +235,7 @@ public class VrfVirtualCircuitUpdateInput {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    speed: ").append(toIndentedString(speed)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -244,25 +281,17 @@ public class VrfVirtualCircuitUpdateInput {
           throw new IllegalArgumentException(String.format("The required field(s) %s in VrfVirtualCircuitUpdateInput is not found in the empty JSON string", VrfVirtualCircuitUpdateInput.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Entry<String, JsonElement> entry : entries) {
-        if (!VrfVirtualCircuitUpdateInput.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `VrfVirtualCircuitUpdateInput` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
-        }
-      }
-      if (jsonObj.get("description") != null && !jsonObj.get("description").isJsonPrimitive()) {
+      if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));
       }
-      if (jsonObj.get("name") != null && !jsonObj.get("name").isJsonPrimitive()) {
+      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if (jsonObj.get("speed") != null && !jsonObj.get("speed").isJsonPrimitive()) {
+      if ((jsonObj.get("speed") != null && !jsonObj.get("speed").isJsonNull()) && !jsonObj.get("speed").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `speed` to be a primitive type in the JSON string but got `%s`", jsonObj.get("speed").toString()));
       }
       // ensure the json data is an array
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonArray()) {
+      if ((jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
   }
@@ -282,6 +311,23 @@ public class VrfVirtualCircuitUpdateInput {
            @Override
            public void write(JsonWriter out, VrfVirtualCircuitUpdateInput value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additonal properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -289,7 +335,25 @@ public class VrfVirtualCircuitUpdateInput {
            public VrfVirtualCircuitUpdateInput read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
-             return thisAdapter.fromJsonTree(jsonObj);
+             // store additional fields in the deserialized instance
+             VrfVirtualCircuitUpdateInput instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else { // non-primitive type
+                   instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/AuthTokenProjectTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/AuthTokenProjectTest.java
@@ -14,7 +14,6 @@
 package com.equinix.openapi.metal.v1.model;
 
 import com.equinix.openapi.metal.v1.model.Href;
-import com.equinix.openapi.metal.v1.model.Project;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/AuthTokenUserTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/AuthTokenUserTest.java
@@ -14,7 +14,6 @@
 package com.equinix.openapi.metal.v1.model;
 
 import com.equinix.openapi.metal.v1.model.Href;
-import com.equinix.openapi.metal.v1.model.User;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceCreatedByTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceCreatedByTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.UserLite;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceMetroTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceMetroTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceNetworkPortsTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceNetworkPortsTest.java
@@ -14,7 +14,6 @@
 package com.equinix.openapi.metal.v1.model;
 
 import com.equinix.openapi.metal.v1.model.Href;
-import com.equinix.openapi.metal.v1.model.Port;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceProjectLiteTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceProjectLiteTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.Href;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceProjectTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/DeviceProjectTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.Href;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/IPAssignmentMetroTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/IPAssignmentMetroTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/IPReservationFacilityTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/IPReservationFacilityTest.java
@@ -15,7 +15,6 @@ package com.equinix.openapi.metal.v1.model;
 
 import com.equinix.openapi.metal.v1.model.Address;
 import com.equinix.openapi.metal.v1.model.DeviceMetro;
-import com.equinix.openapi.metal.v1.model.Facility;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/IPReservationMetroTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/IPReservationMetroTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/InterconnectionMetroTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/InterconnectionMetroTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestMetroTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/model/SpotMarketRequestMetroTest.java
@@ -13,7 +13,6 @@
 
 package com.equinix.openapi.metal.v1.model;
 
-import com.equinix.openapi.metal.v1.model.Metro;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/spec/oas3.config.json
+++ b/spec/oas3.config.json
@@ -6,5 +6,6 @@
    "invokerPackage": "com.equinix.openapi",
    "modelPackage": "com.equinix.openapi.metal.v1.model",
    "apiPackage": "com.equinix.openapi.metal.v1.api",
-   "hideGenerationTimestamp": true
+   "hideGenerationTimestamp": true,
+   "disallowAdditionalPropertiesIfNotPresent": false
 }


### PR DESCRIPTION
This commit address following issues:

1. issue #16 - This to allow additional properties as OAS 3.0 is not in sync with server response and server might send more params than expected.
2. issue #15 - Nullable field failing when receiving null value because gson.JsonObject returns a instance of JsonNull rather then null. This issue is fixed in latest version of openapi generator.