### PR TITLE
Update maven-publish.yml

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,8 +5,9 @@ name: Maven publish package
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      # listen to tags that starts with the letter v as a convention to release tags.
+      - v*
 
 jobs:
   build:


### PR DESCRIPTION
Run maven publish package when a tag is created that starts with the letter `v` as a convention to release tags.