### PR TITLE
add docs/ format of the spec with individual schema and path files

### DIFF
--- a/equinix-openapi-metal/api/openapi.yaml
+++ b/equinix-openapi-metal/api/openapi.yaml
@@ -8943,6 +8943,32 @@ paths:
           format: uuid
           type: string
         style: simple
+      - description: |-
+          Nested attributes to include. Included objects will return their full
+          attributes. Attribute names can be dotted (up to 3 levels) to included deeply
+          nested objects.
+        explode: false
+        in: query
+        name: include
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: |-
+          Nested attributes to exclude. Excluded objects will return only the href
+          attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+          nested objects.
+        explode: false
+        in: query
+        name: exclude
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
       - description: Page to return
         explode: true
         in: query

--- a/equinix-openapi-metal/docs/MetalGatewaysApi.md
+++ b/equinix-openapi-metal/docs/MetalGatewaysApi.md
@@ -235,7 +235,7 @@ public class Example {
 
 <a name="findMetalGatewaysByProject"></a>
 # **findMetalGatewaysByProject**
-> MetalGatewayList findMetalGatewaysByProject(projectId, page, perPage)
+> MetalGatewayList findMetalGatewaysByProject(projectId, include, exclude, page, perPage)
 
 Returns all metal gateways for a project
 
@@ -264,10 +264,12 @@ public class Example {
 
     MetalGatewaysApi apiInstance = new MetalGatewaysApi(defaultClient);
     UUID projectId = UUID.randomUUID(); // UUID | Project UUID
+    List<String> include = Arrays.asList(); // List<String> | Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects.
+    List<String> exclude = Arrays.asList(); // List<String> | Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects.
     Integer page = 1; // Integer | Page to return
     Integer perPage = 10; // Integer | Items returned per page
     try {
-      MetalGatewayList result = apiInstance.findMetalGatewaysByProject(projectId, page, perPage);
+      MetalGatewayList result = apiInstance.findMetalGatewaysByProject(projectId, include, exclude, page, perPage);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling MetalGatewaysApi#findMetalGatewaysByProject");
@@ -285,6 +287,8 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **projectId** | **UUID**| Project UUID | |
+| **include** | [**List&lt;String&gt;**](String.md)| Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. | [optional] |
+| **exclude** | [**List&lt;String&gt;**](String.md)| Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. | [optional] |
 | **page** | **Integer**| Page to return | [optional] [default to 1] |
 | **perPage** | **Integer**| Items returned per page | [optional] [default to 10] |
 

--- a/equinix-openapi-metal/pom.xml
+++ b/equinix-openapi-metal/pom.xml
@@ -300,6 +300,7 @@
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable-version}</version>
         </dependency>
+
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/ApiClient.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/ApiClient.java
@@ -454,6 +454,18 @@ public class ApiClient {
     }
 
     /**
+     * Helper method to set credentials for AWSV4 Signature
+     *
+     * @param accessKey Access Key
+     * @param secretKey Secret Key
+     * @param region Region
+     * @param service Service to access to
+     */
+    public void setAWS4Configuration(String accessKey, String secretKey, String region, String service) {
+        throw new RuntimeException("No AWS4 authentication configured!");
+    }
+
+    /**
      * Set the User-Agent header's value (by adding to the default header map).
      *
      * @param userAgent HTTP request's user agent

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/api/MetalGatewaysApi.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/api/MetalGatewaysApi.java
@@ -515,6 +515,8 @@ public class MetalGatewaysApi {
     /**
      * Build call for findMetalGatewaysByProject
      * @param projectId Project UUID (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
      * @param page Page to return (optional, default to 1)
      * @param perPage Items returned per page (optional, default to 10)
      * @param _callback Callback for upload/download progress
@@ -528,7 +530,7 @@ public class MetalGatewaysApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findMetalGatewaysByProjectCall(UUID projectId, Integer page, Integer perPage, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call findMetalGatewaysByProjectCall(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -553,6 +555,14 @@ public class MetalGatewaysApi {
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (include != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "include", include));
+        }
+
+        if (exclude != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "exclude", exclude));
+        }
 
         if (page != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("page", page));
@@ -582,13 +592,13 @@ public class MetalGatewaysApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call findMetalGatewaysByProjectValidateBeforeCall(UUID projectId, Integer page, Integer perPage, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call findMetalGatewaysByProjectValidateBeforeCall(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage, final ApiCallback _callback) throws ApiException {
         // verify the required parameter 'projectId' is set
         if (projectId == null) {
             throw new ApiException("Missing the required parameter 'projectId' when calling findMetalGatewaysByProject(Async)");
         }
 
-        return findMetalGatewaysByProjectCall(projectId, page, perPage, _callback);
+        return findMetalGatewaysByProjectCall(projectId, include, exclude, page, perPage, _callback);
 
     }
 
@@ -596,6 +606,8 @@ public class MetalGatewaysApi {
      * Returns all metal gateways for a project
      * Return all metal gateways for a project
      * @param projectId Project UUID (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
      * @param page Page to return (optional, default to 1)
      * @param perPage Items returned per page (optional, default to 10)
      * @return MetalGatewayList
@@ -608,8 +620,8 @@ public class MetalGatewaysApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public MetalGatewayList findMetalGatewaysByProject(UUID projectId, Integer page, Integer perPage) throws ApiException {
-        ApiResponse<MetalGatewayList> localVarResp = findMetalGatewaysByProjectWithHttpInfo(projectId, page, perPage);
+    public MetalGatewayList findMetalGatewaysByProject(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage) throws ApiException {
+        ApiResponse<MetalGatewayList> localVarResp = findMetalGatewaysByProjectWithHttpInfo(projectId, include, exclude, page, perPage);
         return localVarResp.getData();
     }
 
@@ -617,6 +629,8 @@ public class MetalGatewaysApi {
      * Returns all metal gateways for a project
      * Return all metal gateways for a project
      * @param projectId Project UUID (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
      * @param page Page to return (optional, default to 1)
      * @param perPage Items returned per page (optional, default to 10)
      * @return ApiResponse&lt;MetalGatewayList&gt;
@@ -629,8 +643,8 @@ public class MetalGatewaysApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<MetalGatewayList> findMetalGatewaysByProjectWithHttpInfo(UUID projectId, Integer page, Integer perPage) throws ApiException {
-        okhttp3.Call localVarCall = findMetalGatewaysByProjectValidateBeforeCall(projectId, page, perPage, null);
+    public ApiResponse<MetalGatewayList> findMetalGatewaysByProjectWithHttpInfo(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage) throws ApiException {
+        okhttp3.Call localVarCall = findMetalGatewaysByProjectValidateBeforeCall(projectId, include, exclude, page, perPage, null);
         Type localVarReturnType = new TypeToken<MetalGatewayList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -639,6 +653,8 @@ public class MetalGatewaysApi {
      * Returns all metal gateways for a project (asynchronously)
      * Return all metal gateways for a project
      * @param projectId Project UUID (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
      * @param page Page to return (optional, default to 1)
      * @param perPage Items returned per page (optional, default to 10)
      * @param _callback The callback to be executed when the API call finishes
@@ -652,9 +668,9 @@ public class MetalGatewaysApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findMetalGatewaysByProjectAsync(UUID projectId, Integer page, Integer perPage, final ApiCallback<MetalGatewayList> _callback) throws ApiException {
+    public okhttp3.Call findMetalGatewaysByProjectAsync(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage, final ApiCallback<MetalGatewayList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = findMetalGatewaysByProjectValidateBeforeCall(projectId, page, perPage, _callback);
+        okhttp3.Call localVarCall = findMetalGatewaysByProjectValidateBeforeCall(projectId, include, exclude, page, perPage, _callback);
         Type localVarReturnType = new TypeToken<MetalGatewayList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/api/MetalGatewaysApiTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/api/MetalGatewaysApiTest.java
@@ -92,9 +92,11 @@ public class MetalGatewaysApiTest {
     @Test
     public void findMetalGatewaysByProjectTest() throws ApiException {
         UUID projectId = null;
+        List<String> include = null;
+        List<String> exclude = null;
         Integer page = null;
         Integer perPage = null;
-        MetalGatewayList response = api.findMetalGatewaysByProject(projectId, page, perPage);
+        MetalGatewayList response = api.findMetalGatewaysByProject(projectId, include, exclude, page, perPage);
         // TODO: test validations
     }
 

--- a/spec/docs/openapi/public/components/parameters/Exclude.yaml
+++ b/spec/docs/openapi/public/components/parameters/Exclude.yaml
@@ -1,0 +1,12 @@
+description: |-
+  Nested attributes to exclude. Excluded objects will return only the href
+  attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+  nested objects.
+in: query
+name: exclude
+schema:
+  items:
+    type: string
+  type: array
+style: form
+explode: false

--- a/spec/docs/openapi/public/components/parameters/Include.yaml
+++ b/spec/docs/openapi/public/components/parameters/Include.yaml
@@ -1,0 +1,12 @@
+description: |-
+  Nested attributes to include. Included objects will return their full
+  attributes. Attribute names can be dotted (up to 3 levels) to included deeply
+  nested objects.
+in: query
+name: include
+schema:
+  items:
+    type: string
+  type: array
+style: form
+explode: false

--- a/spec/docs/openapi/public/components/parameters/Page.yaml
+++ b/spec/docs/openapi/public/components/parameters/Page.yaml
@@ -1,0 +1,9 @@
+description: Page to return
+in: query
+name: page
+schema:
+  default: 1
+  format: int32
+  maximum: 100000
+  minimum: 1
+  type: integer

--- a/spec/docs/openapi/public/components/parameters/PerPage.yaml
+++ b/spec/docs/openapi/public/components/parameters/PerPage.yaml
@@ -1,0 +1,9 @@
+description: Items returned per page
+in: query
+name: per_page
+schema:
+  default: 10
+  format: int32
+  maximum: 1000
+  minimum: 1
+  type: integer

--- a/spec/docs/openapi/public/components/requestBodies/InterconnectionCreateInput.yaml
+++ b/spec/docs/openapi/public/components/requestBodies/InterconnectionCreateInput.yaml
@@ -1,0 +1,6 @@
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/InterconnectionCreateInput.yaml'
+description: Interconnection details
+required: true

--- a/spec/docs/openapi/public/components/requestBodies/InvitationInput.yaml
+++ b/spec/docs/openapi/public/components/requestBodies/InvitationInput.yaml
@@ -1,0 +1,6 @@
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/InvitationInput.yaml'
+description: Invitation to create
+required: true

--- a/spec/docs/openapi/public/components/requestBodies/PortAssignInput.yaml
+++ b/spec/docs/openapi/public/components/requestBodies/PortAssignInput.yaml
@@ -1,0 +1,6 @@
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/PortAssignInput.yaml'
+description: 'Virtual Network ID. May be the UUID of the Virtual Network record, or the VLAN value itself (ex: ''1001'').'
+required: true

--- a/spec/docs/openapi/public/components/requestBodies/SSHKeyCreateInput.yaml
+++ b/spec/docs/openapi/public/components/requestBodies/SSHKeyCreateInput.yaml
@@ -1,0 +1,6 @@
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/SSHKeyCreateInput.yaml'
+description: ssh key to create
+required: true

--- a/spec/docs/openapi/public/components/schemas/Address.yaml
+++ b/spec/docs/openapi/public/components/schemas/Address.yaml
@@ -1,0 +1,20 @@
+properties:
+  address:
+    type: string
+  address2:
+    type: string
+  city:
+    type: string
+  coordinates:
+    $ref: './Coordinates.yaml'
+  country:
+    type: string
+  state:
+    type: string
+  zip_code:
+    type: string
+required:
+- address
+- zip_code
+- country
+type: object

--- a/spec/docs/openapi/public/components/schemas/AuthToken.yaml
+++ b/spec/docs/openapi/public/components/schemas/AuthToken.yaml
@@ -1,0 +1,26 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  description:
+    description: Available only for API keys
+    type: string
+  id:
+    format: uuid
+    type: string
+  project:
+    allOf:
+    - $ref: './Project.yaml'
+    - description: Available only for project tokens
+  read_only:
+    type: boolean
+  token:
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  user:
+    allOf:
+    - $ref: './User.yaml'
+    - description: Available only for user tokens
+type: object

--- a/spec/docs/openapi/public/components/schemas/AuthTokenInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/AuthTokenInput.yaml
@@ -1,0 +1,6 @@
+properties:
+  description:
+    type: string
+  read_only:
+    type: boolean
+type: object

--- a/spec/docs/openapi/public/components/schemas/AuthTokenList.yaml
+++ b/spec/docs/openapi/public/components/schemas/AuthTokenList.yaml
@@ -1,0 +1,6 @@
+properties:
+  api_keys:
+    items:
+      $ref: './AuthToken.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/BGPSessionInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/BGPSessionInput.yaml
@@ -1,0 +1,13 @@
+properties:
+  address_family:
+    description: Address family for BGP session.
+    enum:
+    - ipv4
+    - ipv6
+    example: ipv4
+    type: string
+  default_route:
+    default: false
+    description: Set the default route policy.
+    type: boolean
+type: object

--- a/spec/docs/openapi/public/components/schemas/Batch.yaml
+++ b/spec/docs/openapi/public/components/schemas/Batch.yaml
@@ -1,0 +1,25 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  devices:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  error_messages:
+    items:
+      type: string
+    type: array
+  id:
+    format: uuid
+    type: string
+  project:
+    $ref: './Href.yaml'
+  quantity:
+    type: integer
+  state:
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/BatchesList.yaml
+++ b/spec/docs/openapi/public/components/schemas/BatchesList.yaml
@@ -1,0 +1,6 @@
+properties:
+  batches:
+    items:
+      $ref: './Batch.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/BgpConfig.yaml
+++ b/spec/docs/openapi/public/components/schemas/BgpConfig.yaml
@@ -1,0 +1,61 @@
+properties:
+  asn:
+    description: Autonomous System Number. ASN is required with Global BGP. With Local
+      BGP the private ASN, 65000, is assigned.
+    example: 65000
+    format: int32
+    type: integer
+  created_at:
+    format: date-time
+    type: string
+  deployment_type:
+    description: |
+      In a Local BGP deployment, a customer uses an internal ASN to control routes within a single Equinix Metal datacenter. This means that the routes are never advertised to the global Internet. Global BGP, on the other hand, requires a customer to have a registered ASN and IP space.
+    enum:
+    - global
+    - local
+    example: local
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  max_prefix:
+    default: 10
+    description: The maximum number of route filters allowed per server
+    type: integer
+  md5:
+    description: (Optional) Password for BGP session in plaintext (not a checksum)
+    nullable: true
+    type: string
+  project:
+    $ref: './Href.yaml'
+  ranges:
+    description: The IP block ranges associated to the ASN (Populated in Global BGP
+      only)
+    items:
+      $ref: './GlobalBgpRange.yaml'
+    type: array
+  requested_at:
+    format: date-time
+    type: string
+  route_object:
+    description: Specifies AS-MACRO (aka AS-SET) to use when building client route
+      filters
+    type: string
+  sessions:
+    description: The direct connections between neighboring routers that want to exchange
+      routing information.
+    items:
+      $ref: './BgpSession.yaml'
+    type: array
+  status:
+    description: Status of the BGP Config. Status "requested" is valid only with the
+      "global" deployment_type.
+    enum:
+    - requested
+    - enabled
+    - disabled
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/BgpConfigRequestInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/BgpConfigRequestInput.yaml
@@ -1,0 +1,13 @@
+properties:
+  asn:
+    type: integer
+  deployment_type:
+    type: string
+  md5:
+    type: string
+  use_case:
+    type: string
+required:
+- deployment_type
+- asn
+type: object

--- a/spec/docs/openapi/public/components/schemas/BgpNeighborData.yaml
+++ b/spec/docs/openapi/public/components/schemas/BgpNeighborData.yaml
@@ -1,0 +1,68 @@
+properties:
+  address_family:
+    description: Address Family for IP Address. Accepted values are 4 or 6
+    example: 4
+    format: integer
+    type: number
+  customer_as:
+    description: The customer's ASN. In a local BGP deployment, this will be an internal
+      ASN used to route within the data center. For a global BGP deployment, this
+      will be the your own ASN, configured when you set up BGP for your project.
+    example: 65000
+    format: integer
+    type: number
+  customer_ip:
+    description: The device's IP address. For an IPv4 BGP session, this is typically
+      the private bond0 address for the device.
+    example: 10.32.16.1 (IPv4) or 2604:1380:4111:2700::1 (IPv6)
+    type: string
+  md5_enabled:
+    description: True if an MD5 password is configured for the project.
+    type: boolean
+  md5_password:
+    description: The MD5 password configured for the project, if set.
+    type: string
+  multihop:
+    description: True when the BGP session should be configured as multihop.
+    type: boolean
+  peer_as:
+    description: The Peer ASN to use when configuring BGP on your device.
+    example: 65530
+    format: integer
+    type: number
+  peer_ips:
+    description: A list of one or more IP addresses to use for the Peer IP section
+      of your BGP configuration. For non-multihop sessions, this will typically be
+      a single gateway address for the device. For multihop sessions, it will be a
+      list of IPs.
+    example:
+    - 169.254.255.1
+    - 169.254.255.2
+    items:
+      type: string
+    type: array
+  routes_in:
+    description: A list of project subnets
+    items:
+      properties:
+        exact:
+          type: boolean
+        route:
+          description: A project network
+          example: 10.32.16.0/31
+          type: string
+      type: object
+    type: array
+  routes_out:
+    description: A list of outgoing routes. Only populated if the BGP session has
+      default route enabled.
+    items:
+      properties:
+        exact:
+          type: boolean
+        route:
+          example: 0.0.0.0/0
+          type: string
+      type: object
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/BgpSession.yaml
+++ b/spec/docs/openapi/public/components/schemas/BgpSession.yaml
@@ -1,0 +1,41 @@
+properties:
+  address_family:
+    enum:
+    - ipv4
+    - ipv6
+    type: string
+  created_at:
+    format: date-time
+    type: string
+  default_route:
+    type: boolean
+  device:
+    $ref: './Href.yaml'
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  learned_routes:
+    items:
+      description: IPv4 or IPv6 range
+      example: 10.32.16.0/31
+      type: string
+    type: array
+  status:
+    description: ' The status of the BGP Session. Multiple status values may be reported
+      when the device is connected to multiple switches, one value per switch. Each
+      status will start with "unknown" and progress to "up" or "down" depending on
+      the connected device. Subsequent "unknown" values indicate a problem acquiring
+      status from the switch. '
+    enum:
+    - unknown
+    - up
+    - down
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+required:
+- address_family
+type: object

--- a/spec/docs/openapi/public/components/schemas/BgpSessionList.yaml
+++ b/spec/docs/openapi/public/components/schemas/BgpSessionList.yaml
@@ -1,0 +1,6 @@
+properties:
+  bgp_sessions:
+    items:
+      $ref: './BgpSession.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/BgpSessionNeighbors.yaml
+++ b/spec/docs/openapi/public/components/schemas/BgpSessionNeighbors.yaml
@@ -1,0 +1,7 @@
+properties:
+  bgp_neighbors:
+    description: A list of BGP session neighbor data
+    items:
+      $ref: './BgpNeighborData.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/BondPortData.yaml
+++ b/spec/docs/openapi/public/components/schemas/BondPortData.yaml
@@ -1,0 +1,9 @@
+properties:
+  id:
+    description: ID of the bonding port
+    type: string
+    format: uuid
+  name:
+    description: Name of the port interface for the bond ("bond0")
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityCheckPerFacilityInfo.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityCheckPerFacilityInfo.yaml
@@ -1,0 +1,10 @@
+properties:
+  available:
+    type: boolean
+  facility:
+    type: string
+  plan:
+    type: string
+  quantity:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityCheckPerFacilityList.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityCheckPerFacilityList.yaml
@@ -1,0 +1,6 @@
+properties:
+  servers:
+    items:
+      $ref: './CapacityCheckPerFacilityInfo.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityCheckPerMetroInfo.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityCheckPerMetroInfo.yaml
@@ -1,0 +1,15 @@
+properties:
+  available:
+    description: Returns true if there is enough capacity in the metro to fulfill
+      the quantity set. Returns false if there is not enough.
+    type: boolean
+  metro:
+    description: The metro ID or code sent to check capacity.
+    type: string
+  plan:
+    description: The plan ID or slug sent to check capacity.
+    type: string
+  quantity:
+    description: The number of servers sent to check capacity.
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityCheckPerMetroList.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityCheckPerMetroList.yaml
@@ -1,0 +1,6 @@
+properties:
+  servers:
+    items:
+      $ref: './CapacityCheckPerMetroInfo.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityInput.yaml
@@ -1,0 +1,6 @@
+properties:
+  servers:
+    items:
+      $ref: './ServerInfo.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityLevelPerBaremetal.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityLevelPerBaremetal.yaml
@@ -1,0 +1,4 @@
+properties:
+  level:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityList.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityList.yaml
@@ -1,0 +1,4 @@
+properties:
+  capacity:
+    $ref: './CapacityReport.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityPerFacility.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityPerFacility.yaml
@@ -1,0 +1,20 @@
+properties:
+  baremetal_0:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  baremetal_1:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  baremetal_2:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  baremetal_2a:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  baremetal_2a2:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  baremetal_3:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  baremetal_s:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  c2.medium.x86:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+  m2.xlarge.x86:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityPerMetroInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityPerMetroInput.yaml
@@ -1,0 +1,6 @@
+properties:
+  servers:
+    items:
+      $ref: './MetroServerInfo.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityPerNewFacility.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityPerNewFacility.yaml
@@ -1,0 +1,4 @@
+properties:
+  baremetal_1e:
+    $ref: './CapacityLevelPerBaremetal.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/CapacityReport.yaml
+++ b/spec/docs/openapi/public/components/schemas/CapacityReport.yaml
@@ -1,0 +1,30 @@
+properties:
+  ams1:
+    $ref: './CapacityPerFacility.yaml'
+  atl1:
+    $ref: './CapacityPerNewFacility.yaml'
+  dfw1:
+    $ref: './CapacityPerNewFacility.yaml'
+  ewr1:
+    $ref: './CapacityPerFacility.yaml'
+  fra1:
+    $ref: './CapacityPerNewFacility.yaml'
+  iad1:
+    $ref: './CapacityPerNewFacility.yaml'
+  lax1:
+    $ref: './CapacityPerNewFacility.yaml'
+  nrt1:
+    $ref: './CapacityPerFacility.yaml'
+  ord1:
+    $ref: './CapacityPerNewFacility.yaml'
+  sea1:
+    $ref: './CapacityPerNewFacility.yaml'
+  sin1:
+    $ref: './CapacityPerNewFacility.yaml'
+  sjc1:
+    $ref: './CapacityPerFacility.yaml'
+  syd1:
+    $ref: './CapacityPerNewFacility.yaml'
+  yyz1:
+    $ref: './CapacityPerNewFacility.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/Coordinates.yaml
+++ b/spec/docs/openapi/public/components/schemas/Coordinates.yaml
@@ -1,0 +1,6 @@
+properties:
+  latitude:
+    type: string
+  longitude:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/CreateEmailInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/CreateEmailInput.yaml
@@ -1,0 +1,6 @@
+properties:
+  address:
+    type: string
+required:
+- address
+type: object

--- a/spec/docs/openapi/public/components/schemas/CreateSelfServiceReservationRequest.yaml
+++ b/spec/docs/openapi/public/components/schemas/CreateSelfServiceReservationRequest.yaml
@@ -1,0 +1,23 @@
+properties:
+  item:
+    items:
+      $ref: './SelfServiceReservationItemRequest.yaml'
+    type: array
+  notes:
+    type: string
+  period:
+    properties:
+      count:
+        enum:
+        - 12
+        - 36
+        type: number
+      unit:
+        enum:
+        - monthly
+        type: string
+    type: object
+  start_date:
+    format: date-time
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/Device.yaml
+++ b/spec/docs/openapi/public/components/schemas/Device.yaml
@@ -1,0 +1,151 @@
+properties:
+  always_pxe:
+    type: boolean
+  billing_cycle:
+    type: string
+  bonding_mode:
+    type: integer
+  created_at:
+    format: date-time
+    type: string
+  created_by:
+    allOf:
+    - $ref: './UserLite.yaml'
+    - description: The user that created the device.
+  customdata:
+    type: object
+  description:
+    type: string
+  facility:
+    $ref: './Facility.yaml'
+  hardware_reservation:
+    $ref: './Href.yaml'
+  hostname:
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  image_url:
+    type: string
+  ip_addresses:
+    items:
+      $ref: './IPAssignment.yaml'
+    type: array
+  ipxe_script_url:
+    type: string
+  iqn:
+    type: string
+  locked:
+    type: boolean
+  metro:
+    allOf:
+    - $ref: './Metro.yaml'
+    - description: The metro the facility is in
+  network_ports:
+    description:
+      By default, servers at Equinix Metal are configured in a “bonded” mode
+      using LACP (Link Aggregation Control Protocol). Each 2-NIC server is
+      configured with a single bond (namely bond0) with both interfaces eth0
+      and eth1 as members of the bond in a default Layer 3 mode. Some device
+      plans may have a different number of ports and bonds available.
+    type: array
+    items:
+      $ref: './Port.yaml'
+  operating_system:
+    $ref: './OperatingSystem.yaml'
+  actions:
+    description: Actions supported by the device instance.
+    items:
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+      type: object
+    type: array
+  plan:
+    $ref: './Plan.yaml'
+  project:
+    allOf:
+    - $ref: './Href.yaml'
+    - description: Full version of project object when included
+  project_lite:
+    allOf:
+    - $ref: './Href.yaml'
+    - description: Lite version of project object when included
+  provisioning_events:
+    items:
+      $ref: './Event.yaml'
+    type: array
+  provisioning_percentage:
+    description: Only visible while device provisioning
+    format: float
+    type: number
+  root_password:
+    description: Root password is automatically generated when server is provisioned
+      and it is removed after 24 hours
+    type: string
+  short_id:
+    type: string
+  spot_instance:
+    description: Whether or not the device is a spot instance.
+    type: boolean
+  spot_price_max:
+    description: |-
+      The maximum price per hour you are willing to pay to keep this spot
+      instance.  If you are outbid, the termination will be set allowing two
+      minutes before shutdown.
+    format: float
+    type: number
+  ssh_keys:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  state:
+    type: string
+    enum:
+      - active
+      - deleted
+      - deprovisioning
+      - failed
+      - inactive
+      - queued
+      - reinstalling
+      - post_provisioning
+      - powering_on
+      - powering_off
+      - provisioning
+  switch_uuid:
+    description: |-
+      Switch short id. This can be used to determine if two devices are
+      connected to the same switch, for example.
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+  termination_time:
+    description: |-
+      When the device will be terminated. This is commonly set in advance for
+      ephemeral spot market instances but this field may also be set with
+      on-demand and reservation instances to automatically delete the resource
+      at a given time. The termination time can also be used to release a
+      hardware reservation instance at a given time, keeping the reservation
+      open for other uses.  On a spot market device, the termination time will
+      be set automatically when outbid.
+    format: date-time
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  user:
+    type: string
+  userdata:
+    type: string
+  volumes:
+    items:
+      $ref: './Href.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/DeviceActionInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceActionInput.yaml
@@ -1,0 +1,30 @@
+type: object
+required:
+- type
+properties:
+  type:
+    description: Action to perform. See Device.actions for possible actions.
+    type: string
+    enum:
+    - power_on
+    - power_off
+    - reboot
+    - rescue
+    - reinstall
+  force_delete:
+    description: May be required to perform actions under certain conditions
+    type: boolean
+  deprovision_fast:
+    description: When type is `reinstall`, enabling fast deprovisioning will bypass full disk wiping.
+    type: boolean
+  preserve_data:
+    description: When type is `reinstall`, preserve the existing data on all disks except the operating-system disk.
+    type: boolean
+  operating_system:
+    description: When type is `reinstall`, use this `operating_system` (defaults to the current `operating system`)
+    type: string
+    example: ubuntu_22_04
+  ipxe_script_url:
+    description: When type is `reinstall`, use this `ipxe_script_url` (`operating_system` must be `custom_ipxe`, defaults to the current `ipxe_script_url`)
+    type: string
+

--- a/spec/docs/openapi/public/components/schemas/DeviceCreateInFacilityInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceCreateInFacilityInput.yaml
@@ -1,0 +1,3 @@
+allOf:
+- $ref: './FacilityInput.yaml'
+- $ref: './DeviceCreateInput.yaml'

--- a/spec/docs/openapi/public/components/schemas/DeviceCreateInMetroInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceCreateInMetroInput.yaml
@@ -1,0 +1,3 @@
+allOf:
+- $ref: './MetroInput.yaml'
+- $ref: './DeviceCreateInput.yaml'

--- a/spec/docs/openapi/public/components/schemas/DeviceCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceCreateInput.yaml
@@ -1,0 +1,220 @@
+properties:
+  always_pxe:
+    default: false
+    description: |-
+      When true, devices with a `custom_ipxe` OS will always boot to iPXE. The
+      default setting of false ensures that iPXE will be used on only the
+      first boot.
+    type: boolean
+  billing_cycle:
+    description: The billing cycle of the device.
+    enum:
+    - hourly
+    - daily
+    - monthly
+    - yearly
+    type: string
+  customdata:
+    description: |-
+      Customdata is an arbitrary JSON value that can be accessed via the
+      metadata service.
+    default: {}
+  description:
+    description: |-
+      Any description of the device or how it will be used. This may be used
+      to inform other API consumers with project access.
+    type: string
+  features:
+    description: |-
+      The features attribute allows you to optionally specify what features your server should have.
+
+      In the API shorthand syntax, all features listed are `required`:
+
+      ```
+      { "features": ["tpm"] }
+      ```
+
+      Alternatively, if you do not require a certain feature, but would prefer to be assigned a server with that feature if there are any available, you may specify that feature with a `preferred` value. The request will not fail if we have no servers with that feature in our inventory. The API offers an alternative syntax for mixing preferred and required features:
+
+      ```
+      { "features": { "tpm": "required", "raid": "preferred" } }
+      ```
+
+      The request will only fail if there are no available servers matching the required `tpm` criteria.
+    items:
+      type: string
+    type: array
+  hardware_reservation_id:
+    default: ""
+    description: |-
+      The Hardware Reservation UUID to provision. Alternatively, `next-available` can be specified to select from any of the available hardware reservations. An error will be returned if the requested reservation option is not available.
+
+      See [Reserved Hardware](https://metal.equinix.com/developers/docs/deploy/reserved/) for more details.
+    example: next-available
+    type: string
+  hostname:
+    description: The hostname to use within the operating system. The same hostname
+      may be used on multiple devices within a project.
+    type: string
+  ip_addresses:
+    default:
+    - address_family: 4
+      public: true
+    - address_family: 4
+      public: false
+    - address_family: 6
+      public: true
+    description: |-
+      The `ip_addresses attribute will allow you to specify the addresses you want created with your device.
+
+      The default value configures public IPv4, public IPv6, and private IPv4.
+
+      Private IPv4 address is required. When specifying `ip_addresses`, one of the array items must enable private IPv4.
+
+      Some operating systems require public IPv4 address. In those cases you will receive an error message if public IPv4 is not enabled.
+
+      For example, to only configure your server with a private IPv4 address, you can send `{ "ip_addresses": [{ "address_family": 4, "public": false }] }`.
+
+      It is possible to request a subnet size larger than a `/30` by assigning addresses using the UUID(s) of ip_reservations in your project.
+
+      For example, `{ "ip_addresses": [..., {"address_family": 4, "public": true, "ip_reservations": ["uuid1", "uuid2"]}] }`
+
+      To access a server without public IPs, you can use our Out-of-Band console access (SOS) or proxy through another server in the project with public IPs enabled.
+    items:
+      properties:
+        address_family:
+          description: Address Family for IP Address
+          enum:
+          - 4
+          - 6
+          example: 4
+          format: integer
+          type: number
+        cidr:
+          description: Cidr Size for the IP Block created. Valid values depends on
+            the operating system being provisioned. (28..32 for IPv4 addresses, 124..127
+            for IPv6 addresses)
+          example: 28
+          format: integer
+          type: number
+        ip_reservations:
+          description: UUIDs of any IP reservations to use when assigning IPs
+          items:
+            type: string
+          type: array
+        public:
+          default: true
+          description: Address Type for IP Address
+          example: false
+          type: boolean
+      type: object
+    type: array
+  ipxe_script_url:
+    description: |-
+      When set, the device will chainload an iPXE Script at boot fetched from the supplied URL.
+
+      See [Custom iPXE](https://metal.equinix.com/developers/docs/operating-systems/custom-ipxe/) for more details.
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/operating-systems/custom-ipxe/
+    type: string
+  locked:
+    default: false
+    description: Whether the device should be locked, preventing accidental deletion.
+    type: boolean
+  no_ssh_keys:
+    default: false
+    description: Overrides default behaviour of attaching all of the organization
+      members ssh keys and project ssh keys to device if no specific keys specified
+    type: boolean
+  operating_system:
+    description: The slug of the operating system to provision. Check the Equinix
+      Metal operating system documentation for rules that may be imposed per operating
+      system, including restrictions on IP address options and device plans.
+    type: string
+  plan:
+    description: The slug of the device plan to provision.
+    type: string
+    example: "c3.large.x86"
+  private_ipv4_subnet_size:
+    default: 28
+    description: Deprecated. Use ip_addresses. Subnet range for addresses allocated
+      to this device.
+    format: integer
+    type: number
+    x-deprecated: true
+  project_ssh_keys:
+    description: |+
+      A list of UUIDs identifying the device parent project
+      that should be authorized to access this device (typically
+      via /root/.ssh/authorized_keys). These keys will also appear in the device metadata.
+
+      If no SSH keys are specified (`user_ssh_keys`, `project_ssh_keys`, and `ssh_keys` are all empty lists or omitted),
+      all parent project keys, parent project members keys and organization members keys will be included. This behaviour can
+      be changed with 'no_ssh_keys' option to omit any SSH key being added.
+    items:
+      format: uuid
+      type: string
+    type: array
+  public_ipv4_subnet_size:
+    default: 31
+    description: Deprecated. Use ip_addresses. Subnet range for addresses allocated
+      to this device. Your project must have addresses available for a non-default
+      request.
+    format: integer
+    type: number
+    x-deprecated: true
+  spot_instance:
+    type: boolean
+    description: Create a spot instance. Spot instances are created with a maximum
+      bid price. If the bid price is not met, the spot instance will be terminated as indicated by the `termination_time` field.
+  spot_price_max:
+    format: float
+    type: number
+    example: 1.23
+    description: The maximum amount to bid for a spot instance.
+  ssh_keys:
+    description: |
+      A list of new or existing project ssh_keys
+      that should be authorized to access this device (typically
+      via /root/.ssh/authorized_keys). These keys will also
+      appear in the device metadata.
+
+      These keys are added in addition to any keys defined by
+        `project_ssh_keys` and `user_ssh_keys`.
+    items:
+      $ref: './SSHKeyInput.yaml'
+    type: array
+  tags:
+    items:
+      type: string
+    type: array
+  termination_time:
+    format: date-time
+    type: string
+  user_ssh_keys:
+    description: |
+      A list of UUIDs identifying the users
+      that should be authorized to access this device (typically
+      via /root/.ssh/authorized_keys).  These keys will also
+      appear in the device metadata.
+
+      The users must be members of the project or organization.
+
+      If no SSH keys are specified (`user_ssh_keys`, `project_ssh_keys`, and `ssh_keys` are all empty lists or omitted),
+      all parent project keys, parent project members keys and organization members keys will be included. This behaviour can
+      be changed with 'no_ssh_keys' option to omit any SSH key being added.
+    items:
+      format: uuid
+      type: string
+    type: array
+  userdata:
+    description: |-
+      The userdata presented in the metadata service for this device.  Userdata is fetched and interpreted by the operating system installed on the device. Acceptable formats are determined by the operating system, with the exception of a special iPXE enabling syntax which is handled before the operating system starts.
+
+      See [Server User Data](https://metal.equinix.com/developers/docs/servers/user-data/) and [Provisioning with Custom iPXE](https://metal.equinix.com/developers/docs/operating-systems/custom-ipxe/#provisioning-with-custom-ipxe) for more details.
+    type: string
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/servers/user-data/
+required:
+- plan
+- operating_system

--- a/spec/docs/openapi/public/components/schemas/DeviceList.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceList.yaml
@@ -1,0 +1,8 @@
+properties:
+  devices:
+    items:
+      $ref: './Device.yaml'
+    type: array
+  meta:
+    $ref: './Meta.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/DeviceUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceUpdateInput.yaml
@@ -1,0 +1,31 @@
+properties:
+  always_pxe:
+    type: boolean
+  billing_cycle:
+    type: string
+  customdata:
+    type: object
+  description:
+    type: string
+  hostname:
+    type: string
+  ipxe_script_url:
+    type: string
+  locked:
+    type: boolean
+  network_frozen:
+    description: If true, this instance can not be converted to a different network
+      type.
+    type: boolean
+  spot_instance:
+    type: boolean
+    description: Can be set to false to convert a spot-market instance to on-demand.
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/deploy/spot-market/#converting-a-spot-market-server-to-on-demand
+  tags:
+    items:
+      type: string
+    type: array
+  userdata:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/DeviceUsage.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceUsage.yaml
@@ -1,0 +1,8 @@
+properties:
+  quantity:
+    type: string
+  total:
+    type: string
+  unit:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/DeviceUsageList.yaml
+++ b/spec/docs/openapi/public/components/schemas/DeviceUsageList.yaml
@@ -1,0 +1,6 @@
+properties:
+  usages:
+    items:
+      $ref: './DeviceUsage.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Email.yaml
+++ b/spec/docs/openapi/public/components/schemas/Email.yaml
@@ -1,0 +1,13 @@
+properties:
+  address:
+    type: string
+  default:
+    type: boolean
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  verified:
+    type: boolean
+type: object

--- a/spec/docs/openapi/public/components/schemas/EmailInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/EmailInput.yaml
@@ -1,0 +1,8 @@
+properties:
+  address:
+    type: string
+  default:
+    type: boolean
+required:
+- address
+type: object

--- a/spec/docs/openapi/public/components/schemas/Entitlement.yaml
+++ b/spec/docs/openapi/public/components/schemas/Entitlement.yaml
@@ -1,0 +1,32 @@
+properties:
+  description:
+    type: string
+  feature_access:
+    type: object
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  instance_quota:
+    type: object
+  ip_quota:
+    type: object
+  name:
+    type: string
+  project_quota:
+    default: 0
+    type: integer
+  slug:
+    type: string
+  volume_limits:
+    type: object
+  volume_quota:
+    type: object
+  weight:
+    type: integer
+required:
+- id
+- slug
+- weight
+type: object

--- a/spec/docs/openapi/public/components/schemas/Error.yaml
+++ b/spec/docs/openapi/public/components/schemas/Error.yaml
@@ -1,0 +1,13 @@
+description: Error responses are included with 4xx and 5xx HTTP responses from the
+  API service. Either "error" or "errors" will be set.
+properties:
+  error:
+    description: A description of the error that caused the request to fail.
+    type: string
+  errors:
+    description: A list of errors that contributed to the request failing.
+    items:
+      description: An error message that contributed to the request failing.
+      type: string
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Event.yaml
+++ b/spec/docs/openapi/public/components/schemas/Event.yaml
@@ -1,0 +1,22 @@
+properties:
+  body:
+    type: string
+  created_at:
+    format: date-time
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  interpolated:
+    type: string
+  relationships:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  state:
+    type: string
+  type:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/EventList.yaml
+++ b/spec/docs/openapi/public/components/schemas/EventList.yaml
@@ -1,0 +1,8 @@
+properties:
+  events:
+    items:
+      $ref: './Event.yaml'
+    type: array
+  meta:
+    $ref: './Meta.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/FabricServiceToken.yaml
+++ b/spec/docs/openapi/public/components/schemas/FabricServiceToken.yaml
@@ -1,0 +1,48 @@
+properties:
+  expires_at:
+    description: The expiration date and time of the Fabric service token. Once a
+      service token is expired, it is no longer redeemable.
+    format: date-time
+    type: string
+  id:
+    description: |-
+      The UUID that can be used on the Fabric Portal to redeem either an A-Side or Z-Side Service Token.
+      For Fabric VCs (Metal Billed), this UUID will represent an A-Side Service Token, which will allow interconnections
+      to be made from Equinix Metal to other Service Providers on Fabric. For Fabric VCs (Fabric Billed), this UUID will
+      represent a Z-Side Service Token, which will allow interconnections to be made to connect an owned Fabric Port or 
+      Virtual Device to Equinix Metal.
+    format: uuid
+    type: string
+  max_allowed_speed:
+    description: |-
+      The maximum speed that can be selected on the Fabric Portal when configuring a interconnection with either 
+      an A-Side or Z-Side Service Token. For Fabric VCs (Metal Billed), this is what the billing is based off of, and can be one
+      of the following options, '50mbps', '200mbps', '500mbps', '1gbps', '2gbps', '5gbps' or '10gbps'. For Fabric VCs
+      (Fabric Billed), this will default to 10Gbps.
+    type: integer
+    example: 10000000000
+  role:
+    description: Either primary or secondary, depending on which interconnection the service token is associated to.
+    enum:
+    - primary
+    - secondary
+    type: string
+  service_token_type:
+    description: Either 'a_side' or 'z_side', depending on which type of Fabric VC was requested.
+    enum:
+    - a_side
+    - z_side
+    type: string
+  state:
+    description: |-
+      The state of the service token that corresponds with the service
+      token state on Fabric. An 'inactive' state refers to a token that has not been
+      redeemed yet on the Fabric side, an 'active' state refers to a token that has
+      already been redeemed, and an 'expired' state refers to a token that has reached
+      its expiry time.
+    enum:
+    - inactive
+    - active
+    - expired
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/Facility.yaml
+++ b/spec/docs/openapi/public/components/schemas/Facility.yaml
@@ -1,0 +1,37 @@
+properties:
+  address:
+    $ref: './Address.yaml'
+  code:
+    type: string
+  features:
+    example:
+    - baremetal
+    - backend_transfer
+    - global_ipv4
+    items:
+      enum:
+      - baremetal
+      - backend_transfer
+      - layer_2
+      - global_ipv4
+      - ibx
+      type: string
+    type: array
+  id:
+    format: uuid
+    type: string
+  ip_ranges:
+    description: IP ranges registered in facility. Can be used for GeoIP location
+    example:
+    - 2604:1380::/36
+    - 147.75.192.0/21
+    items:
+      type: string
+    type: array
+  metro:
+    allOf:
+    - $ref: './Metro.yaml'
+    - description: The metro the facility is in
+  name:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/FacilityInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/FacilityInput.yaml
@@ -1,0 +1,19 @@
+required:
+  - facility
+properties:
+  facility:
+    description: |-
+      The datacenter where the device should be created.
+
+      Either metro or facility must be provided.
+
+      The API will accept either a single facility `{ "facility": "f1" }`, or it can be instructed to create the device in the best available datacenter `{ "facility": "any" }`.
+
+      Additionally it is possible to set a prioritized location selection. For example `{ "facility": ["f3", "f2", "any"] }` can be used to prioritize `f3` and then `f2` before accepting `any` facility. If none of the facilities provided have availability for the requested device the request will fail.
+    anyOf:
+    - type: array
+      items:
+        type: string
+      example: ["sv15"]
+    - type: string
+      example: "any"

--- a/spec/docs/openapi/public/components/schemas/FacilityList.yaml
+++ b/spec/docs/openapi/public/components/schemas/FacilityList.yaml
@@ -1,0 +1,6 @@
+properties:
+  facilities:
+    items:
+      $ref: './Facility.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/GlobalBgpRange.yaml
+++ b/spec/docs/openapi/public/components/schemas/GlobalBgpRange.yaml
@@ -1,0 +1,13 @@
+properties:
+  address_family:
+    type: integer
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  project:
+    $ref: './Href.yaml'
+  range:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/GlobalBgpRangeList.yaml
+++ b/spec/docs/openapi/public/components/schemas/GlobalBgpRangeList.yaml
@@ -1,0 +1,6 @@
+properties:
+  global_bgp_ranges:
+    items:
+      $ref: './GlobalBgpRange.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/HardwareReservation.yaml
+++ b/spec/docs/openapi/public/components/schemas/HardwareReservation.yaml
@@ -1,0 +1,42 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  custom_rate:
+    description: Amount that will be charged for every billing_cycle.
+    example: 1050.5
+    format: float
+    type: number
+  device:
+    $ref: './Device.yaml'
+  facility:
+    $ref: './Facility.yaml'
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  need_of_service:
+    description: Whether this Device requires assistance from Metal Equinix.
+    type: boolean
+  plan:
+    $ref: './Plan.yaml'
+  project:
+    $ref: './Project.yaml'
+  provisionable:
+    description: Whether the reserved server is provisionable or not. Spare devices
+      can't be provisioned unless they are activated first.
+    type: boolean
+  short_id:
+    description: Short version of the ID.
+    format: string
+    type: string
+  spare:
+    description: Whether the Hardware Reservation is a spare. Spare Hardware Reservations
+      are used when a Hardware Reservations requires service from Metal Equinix
+    type: boolean
+  switch_uuid:
+    description: Switch short id. This can be used to determine if two devices are
+      connected to the same switch, for example.
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/HardwareReservationList.yaml
+++ b/spec/docs/openapi/public/components/schemas/HardwareReservationList.yaml
@@ -1,0 +1,8 @@
+properties:
+  hardware_reservations:
+    items:
+      $ref: './HardwareReservation.yaml'
+    type: array
+  meta:
+    $ref: './Meta.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/Href.yaml
+++ b/spec/docs/openapi/public/components/schemas/Href.yaml
@@ -1,0 +1,6 @@
+properties:
+  href:
+    type: string
+required:
+- href
+type: object

--- a/spec/docs/openapi/public/components/schemas/IPAssignment.yaml
+++ b/spec/docs/openapi/public/components/schemas/IPAssignment.yaml
@@ -1,0 +1,40 @@
+properties:
+  address:
+    type: string
+  address_family:
+    type: integer
+  assigned_to:
+    $ref: './Href.yaml'
+  cidr:
+    type: integer
+  created_at:
+    format: date-time
+    type: string
+  enabled:
+    type: boolean
+  gateway:
+    type: string
+  global_ip:
+    type: boolean
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  manageable:
+    type: boolean
+  management:
+    type: boolean
+  metro:
+    allOf:
+    - $ref: './Metro.yaml'
+    - description: The metro the IP address is in
+  netmask:
+    type: string
+  network:
+    type: string
+  parent_block:
+    $ref: './ParentBlock.yaml'
+  public:
+    type: boolean
+type: object

--- a/spec/docs/openapi/public/components/schemas/IPAssignmentInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/IPAssignmentInput.yaml
@@ -1,0 +1,10 @@
+properties:
+  address:
+    type: string
+  customdata:
+    type: object
+  manageable:
+    type: boolean
+required:
+- address
+type: object

--- a/spec/docs/openapi/public/components/schemas/IPAssignmentList.yaml
+++ b/spec/docs/openapi/public/components/schemas/IPAssignmentList.yaml
@@ -1,0 +1,6 @@
+properties:
+  ip_addresses:
+    items:
+      $ref: './IPAssignment.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/IPAvailabilitiesList.yaml
+++ b/spec/docs/openapi/public/components/schemas/IPAvailabilitiesList.yaml
@@ -1,0 +1,6 @@
+properties:
+  available:
+    items:
+      type: string
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/IPReservation.yaml
+++ b/spec/docs/openapi/public/components/schemas/IPReservation.yaml
@@ -1,0 +1,83 @@
+properties:
+  addon:
+    type: boolean
+  address:
+    type: string
+  address_family:
+    type: integer
+  assignments:
+    items:
+      $ref: './IPAssignment.yaml'
+    type: array
+  available:
+    type: string
+  bill:
+    type: boolean
+  cidr:
+    type: integer
+  created_at:
+    format: date-time
+    type: string
+  customdata:
+    type: object
+  enabled:
+    type: boolean
+  details:
+    type: string
+  facility:
+    allOf:
+    - $ref: './Facility.yaml'
+    - description: The facility the IP reservation is in. If the facility the IP reservation
+        was requested in is in a metro, a metro value will also be set, and the subsequent
+        IP reservation can be used on a metro level. Can be null if requesting an
+        IP reservation in a metro.
+  gateway:
+    type: string
+  global_ip:
+    type: boolean
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  manageable:
+    type: boolean
+  management:
+    type: boolean
+  metal_gateway:
+    $ref: './MetalGatewayLite.yaml'
+  metro:
+    allOf:
+    - $ref: './Metro.yaml'
+    - description: The metro the IP reservation is in. As long as the IP reservation
+        has a metro, it can be used on a metro level. Can be null if requesting an
+        IP reservation in a facility that is not in a metro.
+  netmask:
+    type: string
+  network:
+    type: string
+  project:
+    $ref: './Project.yaml'
+  project_lite:
+    $ref: './Href.yaml'
+  requested_by:
+    $ref: './Href.yaml'
+  public:
+    type: boolean
+  state:
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+  type:
+    type: string
+    enum:
+    - global_ipv4
+    - public_ipv4
+    - private_ipv4
+    - public_ipv6
+type: object
+additionalProperties: false
+required:
+  -  type

--- a/spec/docs/openapi/public/components/schemas/IPReservationList.yaml
+++ b/spec/docs/openapi/public/components/schemas/IPReservationList.yaml
@@ -1,0 +1,8 @@
+properties:
+  ip_addresses:
+    items:
+      anyOf:
+      - $ref: './IPReservation.yaml'
+      - $ref: './VrfIpReservation.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/IPReservationRequestInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/IPReservationRequestInput.yaml
@@ -1,0 +1,27 @@
+properties:
+  comments:
+    type: string
+  customdata:
+    type: object
+  details:
+    type: string
+  facility:
+    type: string
+  fail_on_approval_required:
+    type: boolean
+  metro:
+    description: The code of the metro you are requesting the IP reservation in.
+    example: SV
+    type: string
+  quantity:
+    type: integer
+  tags:
+    items:
+      type: string
+    type: array
+  type:
+    type: string
+required:
+- type
+- quantity
+type: object

--- a/spec/docs/openapi/public/components/schemas/InstancesBatchCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/InstancesBatchCreateInput.yaml
@@ -1,0 +1,18 @@
+properties:
+  batches:
+    items:
+      allOf:
+      - properties:
+          hostnames:
+            items:
+              type: string
+            type: array
+          quantity:
+            type: integer
+            description: The number of devices to create in this batch. The hostname may contain an `{{index}}` placeholder, which will be replaced with the index of the device in the batch. For example, if the hostname is `device-{{index}}`, the first device in the batch will have the hostname `device-01`, the second device will have the hostname `device-02`, and so on.
+      - oneOf:
+        - $ref: 'DeviceCreateInMetroInput.yaml'
+        - $ref: 'DeviceCreateInFacilityInput.yaml'
+    type: array
+type: object
+

--- a/spec/docs/openapi/public/components/schemas/Interconnection.yaml
+++ b/spec/docs/openapi/public/components/schemas/Interconnection.yaml
@@ -1,0 +1,70 @@
+properties:
+  contact_email:
+    type: string
+  description:
+    type: string
+  facility:
+    $ref: './Href.yaml'
+  id:
+    format: uuid
+    type: string
+  metro:
+    allOf:
+    - $ref: './Metro.yaml'
+    description: |-
+      The location of where the shared or Dedicated Port is located. For interconnections with Dedicated Ports,
+        this will be the location of the Dedicated Ports. For Fabric VCs (Metal Billed), this is where interconnection will be originating from, as we pre-authorize the use of one of our shared ports
+        as the origin of the interconnection using A-Side service tokens. We only allow local connections for Fabric VCs (Metal Billed), so the destination location must be the same as the origin. For Fabric VCs (Fabric Billed), 
+        this will be the destination of the interconnection. We allow remote connections for Fabric VCs (Fabric Billed), so the origin of the interconnection can be a different metro set here.
+  mode:
+    description: |-
+      The mode of the interconnection (only relevant to Dedicated Ports). Shared connections won't have this field. Can be either 'standard' or 'tunnel'.
+        The default mode of an interconnection on a Dedicated Port is 'standard'. The mode can only be changed when there are no associated virtual circuits on the interconnection.
+        In tunnel mode, an 802.1q tunnel is added to a port to send/receive double tagged packets from server instances.
+    enum:
+    - standard
+    - tunnel
+    example: standard
+    type: string
+  name:
+    type: string
+  organization:
+    $ref: './Href.yaml'
+  ports:
+    items:
+      $ref: './InterconnectionPort.yaml'
+    type: array
+    description: For Fabric VCs, these represent Virtual Port(s) created for the interconnection. For dedicated interconnections, these represent the Dedicated Port(s).
+  redundancy:
+    type: string
+    enum:
+    - primary
+    - redundant
+    description: Either 'primary', meaning a single interconnection, or 'redundant', meaning a redundant interconnection.
+  service_tokens:
+    items:
+      $ref: './FabricServiceToken.yaml'
+    type: array
+    description: For Fabric VCs (Metal Billed), this will show details of the A-Side service tokens issued for the interconnection. For Fabric VCs (Fabric Billed), this will show the details of the Z-Side service tokens issued for the interconnection. Dedicated interconnections will not have any service tokens issued.
+      There will be one per interconnection, so for redundant interconnections, there should be two service tokens issued.
+  speed:
+    description: For interconnections on Dedicated Ports and shared connections, this represents the interconnection's speed in bps. For Fabric VCs, this field refers to the maximum speed of the interconnection in bps. This value will default to 10Gbps for Fabric VCs (Fabric Billed).
+    type: integer
+    example: 10000000000
+  status:
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+  token:
+    format: uuid
+    type: string
+    description: This token is used for shared interconnections to be used as the Fabric Token. This field is entirely deprecated.
+  type:
+    type: string
+    enum:
+    - shared
+    - dedicated
+    description: The 'shared' type of interconnection refers to shared connections, or later also known as Fabric Virtual Connections (or Fabric VCs). The 'dedicated' type of interconnection refers to interconnections created with Dedicated Ports.
+type: object

--- a/spec/docs/openapi/public/components/schemas/InterconnectionCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/InterconnectionCreateInput.yaml
@@ -1,0 +1,70 @@
+properties:
+  contact_email:
+    type: string
+  description:
+    type: string
+  metro:
+    description: A Metro ID or code. For interconnections with Dedicated Ports, this will be the location of the issued Dedicated Ports.
+      When creating Fabric VCs (Metal Billed), this is where interconnection will be originating from, as we pre-authorize the use of one of our shared ports as the origin of the interconnection using A-Side service tokens. 
+      We only allow local connections for Fabric VCs (Metal Billed), so the destination location must be the same as the origin. For Fabric VCs (Fabric Billed), or shared connections, this will be the destination of the interconnection. We allow remote connections for Fabric VCs (Fabric Billed), 
+      so the origin of the interconnection can be a different metro set here.
+    type: string
+  mode:
+    description: |-
+      The mode of the interconnection (only relevant to Dedicated Ports). Fabric VCs won't have this field. Can be either 'standard' or 'tunnel'.
+        The default mode of an interconnection on a Dedicated Port is 'standard'. The mode can only be changed when there are no associated virtual circuits on the interconnection.
+        In tunnel mode, an 802.1q tunnel is added to a port to send/receive double tagged packets from server instances.
+    enum:
+    - standard
+    - tunnel
+    example: standard
+    type: string
+  name:
+    type: string
+  project:
+    type: string
+  redundancy:
+    description: Either 'primary' or 'redundant'.
+    type: string
+  service_token_type:
+    description: Either 'a_side' or 'z_side'. Setting this field to 'a_side' will create an interconnection with Fabric VCs (Metal Billed). Setting this field
+      to 'z_side' will create an interconnection with Fabric VCs (Fabric Billed). This is required when the 'type' is 'shared', but this is not applicable when the 'type' is 'dedicated'.
+      This parameter is included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
+    enum:
+    - a_side
+    - z_side
+    example: a_side
+    type: string
+  speed:
+    description: |-
+      A interconnection speed, in bps, mbps, or gbps. For Dedicated Ports, this can be 10Gbps or 100Gbps.
+      For Fabric VCs, this represents the maximum speed of the interconnection. For Fabric VCs (Metal Billed), this can only be one of the following: 
+      ''50mbps'', ''200mbps'', ''500mbps'', ''1gbps'', ''2gbps'', ''5gbps'' or ''10gbps'', and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to ''10gbps'' even if it is not provided.
+      For example, ''500000000'', ''50m'', or' ''500mbps'' will all work as valid inputs.
+    type: integer
+    example: 10000000000
+  tags:
+    items:
+      type: string
+    type: array
+  type:
+    description: Either 'shared' or 'dedicated'. The 'shared' type represents shared interconnections, or also known as Fabric VCs. The 'dedicated' type represents
+      dedicated interconnections, or also known as Dedicated Ports.
+    type: string
+  vlans:
+    description: A list of one or two metro-based VLANs that will be set on the virtual circuits of primary
+      and/or secondary (if redundant) interconnections respectively when creating Fabric VCs.
+      VLANs can also be set after the interconnection is created, but are required to fully activate the interconnection.
+      This parameter is included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
+    example:
+    - 1000
+    - 1001
+    items:
+      type: integer
+    type: array
+required:
+- name
+- metro
+- type
+- redundancy
+type: object

--- a/spec/docs/openapi/public/components/schemas/InterconnectionList.yaml
+++ b/spec/docs/openapi/public/components/schemas/InterconnectionList.yaml
@@ -1,0 +1,6 @@
+properties:
+  interconnections:
+    items:
+      $ref: './Interconnection.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/InterconnectionPort.yaml
+++ b/spec/docs/openapi/public/components/schemas/InterconnectionPort.yaml
@@ -1,0 +1,28 @@
+properties:
+  id:
+    format: uuid
+    type: string
+  organization:
+    $ref: './Href.yaml'
+  role:
+    description: Either 'primary' or 'secondary'.
+    type: string
+    enum:
+    - primary
+    - secondary
+  status:
+    type: string
+    description: For both Fabric VCs and Dedicated Ports, this will be 'requested' on creation and 'deleting' on deletion. Once the Fabric VC has found its corresponding Fabric connection,
+      this will turn to 'active'. For Dedicated Ports, once the dedicated port is associated, this will also turn to 'active'. For Fabric VCs, this can turn into an 'expired' state if the 
+      service token associated is expired.
+    enum:
+    - requested
+    - active
+    - deleting
+    - expired
+  switch_id:
+    description: A switch 'short ID'
+    type: string
+  virtual_circuits:
+    $ref: './VirtualCircuitList.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/InterconnectionPortList.yaml
+++ b/spec/docs/openapi/public/components/schemas/InterconnectionPortList.yaml
@@ -1,0 +1,6 @@
+properties:
+  ports:
+    items:
+      $ref: './InterconnectionPort.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/InterconnectionUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/InterconnectionUpdateInput.yaml
@@ -1,0 +1,26 @@
+properties:
+  contact_email:
+    type: string
+  description:
+    type: string
+  mode:
+    description: |-
+      The mode of the interconnection (only relevant to Dedicated Ports). Shared connections won't have this field. Can be either 'standard' or 'tunnel'.
+        The default mode of an interconnection on a Dedicated Port is 'standard'. The mode can only be changed when there are no associated virtual circuits on the interconnection.
+        In tunnel mode, an 802.1q tunnel is added to a port to send/receive double tagged packets from server instances.
+    enum:
+    - standard
+    - tunnel
+    example: standard
+    type: string
+  name:
+    type: string
+  redundancy:
+    description: Updating from 'redundant' to 'primary' will remove a secondary port,
+      while updating from 'primary' to 'redundant' will add one.
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Invitation.yaml
+++ b/spec/docs/openapi/public/components/schemas/Invitation.yaml
@@ -1,0 +1,37 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  invitation:
+    $ref: './Href.yaml'
+  invited_by:
+    $ref: './Href.yaml'
+  invitee:
+    type: string
+    format: email
+  nonce:
+    type: string
+  organization:
+    $ref: './Href.yaml'
+  projects:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  roles:
+    items:
+      type: string
+      enum:
+        - admin
+        - billing
+        - collaborator
+        - limited_collaborator
+    type: array
+  updated_at:
+    format: date-time
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/InvitationInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/InvitationInput.yaml
@@ -1,0 +1,26 @@
+properties:
+  invitee:
+    type: string
+    format: email
+  message:
+    type: string
+  organization_id:
+    type: string
+    format: uuid
+  projects_ids:
+    items:
+      type: string
+      format: uuid
+    type: array
+  roles:
+    items:
+      type: string
+      enum:
+        - admin
+        - billing
+        - collaborator
+        - limited_collaborator
+    type: array
+required:
+- invitee
+type: object

--- a/spec/docs/openapi/public/components/schemas/InvitationList.yaml
+++ b/spec/docs/openapi/public/components/schemas/InvitationList.yaml
@@ -1,0 +1,6 @@
+properties:
+  invitations:
+    items:
+      $ref: './Membership.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/License.yaml
+++ b/spec/docs/openapi/public/components/schemas/License.yaml
@@ -1,0 +1,15 @@
+properties:
+  description:
+    type: string
+  id:
+    format: uuid
+    type: string
+  license_key:
+    type: string
+  licensee_product:
+    $ref: './Href.yaml'
+  project:
+    $ref: './Href.yaml'
+  size:
+    type: number
+type: object

--- a/spec/docs/openapi/public/components/schemas/LicenseCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/LicenseCreateInput.yaml
@@ -1,0 +1,8 @@
+properties:
+  description:
+    type: string
+  licensee_product_id:
+    type: string
+  size:
+    type: number
+type: object

--- a/spec/docs/openapi/public/components/schemas/LicenseList.yaml
+++ b/spec/docs/openapi/public/components/schemas/LicenseList.yaml
@@ -1,0 +1,6 @@
+properties:
+  licenses:
+    items:
+      $ref: './License.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/LicenseUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/LicenseUpdateInput.yaml
@@ -1,0 +1,6 @@
+properties:
+  description:
+    type: string
+  size:
+    type: number
+type: object

--- a/spec/docs/openapi/public/components/schemas/Membership.yaml
+++ b/spec/docs/openapi/public/components/schemas/Membership.yaml
@@ -1,0 +1,21 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  project:
+    $ref: './Href.yaml'
+  roles:
+    items:
+      type: string
+    type: array
+  updated_at:
+    format: date-time
+    type: string
+  user:
+    $ref: './Href.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/MembershipInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/MembershipInput.yaml
@@ -1,0 +1,6 @@
+properties:
+  role:
+    items:
+      type: string
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/MembershipList.yaml
+++ b/spec/docs/openapi/public/components/schemas/MembershipList.yaml
@@ -1,0 +1,6 @@
+properties:
+  memberships:
+    items:
+      $ref: './Membership.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Meta.yaml
+++ b/spec/docs/openapi/public/components/schemas/Meta.yaml
@@ -1,0 +1,14 @@
+properties:
+  first:
+    $ref: './Href.yaml'
+  last:
+    $ref: './Href.yaml'
+  next:
+    $ref: './Href.yaml'
+  previous:
+    $ref: './Href.yaml'
+  self:
+    $ref: './Href.yaml'
+  total:
+    type: integer
+type: object

--- a/spec/docs/openapi/public/components/schemas/Metadata.yaml
+++ b/spec/docs/openapi/public/components/schemas/Metadata.yaml
@@ -1,0 +1,71 @@
+properties:
+  class:
+    type: string
+  customdata:
+    type: object
+  facility:
+    description: The facility code of the instance
+    type: string
+  hostname:
+    type: string
+  id:
+    format: uuid
+    type: string
+  iqn:
+    type: string
+  metro:
+    description: The metro code of the instance
+    type: string
+  network:
+    properties:
+      addresses:
+        items:
+          type: string
+        type: array
+      interfaces:
+        items:
+          type: object
+        type: array
+      network:
+        properties:
+          bonding:
+            properties:
+              link_aggregation:
+                type: string
+              mac:
+                type: string
+              mode:
+                type: integer
+            type: object
+        type: object
+    type: object
+  operating_system:
+    type: object
+  plan:
+    description: The plan slug of the instance
+    type: string
+  private_subnets:
+    description: An array of the private subnets
+    items:
+      type: string
+    type: array
+  reserved:
+    type: boolean
+  specs:
+    description: The specs of the plan version of the instance
+    type: object
+  ssh_keys:
+    items:
+      type: string
+    type: array
+  switch_short_id:
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+  volumes:
+    items:
+      type: string
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetalGateway.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetalGateway.yaml
@@ -1,0 +1,32 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  created_by:
+    $ref: './Href.yaml'
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  ip_reservation:
+    $ref: './IPReservation.yaml'
+  project:
+    $ref: './Project.yaml'
+  state:
+    description: The current state of the Metal Gateway. 'Ready' indicates the gateway
+      record has been configured, but is currently not active on the network. 'Active'
+      indicates the gateway has been configured on the network. 'Deleting' is a temporary
+      state used to indicate that the gateway is in the process of being un-configured
+      from the network, after which the gateway record will be deleted.
+    enum:
+    - ready
+    - active
+    - deleting
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  virtual_network:
+    $ref: './VirtualNetwork.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetalGatewayCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetalGatewayCreateInput.yaml
@@ -1,0 +1,20 @@
+properties:
+  ip_reservation_id:
+    description: The UUID of an IP reservation that belongs to the same project as
+      where the metal gateway will be created in. This field is required unless the
+      private IPv4 subnet size is specified.
+    format: uuid
+    type: string
+  private_ipv4_subnet_size:
+    description: |-
+      The subnet size (8, 16, 32, 64, or 128) of the private IPv4 reservation that will be created for the metal gateway. This field is required unless a project IP reservation was specified.
+                Please keep in mind that the number of private metal gateway ranges are limited per project. If you would like to increase the limit per project, please contact support for assistance.
+    type: integer
+  virtual_network_id:
+    description: The UUID of a metro virtual network that belongs to the same project
+      as where the metal gateway will be created in.
+    format: uuid
+    type: string
+required:
+- virtual_network_id
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetalGatewayList.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetalGatewayList.yaml
@@ -1,0 +1,8 @@
+properties:
+  metal_gateways:
+    items:
+      anyOf:
+      - $ref: './MetalGateway.yaml'
+      - $ref: './VrfMetalGateway.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetalGatewayLite.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetalGatewayLite.yaml
@@ -1,0 +1,35 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  gateway_address:
+    description: The gateway address with subnet CIDR value for this Metal Gateway.
+      For example, a Metal Gateway using an IP reservation with block 10.1.2.0/27
+      would have a gateway address of 10.1.2.1/27.
+    type: string
+    example: 10.1.2.1/27
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  state:
+    description: The current state of the Metal Gateway. 'Ready' indicates the gateway
+      record has been configured, but is currently not active on the network. 'Active'
+      indicates the gateway has been configured on the network. 'Deleting' is a temporary
+      state used to indicate that the gateway is in the process of being un-configured
+      from the network, after which the gateway record will be deleted.
+    enum:
+    - ready
+    - active
+    - deleting
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  vlan:
+    description: 'The VLAN id of the Virtual Network record associated to this Metal
+      Gateway.'
+    type: integer
+    example: 1001
+type: object

--- a/spec/docs/openapi/public/components/schemas/Metro.yaml
+++ b/spec/docs/openapi/public/components/schemas/Metro.yaml
@@ -1,0 +1,11 @@
+properties:
+  code:
+    type: string
+  country:
+    type: string
+  id:
+    format: uuid
+    type: string
+  name:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetroCapacityList.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetroCapacityList.yaml
@@ -1,0 +1,4 @@
+properties:
+  capacity:
+    $ref: './MetroCapacityReport.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetroCapacityReport.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetroCapacityReport.yaml
@@ -1,0 +1,42 @@
+properties:
+  am:
+    $ref: './CapacityPerFacility.yaml'
+  at:
+    $ref: './CapacityPerFacility.yaml'
+  ch:
+    $ref: './CapacityPerFacility.yaml'
+  da:
+    $ref: './CapacityPerFacility.yaml'
+  dc:
+    $ref: './CapacityPerFacility.yaml'
+  fr:
+    $ref: './CapacityPerFacility.yaml'
+  hk:
+    $ref: './CapacityPerFacility.yaml'
+  la:
+    $ref: './CapacityPerFacility.yaml'
+  ld:
+    $ref: './CapacityPerFacility.yaml'
+  md:
+    $ref: './CapacityPerFacility.yaml'
+  ny:
+    $ref: './CapacityPerFacility.yaml'
+  pa:
+    $ref: './CapacityPerFacility.yaml'
+  se:
+    $ref: './CapacityPerFacility.yaml'
+  sg:
+    $ref: './CapacityPerFacility.yaml'
+  sl:
+    $ref: './CapacityPerFacility.yaml'
+  sp:
+    $ref: './CapacityPerFacility.yaml'
+  sv:
+    $ref: './CapacityPerFacility.yaml'
+  sy:
+    $ref: './CapacityPerFacility.yaml'
+  tr:
+    $ref: './CapacityPerFacility.yaml'
+  ty:
+    $ref: './CapacityPerFacility.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetroInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetroInput.yaml
@@ -1,0 +1,9 @@
+required:
+  - metro
+properties:
+  metro:
+    description: |-
+      Metro code or ID of where the instance should be provisioned in.
+      Either metro or facility must be provided.
+    type: string
+    example: sv

--- a/spec/docs/openapi/public/components/schemas/MetroList.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetroList.yaml
@@ -1,0 +1,6 @@
+properties:
+  metros:
+    items:
+      $ref: './Metro.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/MetroServerInfo.yaml
+++ b/spec/docs/openapi/public/components/schemas/MetroServerInfo.yaml
@@ -1,0 +1,11 @@
+properties:
+  metro:
+    description: The metro ID or code to check the capacity in.
+    type: string
+  plan:
+    description: The plan ID or slug to check the capacity of.
+    type: string
+  quantity:
+    description: The number of servers to check the capacity of.
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/NewPassword.yaml
+++ b/spec/docs/openapi/public/components/schemas/NewPassword.yaml
@@ -1,0 +1,4 @@
+properties:
+  new_password:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/OperatingSystem.yaml
+++ b/spec/docs/openapi/public/components/schemas/OperatingSystem.yaml
@@ -1,0 +1,31 @@
+properties:
+  distro:
+    type: string
+  distro_label:
+    type: string
+  id:
+    format: uuid
+    type: string
+  licensed:
+    description: Licenced OS is priced according to pricing property
+    type: boolean
+  name:
+    type: string
+  preinstallable:
+    description: Servers can be already preinstalled with OS in order to shorten provision
+      time.
+    type: boolean
+  pricing:
+    description: This object contains price per time unit and optional multiplier
+      value if licence price depends on hardware plan or components (e.g. number of
+      cores)
+    type: object
+  provisionable_on:
+    items:
+      type: string
+    type: array
+  slug:
+    type: string
+  version:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/OperatingSystemList.yaml
+++ b/spec/docs/openapi/public/components/schemas/OperatingSystemList.yaml
@@ -1,0 +1,6 @@
+properties:
+  operating_systems:
+    items:
+      $ref: './OperatingSystem.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Organization.yaml
+++ b/spec/docs/openapi/public/components/schemas/Organization.yaml
@@ -1,0 +1,50 @@
+properties:
+  address:
+    $ref: './Address.yaml'
+  billing_address:
+    $ref: './Address.yaml'
+  created_at:
+    format: date-time
+    type: string
+  credit_amount:
+    format: float
+    type: number
+  customdata:
+    type: object
+  description:
+    type: string
+  enforce_2fa_at:
+    description: Force to all members to have enabled the two factor authentication
+      after that date, unless the value is null
+    format: date-time
+    type: string
+  id:
+    format: uuid
+    type: string
+  logo:
+    format: binary
+    type: string
+  members:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  memberships:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  name:
+    type: string
+  projects:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  terms:
+    type: integer
+  twitter:
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  website:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/OrganizationInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/OrganizationInput.yaml
@@ -1,0 +1,24 @@
+properties:
+  address:
+    $ref: './Address.yaml'
+  billing_address:
+    $ref: './Address.yaml'
+  customdata:
+    type: object
+  description:
+    type: string
+  enforce_2fa_at:
+    description: Force to all members to have enabled the two factor authentication
+      after that date, unless the value is null
+    format: date-time
+    type: string
+  logo:
+    format: binary
+    type: string
+  name:
+    type: string
+  twitter:
+    type: string
+  website:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/OrganizationList.yaml
+++ b/spec/docs/openapi/public/components/schemas/OrganizationList.yaml
@@ -1,0 +1,8 @@
+properties:
+  meta:
+    $ref: './Meta.yaml'
+  organizations:
+    items:
+      $ref: './Organization.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/ParentBlock.yaml
+++ b/spec/docs/openapi/public/components/schemas/ParentBlock.yaml
@@ -1,0 +1,10 @@
+properties:
+  cidr:
+    type: integer
+  href:
+    type: string
+  netmask:
+    type: string
+  network:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/PaymentMethod.yaml
+++ b/spec/docs/openapi/public/components/schemas/PaymentMethod.yaml
@@ -1,0 +1,37 @@
+properties:
+  billing_address:
+    $ref: './PaymentMethodBillingAddress.yaml'
+  card_type:
+    type: string
+  cardholder_name:
+    type: string
+  created_at:
+    format: date-time
+    type: string
+  created_by_user:
+    $ref: './Href.yaml'
+  default:
+    type: boolean
+  email:
+    type: string
+  expiration_month:
+    type: string
+  expiration_year:
+    type: string
+  id:
+    format: uuid
+    type: string
+  name:
+    type: string
+  organization:
+    $ref: './Href.yaml'
+  projects:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  type:
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/PaymentMethodBillingAddress.yaml
+++ b/spec/docs/openapi/public/components/schemas/PaymentMethodBillingAddress.yaml
@@ -1,0 +1,8 @@
+properties:
+  country_code_alpha2:
+    type: string
+  postal_code:
+    type: string
+  street_address:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/PaymentMethodCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/PaymentMethodCreateInput.yaml
@@ -1,0 +1,11 @@
+properties:
+  default:
+    type: boolean
+  name:
+    type: string
+  nonce:
+    type: string
+required:
+- name
+- nonce
+type: object

--- a/spec/docs/openapi/public/components/schemas/PaymentMethodList.yaml
+++ b/spec/docs/openapi/public/components/schemas/PaymentMethodList.yaml
@@ -1,0 +1,6 @@
+properties:
+  payment_methods:
+    items:
+      $ref: './PaymentMethod.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/PaymentMethodUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/PaymentMethodUpdateInput.yaml
@@ -1,0 +1,14 @@
+properties:
+  billing_address:
+    type: object
+  cardholder_name:
+    type: string
+  default:
+    type: boolean
+  expiration_month:
+    type: string
+  expiration_year:
+    type: integer
+  name:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/Plan.yaml
+++ b/spec/docs/openapi/public/components/schemas/Plan.yaml
@@ -1,0 +1,130 @@
+properties:
+  available_in:
+    description: Shows which facilities the plan is available in, and the facility-based
+      price if it is different from the default price.
+    items:
+      type: object
+      properties:
+        href:
+          description: href to the Facility
+          type: string
+        price:
+          type: object
+          properties:
+            hour:
+              type: number
+              format: decimal
+              example: 1.23
+    type: array
+  available_in_metros:
+    description: Shows which metros the plan is available in, and the metro-based
+      price if it is different from the default price.
+    items:
+      type: object
+      properties:
+        href:
+          description: href to the Metro
+          type: string
+        price:
+          type: object
+          properties:
+            hour:
+              type: number
+              format: decimal
+              example: 1.23
+    type: array
+  class:
+    type: string
+    example: m3.large.x86
+  description:
+    type: string
+  deployment_types:
+    items:
+      type: string
+      enum:
+        - on_demand
+        - spot_market
+    type: array
+    minItems: 0
+    uniqueItems: true
+  id:
+    format: uuid
+    type: string
+  legacy:
+    type: boolean
+  line:
+    type: string
+    enum:
+      - baremetal
+  name:
+    type: string
+  pricing:
+    type: object
+  slug:
+    type: string
+    example: m3.large.x86
+  specs:
+    type: object
+    properties:
+      cpus:
+        type: array
+        items:
+          type: object
+          properties:
+            count:
+              type: integer
+            type:
+              type: string
+      drives:
+        type: array
+        items:
+          type: object
+          properties:
+            count:
+              type: integer
+            type:
+              type: string
+              enum:
+                - HDD
+                - SSD
+                - NVME
+            size:
+              type: string
+              example: 3.84TB
+            category:
+              type: string
+              enum:
+                - boot
+                - cache
+                - storage
+      nics:
+        type: array
+        items:
+          type: object
+          properties:
+            count:
+              type: integer
+              example: 2
+            type:
+              type: string
+              enum:
+                - 1Gbps
+                - 10Gbps
+                - 25Gbps
+      features:
+        type: object
+        properties:
+          raid:
+            type: boolean
+          txt:
+            type: boolean
+          uefi:
+            type: boolean
+  type:
+    description: The plan type
+    type: string
+    enum:
+      - standard
+      - workload_optimized
+      - custom
+type: object

--- a/spec/docs/openapi/public/components/schemas/Plan.yaml.orig
+++ b/spec/docs/openapi/public/components/schemas/Plan.yaml.orig
@@ -1,0 +1,125 @@
+properties:
+  available_in:
+    description: Shows which facilities the plan is available in, and the facility-based
+      price if it is different from the default price.
+    items:
+      type: object
+      properties:
+        href:
+          description: href to the Facility
+          type: string
+        price:
+          type: object
+          properties:
+            hour:
+              type: number
+              format: decimal
+              example:
+                1.23
+    type: array
+  available_in_metros:
+    description: Shows which metros the plan is available in, and the metro-based
+      price if it is different from the default price.
+    items:
+      type: object
+      properties:
+        href:
+          description: href to the Metro
+          type: string
+        price:
+          type: object
+          properties:
+            hour:
+              type: number
+              format: decimal
+              example:
+                1.23
+    type: array
+  class:
+    type: string
+    example: m3.large.x86
+  description:
+    type: string
+  deployment_types:
+    items:
+      type: string
+      enum:
+        - on_demand
+        - spot_market
+    type: array
+    minItems: 0
+    uniqueItems: true
+  id:
+    format: uuid
+    type: string
+  legacy:
+    type: boolean
+  line:
+    type: string
+    enum:
+      - baremetal
+  name:
+    type: string
+  pricing:
+    type: object
+  slug:
+    type: string
+    example: m3.large.x86
+  specs:
+    type: object
+    properties:
+      cpus:
+        type: array
+        items:
+          type: object
+          properties:
+            count:
+              type: integer
+            type:
+              type: string
+      drives:
+        type: array
+        items:
+          type: object
+          properties:
+            count:
+              type: integer
+            type:
+              type: string
+              enum:
+                - SSD
+                - NVME
+
+            size:
+              type: string
+              example: 240GB
+      nics:
+        type: array
+        items:
+          type: object
+          properties:
+            count:
+              type: integer
+            type:
+              type: string
+      features:
+        type: object
+        properties:
+          raid:
+<<<<<<< HEAD
+            type: boolean
+          txt:
+            type: boolean
+=======
+            type: bool
+          txt:
+            type: bool
+>>>>>>> d5cdad7ff (oas3: add Plan "spec" and "available_in_metros" properties)
+  type:
+    description: The plan type
+    type: string
+    enum:
+      - standard
+      - workload_optimized
+      - custom
+type: object

--- a/spec/docs/openapi/public/components/schemas/PlanList.yaml
+++ b/spec/docs/openapi/public/components/schemas/PlanList.yaml
@@ -1,0 +1,6 @@
+properties:
+  plans:
+    items:
+      $ref: './Plan.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Port.yaml
+++ b/spec/docs/openapi/public/components/schemas/Port.yaml
@@ -1,0 +1,40 @@
+description: Port is a hardware port associated with a reserved or instantiated hardware device.
+properties:
+  bond:
+    $ref: './BondPortData.yaml'
+  data:
+    $ref: './PortData.yaml'
+  disbond_operation_supported:
+    description: Indicates whether or not the bond can be broken on the port (when
+      applicable).
+    type: boolean
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  name:
+    type: string
+    example: bond0
+  type:
+    description: Type is either "NetworkBondPort" for bond ports or "NetworkPort" for bondable ethernet ports
+    type: string
+    enum:
+    - NetworkPort
+    - NetworkBondPort
+  network_type:
+    description: Composite network type of the bond
+    type: string
+    enum:
+      - 'layer2-bonded'
+      - 'layer2-individual'
+      - 'layer3'
+      - 'hybrid'
+      - 'hybrid-bonded'
+  native_virtual_network:
+    $ref: './VirtualNetwork.yaml'
+  virtual_networks:
+    items:
+      $ref: './Href.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortAssignInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortAssignInput.yaml
@@ -1,0 +1,8 @@
+properties:
+  vnid:
+    description: >
+      Virtual Network ID. May be the UUID of the Virtual Network record,
+      or the VLAN value itself.
+    type: string
+    example: "1001"
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortConvertLayer3Input.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortConvertLayer3Input.yaml
@@ -1,0 +1,11 @@
+properties:
+  request_ips:
+    items:
+      properties:
+        address_family:
+          type: integer
+        public:
+          type: boolean
+      type: object
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortData.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortData.yaml
@@ -1,0 +1,8 @@
+properties:
+  mac:
+    description: MAC address is set for NetworkPort ports
+    type: string
+  bonded:
+    description: Bonded is true for NetworkPort ports in a bond and NetworkBondPort ports that are active
+    type: boolean
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortVlanAssignment.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortVlanAssignment.yaml
@@ -1,0 +1,24 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  id:
+    format: uuid
+    type: string
+  native:
+    type: boolean
+  port:
+    $ref: './Href.yaml'
+  state:
+    enum:
+    - assigned
+    - unassigning
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  virtual_network:
+    $ref: './Href.yaml'
+  vlan:
+    type: integer
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortVlanAssignmentBatch.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortVlanAssignmentBatch.yaml
@@ -1,0 +1,43 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  error_messages:
+    items:
+      type: string
+    type: array
+  id:
+    format: uuid
+    type: string
+  port:
+    $ref: './Port.yaml'
+  quantity:
+    type: integer
+  state:
+    enum:
+    - queued
+    - in_progress
+    - completed
+    - failed
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  vlan_assignments:
+    items:
+      properties:
+        id:
+          format: uuid
+          type: string
+        native:
+          type: boolean
+        state:
+          enum:
+          - assigned
+          - unassigned
+          type: string
+        vlan:
+          type: integer
+      type: object
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortVlanAssignmentBatchCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortVlanAssignmentBatchCreateInput.yaml
@@ -1,0 +1,16 @@
+properties:
+  vlan_assignments:
+    items:
+      properties:
+        native:
+          type: boolean
+        state:
+          enum:
+          - assigned
+          - unassigned
+          type: string
+        vlan:
+          type: string
+      type: object
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortVlanAssignmentBatchList.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortVlanAssignmentBatchList.yaml
@@ -1,0 +1,6 @@
+properties:
+  batches:
+    items:
+      $ref: './PortVlanAssignmentBatch.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/PortVlanAssignmentList.yaml
+++ b/spec/docs/openapi/public/components/schemas/PortVlanAssignmentList.yaml
@@ -1,0 +1,6 @@
+properties:
+  vlan_assignments:
+    items:
+      $ref: './PortVlanAssignment.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Project.yaml
+++ b/spec/docs/openapi/public/components/schemas/Project.yaml
@@ -1,0 +1,47 @@
+properties:
+  bgp_config:
+    $ref: './Href.yaml'
+  created_at:
+    format: date-time
+    type: string
+  customdata:
+    type: object
+  devices:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  id:
+    format: uuid
+    type: string
+  invitations:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  max_devices:
+    type: object
+  members:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  memberships:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  name:
+    type: string
+  network_status:
+    type: object
+  payment_method:
+    $ref: './Href.yaml'
+  ssh_keys:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  updated_at:
+    format: date-time
+    type: string
+  volumes:
+    items:
+      $ref: './Href.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/ProjectCreateFromRootInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/ProjectCreateFromRootInput.yaml
@@ -1,0 +1,14 @@
+properties:
+  customdata:
+    type: object
+  name:
+    type: string
+  organization_id:
+    format: uuid
+    type: string
+  payment_method_id:
+    format: uuid
+    type: string
+required:
+- name
+type: object

--- a/spec/docs/openapi/public/components/schemas/ProjectCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/ProjectCreateInput.yaml
@@ -1,0 +1,11 @@
+properties:
+  customdata:
+    type: object
+  name:
+    type: string
+  payment_method_id:
+    format: uuid
+    type: string
+required:
+- name
+type: object

--- a/spec/docs/openapi/public/components/schemas/ProjectList.yaml
+++ b/spec/docs/openapi/public/components/schemas/ProjectList.yaml
@@ -1,0 +1,8 @@
+properties:
+  meta:
+    $ref: './Meta.yaml'
+  projects:
+    items:
+      $ref: './Project.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/ProjectUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/ProjectUpdateInput.yaml
@@ -1,0 +1,11 @@
+properties:
+  backend_transfer_enabled:
+    type: boolean
+  customdata:
+    type: object
+  name:
+    type: string
+  payment_method_id:
+    format: uuid
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/ProjectUsage.yaml
+++ b/spec/docs/openapi/public/components/schemas/ProjectUsage.yaml
@@ -1,0 +1,20 @@
+properties:
+  facility:
+    type: string
+  name:
+    type: string
+  plan:
+    type: string
+  plan_version:
+    type: string
+  price:
+    type: string
+  quantity:
+    type: string
+  total:
+    type: string
+  type:
+    type: string
+  unit:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/ProjectUsageList.yaml
+++ b/spec/docs/openapi/public/components/schemas/ProjectUsageList.yaml
@@ -1,0 +1,6 @@
+properties:
+  usages:
+    items:
+      $ref: './ProjectUsage.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/RecoveryCodeList.yaml
+++ b/spec/docs/openapi/public/components/schemas/RecoveryCodeList.yaml
@@ -1,0 +1,6 @@
+properties:
+  recovery_codes:
+    items:
+      type: string
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/SSHKey.yaml
+++ b/spec/docs/openapi/public/components/schemas/SSHKey.yaml
@@ -1,0 +1,21 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  entity:
+    $ref: './Href.yaml'
+  fingerprint:
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  key:
+    type: string
+  label:
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/SSHKeyCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/SSHKeyCreateInput.yaml
@@ -1,0 +1,14 @@
+properties:
+  instances_ids:
+    description: |-
+      List of instance UUIDs to associate SSH key with, when empty array is sent all instances belonging
+            to entity will be included
+    items:
+      format: uuid
+      type: string
+    type: array
+  key:
+    type: string
+  label:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/SSHKeyInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/SSHKeyInput.yaml
@@ -1,0 +1,6 @@
+properties:
+  key:
+    type: string
+  label:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/SSHKeyList.yaml
+++ b/spec/docs/openapi/public/components/schemas/SSHKeyList.yaml
@@ -1,0 +1,6 @@
+properties:
+  ssh_keys:
+    items:
+      $ref: './SSHKey.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/SelfServiceReservationItemRequest.yaml
+++ b/spec/docs/openapi/public/components/schemas/SelfServiceReservationItemRequest.yaml
@@ -1,0 +1,15 @@
+properties:
+  amount:
+    format: float
+    type: number
+  metro_id:
+    format: uuid
+    type: string
+  plan_id:
+    format: uuid
+    type: string
+  quantity:
+    type: integer
+  term:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/SelfServiceReservationItemResponse.yaml
+++ b/spec/docs/openapi/public/components/schemas/SelfServiceReservationItemResponse.yaml
@@ -1,0 +1,25 @@
+properties:
+  amount:
+    format: float
+    type: number
+  id:
+    type: string
+  metro_code:
+    type: string
+  metro_id:
+    format: uuid
+    type: string
+  metro_name:
+    type: string
+  plan_id:
+    format: uuid
+    type: string
+  plan_name:
+    type: string
+  plan_slug:
+    type: string
+  quantity:
+    type: integer
+  term:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/SelfServiceReservationList.yaml
+++ b/spec/docs/openapi/public/components/schemas/SelfServiceReservationList.yaml
@@ -1,0 +1,6 @@
+properties:
+  reservations:
+    items:
+      $ref: './SelfServiceReservationResponse.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/SelfServiceReservationResponse.yaml
+++ b/spec/docs/openapi/public/components/schemas/SelfServiceReservationResponse.yaml
@@ -1,0 +1,40 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  item:
+    items:
+      $ref: './SelfServiceReservationItemResponse.yaml'
+    type: array
+  notes:
+    type: string
+  organization:
+    type: string
+  organization_id:
+    format: uuid
+    type: string
+  period:
+    properties:
+      count:
+        enum:
+        - 12
+        - 36
+        type: number
+      unit:
+        enum:
+        - monthly
+        type: string
+    type: object
+  project:
+    type: string
+  project_id:
+    format: uuid
+    type: string
+  start_date:
+    format: date-time
+    type: string
+  status:
+    type: string
+  total_cost:
+    type: integer
+type: object

--- a/spec/docs/openapi/public/components/schemas/ServerInfo.yaml
+++ b/spec/docs/openapi/public/components/schemas/ServerInfo.yaml
@@ -1,0 +1,8 @@
+properties:
+  facility:
+    type: string
+  plan:
+    type: string
+  quantity:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotMarketPricesList.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotMarketPricesList.yaml
@@ -1,0 +1,4 @@
+properties:
+  spot_market_prices:
+    $ref: './SpotPricesReport.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotMarketPricesPerMetroList.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotMarketPricesPerMetroList.yaml
@@ -1,0 +1,4 @@
+properties:
+  spot_market_prices:
+    $ref: './SpotMarketPricesPerMetroReport.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotMarketPricesPerMetroReport.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotMarketPricesPerMetroReport.yaml
@@ -1,0 +1,16 @@
+properties:
+  am:
+    $ref: './SpotPricesPerFacility.yaml'
+  ch:
+    $ref: './SpotPricesPerFacility.yaml'
+  da:
+    $ref: './SpotPricesPerFacility.yaml'
+  la:
+    $ref: './SpotPricesPerFacility.yaml'
+  ny:
+    $ref: './SpotPricesPerFacility.yaml'
+  sg:
+    $ref: './SpotPricesPerFacility.yaml'
+  sv:
+    $ref: './SpotPricesPerFacility.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotMarketRequest.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotMarketRequest.yaml
@@ -1,0 +1,30 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  devices_max:
+    type: integer
+  devices_min:
+    type: integer
+  end_at:
+    format: date-time
+    type: string
+  facilities:
+    $ref: './Href.yaml'
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  instances:
+    $ref: './Href.yaml'
+  max_bid_price:
+    format: float
+    type: number
+  metro:
+    allOf:
+    - $ref: './Metro.yaml'
+    - description: The metro the spot market request was created in
+  project:
+    $ref: './Href.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotMarketRequestCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotMarketRequestCreateInput.yaml
@@ -1,0 +1,74 @@
+properties:
+  devices_max:
+    type: integer
+  devices_min:
+    type: integer
+  end_at:
+    format: date-time
+    type: string
+  facilities:
+    items:
+      format: uuid
+      type: string
+    type: array
+  instance_attributes:
+    properties:
+      always_pxe:
+        type: boolean
+      billing_cycle:
+        type: string
+      customdata:
+        type: object
+      description:
+        type: string
+      features:
+        items:
+          type: string
+        type: array
+      hostname:
+        type: string
+      hostnames:
+        items:
+          type: string
+        type: array
+      locked:
+        type: boolean
+      no_ssh_keys:
+        type: boolean
+      operating_system:
+        type: string
+      plan:
+        type: string
+      private_ipv4_subnet_size:
+        type: integer
+      project_ssh_keys:
+        items:
+          format: uuid
+          type: string
+        type: array
+      public_ipv4_subnet_size:
+        type: integer
+      tags:
+        items:
+          type: string
+        type: array
+      termination_time:
+        format: date-time
+        type: string
+      user_ssh_keys:
+        description: The UUIDs of users whose SSH keys should be included on the provisioned
+          device.
+        items:
+          format: uuid
+          type: string
+        type: array
+      userdata:
+        type: string
+    type: object
+  max_bid_price:
+    format: float
+    type: number
+  metro:
+    description: The metro ID or code the spot market request will be created in.
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotMarketRequestList.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotMarketRequestList.yaml
@@ -1,0 +1,6 @@
+properties:
+  spot_market_requests:
+    items:
+      $ref: './SpotMarketRequest.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotPricesDatapoints.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotPricesDatapoints.yaml
@@ -1,0 +1,6 @@
+properties:
+  datapoints:
+    items:
+      $ref: './SpotPricesDatapointsList.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotPricesDatapointsList.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotPricesDatapointsList.yaml
@@ -1,0 +1,3 @@
+items:
+  type: number
+type: array

--- a/spec/docs/openapi/public/components/schemas/SpotPricesHistoryReport.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotPricesHistoryReport.yaml
@@ -1,0 +1,4 @@
+properties:
+  prices_history:
+    $ref: './SpotPricesDatapoints.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotPricesPerBaremetal.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotPricesPerBaremetal.yaml
@@ -1,0 +1,5 @@
+properties:
+  price:
+    format: float
+    type: number
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotPricesPerFacility.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotPricesPerFacility.yaml
@@ -1,0 +1,20 @@
+properties:
+  baremetal_0:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  baremetal_1:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  baremetal_2:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  baremetal_2a:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  baremetal_2a2:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  baremetal_3:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  baremetal_s:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  c2.medium.x86:
+    $ref: './SpotPricesPerBaremetal.yaml'
+  m2.xlarge.x86:
+    $ref: './SpotPricesPerBaremetal.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotPricesPerNewFacility.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotPricesPerNewFacility.yaml
@@ -1,0 +1,4 @@
+properties:
+  baremetal_1e:
+    $ref: './SpotPricesPerBaremetal.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SpotPricesReport.yaml
+++ b/spec/docs/openapi/public/components/schemas/SpotPricesReport.yaml
@@ -1,0 +1,30 @@
+properties:
+  ams1:
+    $ref: './SpotPricesPerFacility.yaml'
+  atl1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  dfw1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  ewr1:
+    $ref: './SpotPricesPerFacility.yaml'
+  fra1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  iad1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  lax1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  nrt1:
+    $ref: './SpotPricesPerFacility.yaml'
+  ord1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  sea1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  sin1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  sjc1:
+    $ref: './SpotPricesPerFacility.yaml'
+  syd1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+  yyz1:
+    $ref: './SpotPricesPerNewFacility.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/SupportRequestInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/SupportRequestInput.yaml
@@ -1,0 +1,20 @@
+properties:
+  device_id:
+    type: string
+  message:
+    type: string
+  priority:
+    enum:
+    - urgent
+    - high
+    - medium
+    - low
+    type: string
+  project_id:
+    type: string
+  subject:
+    type: string
+required:
+- subject
+- message
+type: object

--- a/spec/docs/openapi/public/components/schemas/TransferRequest.yaml
+++ b/spec/docs/openapi/public/components/schemas/TransferRequest.yaml
@@ -1,0 +1,17 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  project:
+    $ref: './Href.yaml'
+  target_organization:
+    $ref: './Href.yaml'
+  updated_at:
+    format: date-time
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/TransferRequestInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/TransferRequestInput.yaml
@@ -1,0 +1,5 @@
+properties:
+  target_organization_id:
+    format: uuid
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/TransferRequestList.yaml
+++ b/spec/docs/openapi/public/components/schemas/TransferRequestList.yaml
@@ -1,0 +1,6 @@
+properties:
+  transfers:
+    items:
+      $ref: './TransferRequest.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/UpdateEmailInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/UpdateEmailInput.yaml
@@ -1,0 +1,4 @@
+properties:
+  default:
+    type: boolean
+type: object

--- a/spec/docs/openapi/public/components/schemas/User.yaml
+++ b/spec/docs/openapi/public/components/schemas/User.yaml
@@ -1,0 +1,48 @@
+properties:
+  avatar_thumb_url:
+    type: string
+  avatar_url:
+    type: string
+  created_at:
+    format: date-time
+    type: string
+  customdata:
+    type: object
+  email:
+    type: string
+  emails:
+    items:
+      $ref: './Href.yaml'
+    type: array
+  first_name:
+    type: string
+  fraud_score:
+    type: string
+  full_name:
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  last_login_at:
+    format: date-time
+    type: string
+  last_name:
+    type: string
+  max_organizations:
+    type: integer
+  max_projects:
+    type: integer
+  phone_number:
+    type: string
+  short_id:
+    type: string
+  timezone:
+    type: string
+  two_factor_auth:
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/UserCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/UserCreateInput.yaml
@@ -1,0 +1,47 @@
+properties:
+  avatar:
+    format: binary
+    type: string
+  company_name:
+    type: string
+  company_url:
+    type: string
+  customdata:
+    type: object
+  emails:
+    items:
+      $ref: './EmailInput.yaml'
+    type: array
+  first_name:
+    type: string
+  last_name:
+    type: string
+  level:
+    type: string
+  locked:
+    type: boolean
+  password:
+    type: string
+  phone_number:
+    type: string
+  social_accounts:
+    type: object
+  timezone:
+    type: string
+  title:
+    type: string
+  two_factor_auth:
+    type: string
+  verified_at:
+    format: date-time
+    type: string
+  invitation_id:
+    type: string
+    format: uuid
+  nonce:
+    type: string
+required:
+- first_name
+- last_name
+- emails
+type: object

--- a/spec/docs/openapi/public/components/schemas/UserList.yaml
+++ b/spec/docs/openapi/public/components/schemas/UserList.yaml
@@ -1,0 +1,8 @@
+properties:
+  meta:
+    $ref: './Meta.yaml'
+  users:
+    items:
+      $ref: './User.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/UserLite.yaml
+++ b/spec/docs/openapi/public/components/schemas/UserLite.yaml
@@ -1,0 +1,38 @@
+properties:
+  avatar_thumb_url:
+    description: Avatar thumbnail URL of the User
+    type: string
+  created_at:
+    description: When the user was created
+    format: date-time
+    type: string
+  email:
+    description: Primary email address of the User
+    type: string
+  first_name:
+    description: First name of the User
+    type: string
+  full_name:
+    description: Full name of the User
+    type: string
+  href:
+    description: API URL uniquely representing the User
+    type: string
+  id:
+    description: ID of the User
+    format: uuid
+    type: string
+  last_name:
+    description: Last name of the User
+    type: string
+  short_id:
+    description: Short ID of the User
+    type: string
+  updated_at:
+    description: When the user details were last updated
+    format: date-time
+    type: string
+required:
+- id
+- short_id
+type: object

--- a/spec/docs/openapi/public/components/schemas/UserUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/UserUpdateInput.yaml
@@ -1,0 +1,14 @@
+properties:
+  customdata:
+    type: object
+  first_name:
+    type: string
+  last_name:
+    type: string
+  password:
+    type: string
+  phone_number:
+    type: string
+  timezone:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/Userdata.yaml
+++ b/spec/docs/openapi/public/components/schemas/Userdata.yaml
@@ -1,0 +1,4 @@
+properties:
+  userdata:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/VerifyEmail.yaml
+++ b/spec/docs/openapi/public/components/schemas/VerifyEmail.yaml
@@ -1,0 +1,7 @@
+properties:
+  user_token:
+    description: User verification token
+    type: string
+    writeOnly: true
+required: 
+  -  user_token

--- a/spec/docs/openapi/public/components/schemas/VirtualCircuit.yaml
+++ b/spec/docs/openapi/public/components/schemas/VirtualCircuit.yaml
@@ -1,0 +1,65 @@
+required:
+- bill
+- description
+- id
+- name
+- nni_vlan
+- port
+- project
+- status
+- tags
+- virtual_network
+- vnid
+properties:
+  bill:
+    type: boolean
+    default: false
+    description: True if the Virtual Circuit is being billed. Currently, only Virtual Circuits of Fabric VCs (Metal Billed) will be billed. Usage will start the first time the Virtual Circuit becomes active, and will not stop until it is deleted from Metal.
+  description:
+    type: string
+  id:
+    format: uuid
+    type: string
+  name:
+    type: string
+  nni_vlan:
+    type: integer
+  port:
+    $ref: './Href.yaml'
+  project:
+    $ref: './Href.yaml'
+  speed:
+    description: For Virtual Circuits on shared and dedicated connections, this speed should match the one set on their Interconnection Ports. For Virtual Circuits on
+      Fabric VCs (both Metal and Fabric Billed) that have found their corresponding Fabric connection, this is the actual speed of the interconnection that was configured when setting up the interconnection on the Fabric Portal. 
+      Details on Fabric VCs are included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
+    type: integer
+  status:
+    type: string
+    description: The status of a Virtual Circuit is always 'Pending' on creation. The status can turn to 'Waiting on Customer VLAN' if a Metro VLAN was not set yet on the Virtual Circuit and is the last step needed for full activation. For Dedicated interconnections, as long as the Dedicated Port has been associated 
+      to the Virtual Circuit and a NNI VNID has been set, it will turn to 'Waiting on Customer VLAN'.
+      For Fabric VCs, it will only change to 'Waiting on Customer VLAN' once the corresponding Fabric connection has been found on the Fabric side. Once a Metro VLAN is set on the Virtual Circuit 
+      (which for Fabric VCs, can be set on creation) and the necessary set up is done, it will turn into 'Activating' status as it tries to activate the Virtual Circuit. Once the Virtual Circuit fully activates and is configured on the switch, it will turn to staus 'Active'. For Fabric VCs (Metal Billed), 
+      we will start billing the moment the status of the Virtual Circuit turns to 'Active'. If there are any changes to the VLAN after the Virtual Circuit is in an 'Active' status, the status will show 'Changing VLAN' if a new VLAN has been provided, or 'Deactivating' if we are removing the VLAN. When a 
+      deletion request is issued for the Virtual Circuit, it will move to a 'deleting' status until it is fully deleted. If the Virtual Circuit is on a Fabric VC, it can also change into an 'Expired' status if the associated service token has expired.
+    enum: 
+    - pending
+    - waiting_on_customer_vlan
+    - activating
+    - changing_vlan
+    - deactivating
+    - deleting
+    - active
+    - expired
+    - activation_failed
+    - changing_vlan_failed
+    - deactivation_failed
+    - delete_failed
+  tags:
+    items:
+      type: string
+    type: array
+  virtual_network:
+    $ref: './Href.yaml'
+  vnid:
+    type: integer
+type: object

--- a/spec/docs/openapi/public/components/schemas/VirtualCircuitCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VirtualCircuitCreateInput.yaml
@@ -1,0 +1,26 @@
+properties:
+  description:
+    type: string
+  name:
+    type: string
+  nni_vlan:
+    maximum: 4094
+    minimum: 2
+    type: integer
+  project:
+    format: uuid
+    type: string
+  speed:
+    description: speed can be passed as integer number representing bps speed or string
+      (e.g. '52m' or '100g' or '4 gbps')
+    type: integer
+  tags:
+    items:
+      type: string
+    type: array
+  vnid:
+    description: A Virtual Network record UUID or the VNID of a Metro Virtual Network in
+      your project (sent as integer).
+    format: uuid
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/VirtualCircuitList.yaml
+++ b/spec/docs/openapi/public/components/schemas/VirtualCircuitList.yaml
@@ -1,0 +1,8 @@
+properties:
+  virtual_circuits:
+    items:
+      anyOf:
+      - $ref: './VirtualCircuit.yaml'
+      - $ref: './VrfVirtualCircuit.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/VirtualCircuitUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VirtualCircuitUpdateInput.yaml
@@ -1,0 +1,17 @@
+properties:
+  description:
+    type: string
+  name:
+    type: string
+  speed:
+    description: Speed can be changed only if it is an interconnection on a Dedicated Port
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+  vnid:
+    description: A Virtual Network record UUID or the VNID of a Metro Virtual Network in
+      your project.
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/VirtualNetwork.yaml
+++ b/spec/docs/openapi/public/components/schemas/VirtualNetwork.yaml
@@ -1,0 +1,35 @@
+properties:
+  assigned_to:
+    $ref: './Href.yaml'
+  assigned_to_virtual_circuit:
+    description: True if the virtual network is attached to a virtual circuit. False
+      if not.
+    type: boolean
+  description:
+    type: string
+  facility:
+    $ref: './Href.yaml'
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  instances:
+    description: A list of instances with ports currently associated to this Virtual
+      Network.
+    items:
+      $ref: './Href.yaml'
+    type: array
+  metal_gateways:
+    description: A list of metal gateways currently associated to this Virtual Network.
+    items:
+      $ref: './MetalGatewayLite.yaml'
+    type: array
+  metro:
+    $ref: './Href.yaml'
+  metro_code:
+    description: The Metro code of the metro in which this Virtual Network is defined.
+    type: string
+  vxlan:
+    type: integer
+type: object

--- a/spec/docs/openapi/public/components/schemas/VirtualNetworkCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VirtualNetworkCreateInput.yaml
@@ -1,0 +1,18 @@
+properties:
+  description:
+    type: string
+  facility:
+    description: The UUID (or facility code) for the Facility in which to create this
+      Virtual network.
+    type: string
+  metro:
+    description: The UUID (or metro code) for the Metro in which to create this Virtual
+      Network.
+    type: string
+  vxlan:
+    description: VLAN ID between 2-3999. Must be unique for the project within the
+      Metro in which this Virtual Network is being created. If no value is specified,
+      the next-available VLAN ID in the range 1000-1999 will be automatically selected.
+    example: 1099
+    type: integer
+type: object

--- a/spec/docs/openapi/public/components/schemas/VirtualNetworkList.yaml
+++ b/spec/docs/openapi/public/components/schemas/VirtualNetworkList.yaml
@@ -1,0 +1,6 @@
+properties:
+  virtual_networks:
+    items:
+      $ref: './VirtualNetwork.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/Vrf.yaml
+++ b/spec/docs/openapi/public/components/schemas/Vrf.yaml
@@ -1,0 +1,24 @@
+properties:
+  id:
+    format: uuid
+    type: string
+  name:
+    type: string
+  description:
+    description: Optional field that can be set to describe the VRF
+    type: string
+  local_asn:
+    description: A 4-byte ASN associated with the VRF.
+    type: integer
+    format: int32
+  ip_ranges:
+    $ref: './VrfIpRangeList.yaml'
+  project:
+    $ref: './Project.yaml'
+  metro:
+    $ref: './Metro.yaml'
+  created_by:
+    $ref: './User.yaml'
+  href:
+    type: string
+type: object

--- a/spec/docs/openapi/public/components/schemas/VrfCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfCreateInput.yaml
@@ -1,0 +1,16 @@
+properties:
+  description:
+    type: string
+  ip_ranges:
+    $ref: './VrfIpRangeCreateInput.yaml'
+  local_asn:
+    type: integer
+    format: int32
+  metro:
+    description: The UUID (or metro code) for the Metro in which to create this VRF.
+    type: string
+  name:
+    type: string
+required:
+- metro
+- name

--- a/spec/docs/openapi/public/components/schemas/VrfIpRangeCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfIpRangeCreateInput.yaml
@@ -1,0 +1,6 @@
+type: array
+items:
+  type: string
+description: A list of CIDR network addresses. Like ["10.0.0.0/16", "2001:d78::/56"].
+  IPv4 blocks must be between /8 and /29 in size. IPv6 blocks must be between /56 and /64.
+  A VRF\'s IP ranges must be defined in order to create VRF IP Reservations, which can then be used for Metal Gateways or Virtual Circuits.

--- a/spec/docs/openapi/public/components/schemas/VrfIpRangeList.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfIpRangeList.yaml
@@ -1,0 +1,4 @@
+type: array
+items:
+  type: string
+description: A list of CIDR network addresses. Like ["10.0.0.0/16", "2001:d78::/56"].

--- a/spec/docs/openapi/public/components/schemas/VrfIpRangeUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfIpRangeUpdateInput.yaml
@@ -1,0 +1,10 @@
+type: array
+items:
+  type: string
+description: A list of CIDR network addresses. Like ["10.0.0.0/16", "2001:d78::/56"].
+  IPv4 blocks must be between /8 and /29 in size. IPv6 blocks must be between /56 and /64.
+  A VRF\'s IP ranges must be defined in order to create VRF IP Reservations, which can then be used for Metal Gateways or Virtual Circuits.
+  Adding a new CIDR address to the list will result in the creation of a new IP Range for this VRF.
+  Removal of an existing CIDR address from the list will result in the deletion of an existing IP Range for this VRF. Deleting an IP Range will result in the deletion of any VRF IP Reservations contained within the IP Range, as well as the VRF IP Reservation\'s associated Metal Gateways or Virtual Circuits.
+  If you do not wish to add or remove IP Ranges, either include the full existing list of IP Ranges in the update request, or do not specify the `ip_ranges` field in the update request.
+  Specifying a value of `[]` will remove all existing IP Ranges from the VRF.

--- a/spec/docs/openapi/public/components/schemas/VrfIpReservation.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfIpReservation.yaml
@@ -1,0 +1,41 @@
+properties:
+  address_family:
+    type: integer
+  cidr:
+    type: integer
+  created_at:
+    format: date-time
+    type: string
+  created_by:
+    $ref: './Href.yaml'
+  details:
+    type: string
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  metal_gateway:
+    $ref: './MetalGatewayLite.yaml'
+  netmask:
+    type: string
+  network:
+    type: string
+  project:
+    $ref: './Project.yaml'
+  state:
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+  type:
+    type: string
+    enum:
+    - vrf
+  vrf:
+    $ref: './Vrf.yaml'
+required:
+  - vrf
+  - type
+type: object

--- a/spec/docs/openapi/public/components/schemas/VrfIpReservationCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfIpReservationCreateInput.yaml
@@ -1,0 +1,30 @@
+properties:
+  cidr:
+    type: integer
+    example: 16
+    description: The size of the VRF IP Reservation's subnet
+  customdata:
+    type: object
+  details:
+    type: string
+  network:
+    type: string
+    example: "10.1.2.0"
+    description: "The starting address for this VRF IP Reservation's subnet"
+  tags:
+    items:
+      type: string
+    type: array
+  type:
+    type: string
+    example: vrf
+    description: "Must be set to 'vrf'"
+  vrf_id:
+    type: string
+    format: uuid
+    description: The ID of the VRF in which this VRF IP Reservation is created. The VRF must have an existing IP Range that contains the requested subnet. This field may be aliased as just 'vrf'.
+required:
+  - cidr
+  - network
+  - type
+  - vrf_id

--- a/spec/docs/openapi/public/components/schemas/VrfIpReservationList.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfIpReservationList.yaml
@@ -1,0 +1,6 @@
+properties:
+  ip_addresses:
+    items:
+      $ref: './VrfIpReservation.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/VrfList.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfList.yaml
@@ -1,0 +1,6 @@
+properties:
+  vrfs:
+    items:
+      $ref: './Vrf.yaml'
+    type: array
+type: object

--- a/spec/docs/openapi/public/components/schemas/VrfMetalGateway.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfMetalGateway.yaml
@@ -1,0 +1,34 @@
+properties:
+  created_at:
+    format: date-time
+    type: string
+  created_by:
+    $ref: './Href.yaml'
+  href:
+    type: string
+  id:
+    format: uuid
+    type: string
+  ip_reservation:
+    $ref: './VrfIpReservation.yaml'
+  project:
+    $ref: './Project.yaml'
+  state:
+    description: The current state of the Metal Gateway. 'Ready' indicates the gateway
+      record has been configured, but is currently not active on the network. 'Active'
+      indicates the gateway has been configured on the network. 'Deleting' is a temporary
+      state used to indicate that the gateway is in the process of being un-configured
+      from the network, after which the gateway record will be deleted.
+    enum:
+    - ready
+    - active
+    - deleting
+    type: string
+  updated_at:
+    format: date-time
+    type: string
+  virtual_network:
+    $ref: './VirtualNetwork.yaml'
+  vrf:
+    $ref: './Vrf.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/VrfMetalGatewayCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfMetalGatewayCreateInput.yaml
@@ -1,0 +1,16 @@
+properties:
+  ip_reservation_id:
+    description: The UUID an a VRF IP Reservation that belongs to the same project as
+      the one in which the Metal Gateway is to be created. Additionally, the VRF IP Reservation
+      and the Virtual Network must reside in the same Metro.
+    format: uuid
+    type: string
+  virtual_network_id:
+    description: THe UUID of a Metro Virtual Network that belongs to the same project as
+      the one in which the Metal Gateway is to be created. Additionally, the Virtual Network
+      and the VRF IP Reservation must reside in the same metro.
+    format: uuid
+    type: string
+required:
+  - ip_reservation_id
+  - virtual_network_id

--- a/spec/docs/openapi/public/components/schemas/VrfUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfUpdateInput.yaml
@@ -1,0 +1,11 @@
+properties:
+  description:
+    type: string
+  ip_ranges:
+    $ref: './VrfIpRangeUpdateInput.yaml'
+  local_asn:
+    type: integer
+    format: int32
+    description: The new `local_asn` value for the VRF. This field cannot be updated when there are active Interconnection Virtual Circuits associated to the VRF.
+  name:
+    type: string

--- a/spec/docs/openapi/public/components/schemas/VrfVirtualCircuit.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfVirtualCircuit.yaml
@@ -1,0 +1,56 @@
+properties:
+  customer_ip:
+    description: >-
+      An IP address from the subnet that will be used on the Customer side. This parameter is optional,
+      but if supplied, we will use the other usable IP address in the subnet as the Metal IP. By default,
+      the last usable IP address in the subnet will be used.
+    type: string
+    example: "12.0.0.2"
+  description:
+    type: string
+  id:
+    format: uuid
+    type: string
+  md5:
+    description: >-
+      The MD5 password for the BGP peering in plaintext (not a checksum).
+    type: string
+  metal_ip:
+    description: >-
+      An IP address from the subnet that will be used on the Metal side. This parameter is optional,
+      but if supplied, we will use the other usable IP address in the subnet as the Customer IP. By default,
+      the first usable IP address in the subnet will be used.
+    type: string
+    example: "12.0.0.1"
+  name:
+    type: string
+  port:
+    $ref: './Href.yaml'
+  nni_vlan:
+    type: integer
+  peer_asn:
+    description: The peer ASN that will be used with the VRF on the Virtual Circuit.
+    type: integer
+  project:
+    $ref: './Href.yaml'
+  speed:
+    description: integer representing bps speed
+    type: integer
+  status:
+    type: string
+  subnet:
+    description: >-
+      The /30 or /31 subnet of one of the VRF IP Blocks that will be used with the VRF for
+      the Virtual Circuit. This subnet does not have to be an existing VRF IP reservation, as we
+      will create the VRF IP reservation on creation if it does not exist. The Metal IP and Customer
+      IP must be IPs from this subnet. For /30 subnets, the network and broadcast IPs cannot be used
+      as the Metal or Customer IP.
+    type: string
+    example: "12.0.0.0/30"
+  tags:
+    items:
+      type: string
+    type: array
+  vrf:
+    $ref: './Vrf.yaml'
+type: object

--- a/spec/docs/openapi/public/components/schemas/VrfVirtualCircuitCreateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfVirtualCircuitCreateInput.yaml
@@ -1,0 +1,59 @@
+properties:
+  customer_ip:
+    description: An IP address from the subnet that will be used on the Customer side. This parameter is optional,
+      but if supplied, we will use the other usable IP address in the subnet as the Metal IP. By default,
+      the last usable IP address in the subnet will be used.
+    type: string
+    example: "12.0.0.2"
+  description:
+    type: string
+  md5:
+    description: The MD5 password for the BGP peering in plaintext (not a checksum).
+    nullable: true
+    type: string
+  metal_ip:
+    description: An IP address from the subnet that will be used on the Metal side. This parameter is optional,
+      but if supplied, we will use the other usable IP address in the subnet as the Customer IP. By default,
+      the first usable IP address in the subnet will be used.
+    type: string
+    example: "12.0.0.1"
+  name:
+    type: string
+  nni_vlan:
+    maximum: 4094
+    minimum: 2
+    type: integer
+  peer_asn:
+    description: The peer ASN that will be used with the VRF on the Virtual Circuit.
+    type: integer
+  project:
+    format: uuid
+    type: string
+  speed:
+    description: speed can be passed as integer number representing bps speed or string
+      (e.g. '52m' or '100g' or '4 gbps')
+    type: integer
+  subnet:
+    description: The /30 or /31 subnet of one of the VRF IP Blocks that will be used with the VRF for
+      the Virtual Circuit. This subnet does not have to be an existing VRF IP reservation, as we
+      will create the VRF IP reservation on creation if it does not exist. The Metal IP and Customer
+      IP must be IPs from this subnet. For /30 subnets, the network and broadcast IPs cannot be used
+      as the Metal or Customer IP. The subnet specified must be contained within an already-defined
+      IP Range for the VRF.
+    type: string
+    example: "12.0.0.0/30"
+  tags:
+    items:
+      type: string
+    type: array
+  vrf:
+    description: The UUID of the VRF that will be associated with the Virtual Circuit.
+    format: uuid
+    type: string
+type: object
+required:
+- nni_vlan
+- peer_asn
+- project
+- subnet
+- vrf

--- a/spec/docs/openapi/public/components/schemas/VrfVirtualCircuitUpdateInput.yaml
+++ b/spec/docs/openapi/public/components/schemas/VrfVirtualCircuitUpdateInput.yaml
@@ -1,0 +1,13 @@
+properties:
+  description:
+    type: string
+  name:
+    type: string
+  speed:
+    description: Speed can be changed only if it is an interconnection on a Dedicated Port
+    type: string
+  tags:
+    items:
+      type: string
+    type: array
+type: object

--- a/spec/docs/openapi/public/openapi3.yaml
+++ b/spec/docs/openapi/public/openapi3.yaml
@@ -1,0 +1,1043 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Metal API
+  contact:
+    email: support@equinixmetal.com
+    name: Equinix Metal API Team
+  description: |
+    # Introduction
+    Equinix Metal provides a RESTful HTTP API which can be reached at <https://api.equinix.com/metal/v1>. This document describes the API and how to use it.
+
+    The API allows you to programmatically interact with all
+    of your Equinix Metal resources, including devices, networks, addresses, organizations,
+    projects, and your user account. Every feature of the Equinix Metal web interface is accessible through the API.
+
+    The API docs are generated from the Equinix Metal OpenAPI specification and are officially hosted at <https://metal.equinix.com/developers/api>.
+
+    # Common Parameters
+
+    The Equinix Metal API uses a few methods to minimize network traffic and improve throughput. These parameters are not used in all API calls, but are used often enough to warrant their own section. Look for these parameters in the documentation for the API calls that support them.
+
+    ## Pagination
+
+    Pagination is used to limit the number of results returned in a single request. The API will return a maximum of 100 results per page. To retrieve additional results, you can use the `page` and `per_page` query parameters.
+
+    The `page` parameter is used to specify the page number. The first page is `1`. The `per_page` parameter is used to specify the number of results per page. The maximum number of results differs by resource type.
+
+    ## Sorting
+    
+    Where offered, the API allows you to sort results by a specific field. To sort results use the `sort_by` query parameter with the root level field name as the value. The `sort_direction` parameter is used to specify the sort direction, either either `asc` (ascending) or `desc` (descending).
+
+    ## Filtering
+
+    Filtering is used to limit the results returned in a single request. The API supports filtering by certain fields in the response. To filter results, you can use the field as a query parameter.
+
+    For example, to filter the IP list to only return public IPv4 addresses, you can filter by the `type` field, as in the following request:
+
+    ```sh
+    curl -H 'X-Auth-Token: my_authentication_token' \
+      https://api.equinix.com/metal/v1/projects/id/ips?type=public_ipv4
+    ```
+
+    Only IP addresses with the `type` field set to `public_ipv4` will be returned.
+
+    ## Searching
+
+    Searching is used to find matching resources using multiple field comparissons. The API supports searching in resources that define this behavior. The fields available for search differ by resource, as does the search strategy.
+
+    To search resources you can use the `search` query parameter.
+
+    ## Include and Exclude
+
+    For resources that contain references to other resources, sucha as a Device that refers to the Project it resides in, the Equinix Metal API will returns `href` values (API links) to the associated resource.
+
+    ```json
+    {
+      ...
+      "project": {
+        "href": "/metal/v1/projects/f3f131c8-f302-49ef-8c44-9405022dc6dd"
+      }
+    }
+    ```
+
+    If you're going need the project details, you can avoid a second API request.  Specify the contained `href` resources and collections that you'd like to have included in the response using the `include` query parameter.
+    
+    For example:
+      
+    ```sh
+    curl -H 'X-Auth-Token: my_authentication_token' \
+      https://api.equinix.com/metal/v1/user?include=projects
+    ```
+
+    The `include` parameter is generally accepted in `GET`, `POST`, `PUT`, and `PATCH` requests where `href` resources are presented.
+    
+    To have multiple resources include, use a comma-separated list (e.g. `?include=emails,projects,memberships`).
+
+    ```sh
+    curl -H 'X-Auth-Token: my_authentication_token' \
+      https://api.equinix.com/metal/v1/user?include=emails,projects,memberships
+    ```
+
+    You may also include nested associations up to three levels deep using dot notation (`?include=memberships.projects`):
+
+    ```sh
+    curl -H 'X-Auth-Token: my_authentication_token' \
+      https://api.equinix.com/metal/v1/user?include=memberships.projects
+    ```
+
+    To exclude resources, and optimize response delivery, use the `exclude` query parameter. The `exclude` parameter is generally accepted in `GET`, `POST`, `PUT`, and `PATCH` requests for fields with nested object responses. When excluded, these fields will be replaced with an object that contains only an `href` field.
+  license:
+    name: Equinix Metal
+    url: https://metal.equinix.com/legal/
+  termsOfService: https://metal.equinix.com/legal/
+security:
+  - x_auth_token: []
+servers:
+  - url: https://api.equinix.com/metal/v1
+components:
+  parameters:
+    Page:
+      $ref: './components/parameters/Page.yaml'
+    PerPage:
+      $ref: './components/parameters/PerPage.yaml'
+    Include:
+      $ref: './components/parameters/Include.yaml'
+    Exclude:
+      $ref: './components/parameters/Exclude.yaml'
+  requestBodies:
+    InterconnectionCreateInput:
+      $ref: './components/requestBodies/InterconnectionCreateInput.yaml'
+    InvitationInput:
+      $ref: './components/requestBodies/InvitationInput.yaml'
+    PortAssignInput:
+      $ref: './components/requestBodies/PortAssignInput.yaml'
+    SSHKeyCreateInput:
+      $ref: './components/requestBodies/SSHKeyCreateInput.yaml'
+  schemas:
+    Address:
+      $ref: './components/schemas/Address.yaml'
+    AuthToken:
+      $ref: './components/schemas/AuthToken.yaml'
+    AuthTokenInput:
+      $ref: './components/schemas/AuthTokenInput.yaml'
+    AuthTokenList:
+      $ref: './components/schemas/AuthTokenList.yaml'
+    BGPSessionInput:
+      $ref: './components/schemas/BGPSessionInput.yaml'
+    Batch:
+      $ref: './components/schemas/Batch.yaml'
+    BatchesList:
+      $ref: './components/schemas/BatchesList.yaml'
+    BgpConfig:
+      $ref: './components/schemas/BgpConfig.yaml'
+    BgpConfigRequestInput:
+      $ref: './components/schemas/BgpConfigRequestInput.yaml'
+    BgpNeighborData:
+      $ref: './components/schemas/BgpNeighborData.yaml'
+    BgpSession:
+      $ref: './components/schemas/BgpSession.yaml'
+    BgpSessionList:
+      $ref: './components/schemas/BgpSessionList.yaml'
+    BgpSessionNeighbors:
+      $ref: './components/schemas/BgpSessionNeighbors.yaml'
+    CapacityCheckPerFacilityInfo:
+      $ref: './components/schemas/CapacityCheckPerFacilityInfo.yaml'
+    CapacityCheckPerFacilityList:
+      $ref: './components/schemas/CapacityCheckPerFacilityList.yaml'
+    CapacityCheckPerMetroInfo:
+      $ref: './components/schemas/CapacityCheckPerMetroInfo.yaml'
+    CapacityCheckPerMetroList:
+      $ref: './components/schemas/CapacityCheckPerMetroList.yaml'
+    CapacityInput:
+      $ref: './components/schemas/CapacityInput.yaml'
+    CapacityLevelPerBaremetal:
+      $ref: './components/schemas/CapacityLevelPerBaremetal.yaml'
+    CapacityList:
+      $ref: './components/schemas/CapacityList.yaml'
+    CapacityPerFacility:
+      $ref: './components/schemas/CapacityPerFacility.yaml'
+    CapacityPerMetroInput:
+      $ref: './components/schemas/CapacityPerMetroInput.yaml'
+    CapacityPerNewFacility:
+      $ref: './components/schemas/CapacityPerNewFacility.yaml'
+    CapacityReport:
+      $ref: './components/schemas/CapacityReport.yaml'
+    Coordinates:
+      $ref: './components/schemas/Coordinates.yaml'
+    CreateEmailInput:
+      $ref: './components/schemas/CreateEmailInput.yaml'
+    CreateSelfServiceReservationRequest:
+      $ref: './components/schemas/CreateSelfServiceReservationRequest.yaml'
+    Device:
+      $ref: './components/schemas/Device.yaml'
+    DeviceCreateInput:
+      $ref: './components/schemas/DeviceCreateInput.yaml'
+    DeviceCreateInFacilityInput:
+      $ref: './components/schemas/DeviceCreateInFacilityInput.yaml'
+    DeviceCreateInMetroInput:
+      $ref: './components/schemas/DeviceCreateInMetroInput.yaml'
+    DeviceList:
+      $ref: './components/schemas/DeviceList.yaml'
+    DeviceUpdateInput:
+      $ref: './components/schemas/DeviceUpdateInput.yaml'
+    DeviceUsage:
+      $ref: './components/schemas/DeviceUsage.yaml'
+    DeviceUsageList:
+      $ref: './components/schemas/DeviceUsageList.yaml'
+    Email:
+      $ref: './components/schemas/Email.yaml'
+    EmailInput:
+      $ref: './components/schemas/EmailInput.yaml'
+    Entitlement:
+      $ref: './components/schemas/Entitlement.yaml'
+    Error:
+      $ref: './components/schemas/Error.yaml'
+    Event:
+      $ref: './components/schemas/Event.yaml'
+    EventList:
+      $ref: './components/schemas/EventList.yaml'
+    FabricServiceToken:
+      $ref: './components/schemas/FabricServiceToken.yaml'
+    Facility:
+      $ref: './components/schemas/Facility.yaml'
+    FacilityInput:
+      $ref: './components/schemas/FacilityInput.yaml'
+    FacilityList:
+      $ref: './components/schemas/FacilityList.yaml'
+    GlobalBgpRange:
+      $ref: './components/schemas/GlobalBgpRange.yaml'
+    GlobalBgpRangeList:
+      $ref: './components/schemas/GlobalBgpRangeList.yaml'
+    HardwareReservation:
+      $ref: './components/schemas/HardwareReservation.yaml'
+    HardwareReservationList:
+      $ref: './components/schemas/HardwareReservationList.yaml'
+    Href:
+      $ref: './components/schemas/Href.yaml'
+    IPAssignment:
+      $ref: './components/schemas/IPAssignment.yaml'
+    IPAssignmentInput:
+      $ref: './components/schemas/IPAssignmentInput.yaml'
+    IPAssignmentList:
+      $ref: './components/schemas/IPAssignmentList.yaml'
+    IPAvailabilitiesList:
+      $ref: './components/schemas/IPAvailabilitiesList.yaml'
+    IPReservation:
+      $ref: './components/schemas/IPReservation.yaml'
+    IPReservationList:
+      $ref: './components/schemas/IPReservationList.yaml'
+    IPReservationRequestInput:
+      $ref: './components/schemas/IPReservationRequestInput.yaml'
+    InstancesBatchCreateInput:
+      $ref: './components/schemas/InstancesBatchCreateInput.yaml'
+    Interconnection:
+      $ref: './components/schemas/Interconnection.yaml'
+    InterconnectionCreateInput:
+      $ref: './components/schemas/InterconnectionCreateInput.yaml'
+    InterconnectionList:
+      $ref: './components/schemas/InterconnectionList.yaml'
+    InterconnectionPort:
+      $ref: './components/schemas/InterconnectionPort.yaml'
+    InterconnectionPortList:
+      $ref: './components/schemas/InterconnectionPortList.yaml'
+    InterconnectionUpdateInput:
+      $ref: './components/schemas/InterconnectionUpdateInput.yaml'
+    Invitation:
+      $ref: './components/schemas/Invitation.yaml'
+    InvitationInput:
+      $ref: './components/schemas/InvitationInput.yaml'
+    InvitationList:
+      $ref: './components/schemas/InvitationList.yaml'
+    License:
+      $ref: './components/schemas/License.yaml'
+    LicenseCreateInput:
+      $ref: './components/schemas/LicenseCreateInput.yaml'
+    LicenseList:
+      $ref: './components/schemas/LicenseList.yaml'
+    LicenseUpdateInput:
+      $ref: './components/schemas/LicenseUpdateInput.yaml'
+    Membership:
+      $ref: './components/schemas/Membership.yaml'
+    MembershipInput:
+      $ref: './components/schemas/MembershipInput.yaml'
+    MembershipList:
+      $ref: './components/schemas/MembershipList.yaml'
+    Meta:
+      $ref: './components/schemas/Meta.yaml'
+    Metadata:
+      $ref: './components/schemas/Metadata.yaml'
+    MetalGateway:
+      $ref: './components/schemas/MetalGateway.yaml'
+    MetalGatewayCreateInput:
+      $ref: './components/schemas/MetalGatewayCreateInput.yaml'
+    MetalGatewayList:
+      $ref: './components/schemas/MetalGatewayList.yaml'
+    MetalGatewayLite:
+      $ref: './components/schemas/MetalGatewayLite.yaml'
+    Metro:
+      $ref: './components/schemas/Metro.yaml'
+    MetroInput:
+      $ref: './components/schemas/MetroInput.yaml'
+    MetroCapacityList:
+      $ref: './components/schemas/MetroCapacityList.yaml'
+    MetroCapacityReport:
+      $ref: './components/schemas/MetroCapacityReport.yaml'
+    MetroList:
+      $ref: './components/schemas/MetroList.yaml'
+    MetroServerInfo:
+      $ref: './components/schemas/MetroServerInfo.yaml'
+    NewPassword:
+      $ref: './components/schemas/NewPassword.yaml'
+    OperatingSystem:
+      $ref: './components/schemas/OperatingSystem.yaml'
+    OperatingSystemList:
+      $ref: './components/schemas/OperatingSystemList.yaml'
+    Organization:
+      $ref: './components/schemas/Organization.yaml'
+    OrganizationInput:
+      $ref: './components/schemas/OrganizationInput.yaml'
+    OrganizationList:
+      $ref: './components/schemas/OrganizationList.yaml'
+    ParentBlock:
+      $ref: './components/schemas/ParentBlock.yaml'
+    PaymentMethod:
+      $ref: './components/schemas/PaymentMethod.yaml'
+    PaymentMethodBillingAddress:
+      $ref: './components/schemas/PaymentMethodBillingAddress.yaml'
+    PaymentMethodCreateInput:
+      $ref: './components/schemas/PaymentMethodCreateInput.yaml'
+    PaymentMethodList:
+      $ref: './components/schemas/PaymentMethodList.yaml'
+    PaymentMethodUpdateInput:
+      $ref: './components/schemas/PaymentMethodUpdateInput.yaml'
+    Plan:
+      $ref: './components/schemas/Plan.yaml'
+    PlanList:
+      $ref: './components/schemas/PlanList.yaml'
+    Port:
+      $ref: './components/schemas/Port.yaml'
+    PortAssignInput:
+      $ref: './components/schemas/PortAssignInput.yaml'
+    PortConvertLayer3Input:
+      $ref: './components/schemas/PortConvertLayer3Input.yaml'
+    PortVlanAssignment:
+      $ref: './components/schemas/PortVlanAssignment.yaml'
+    PortVlanAssignmentBatch:
+      $ref: './components/schemas/PortVlanAssignmentBatch.yaml'
+    PortVlanAssignmentBatchCreateInput:
+      $ref: './components/schemas/PortVlanAssignmentBatchCreateInput.yaml'
+    PortVlanAssignmentBatchList:
+      $ref: './components/schemas/PortVlanAssignmentBatchList.yaml'
+    PortVlanAssignmentList:
+      $ref: './components/schemas/PortVlanAssignmentList.yaml'
+    Project:
+      $ref: './components/schemas/Project.yaml'
+    ProjectCreateFromRootInput:
+      $ref: './components/schemas/ProjectCreateFromRootInput.yaml'
+    ProjectCreateInput:
+      $ref: './components/schemas/ProjectCreateInput.yaml'
+    ProjectList:
+      $ref: './components/schemas/ProjectList.yaml'
+    ProjectUpdateInput:
+      $ref: './components/schemas/ProjectUpdateInput.yaml'
+    ProjectUsage:
+      $ref: './components/schemas/ProjectUsage.yaml'
+    ProjectUsageList:
+      $ref: './components/schemas/ProjectUsageList.yaml'
+    RecoveryCodeList:
+      $ref: './components/schemas/RecoveryCodeList.yaml'
+    SSHKey:
+      $ref: './components/schemas/SSHKey.yaml'
+    SSHKeyCreateInput:
+      $ref: './components/schemas/SSHKeyCreateInput.yaml'
+    SSHKeyInput:
+      $ref: './components/schemas/SSHKeyInput.yaml'
+    SSHKeyList:
+      $ref: './components/schemas/SSHKeyList.yaml'
+    SelfServiceReservationItemRequest:
+      $ref: './components/schemas/SelfServiceReservationItemRequest.yaml'
+    SelfServiceReservationItemResponse:
+      $ref: './components/schemas/SelfServiceReservationItemResponse.yaml'
+    SelfServiceReservationList:
+      $ref: './components/schemas/SelfServiceReservationList.yaml'
+    SelfServiceReservationResponse:
+      $ref: './components/schemas/SelfServiceReservationResponse.yaml'
+    ServerInfo:
+      $ref: './components/schemas/ServerInfo.yaml'
+    SpotMarketPricesList:
+      $ref: './components/schemas/SpotMarketPricesList.yaml'
+    SpotMarketPricesPerMetroList:
+      $ref: './components/schemas/SpotMarketPricesPerMetroList.yaml'
+    SpotMarketPricesPerMetroReport:
+      $ref: './components/schemas/SpotMarketPricesPerMetroReport.yaml'
+    SpotMarketRequest:
+      $ref: './components/schemas/SpotMarketRequest.yaml'
+    SpotMarketRequestCreateInput:
+      $ref: './components/schemas/SpotMarketRequestCreateInput.yaml'
+    SpotMarketRequestList:
+      $ref: './components/schemas/SpotMarketRequestList.yaml'
+    SpotPricesDatapoints:
+      $ref: './components/schemas/SpotPricesDatapoints.yaml'
+    SpotPricesDatapointsList:
+      $ref: './components/schemas/SpotPricesDatapointsList.yaml'
+    SpotPricesHistoryReport:
+      $ref: './components/schemas/SpotPricesHistoryReport.yaml'
+    SpotPricesPerBaremetal:
+      $ref: './components/schemas/SpotPricesPerBaremetal.yaml'
+    SpotPricesPerFacility:
+      $ref: './components/schemas/SpotPricesPerFacility.yaml'
+    SpotPricesPerNewFacility:
+      $ref: './components/schemas/SpotPricesPerNewFacility.yaml'
+    SpotPricesReport:
+      $ref: './components/schemas/SpotPricesReport.yaml'
+    SupportRequestInput:
+      $ref: './components/schemas/SupportRequestInput.yaml'
+    TransferRequest:
+      $ref: './components/schemas/TransferRequest.yaml'
+    TransferRequestInput:
+      $ref: './components/schemas/TransferRequestInput.yaml'
+    TransferRequestList:
+      $ref: './components/schemas/TransferRequestList.yaml'
+    UpdateEmailInput:
+      $ref: './components/schemas/UpdateEmailInput.yaml'
+    User:
+      $ref: './components/schemas/User.yaml'
+    UserCreateInput:
+      $ref: './components/schemas/UserCreateInput.yaml'
+    Userdata:
+      $ref: './components/schemas/Userdata.yaml'
+    UserList:
+      $ref: './components/schemas/UserList.yaml'
+    UserLite:
+      $ref: './components/schemas/UserLite.yaml'
+    UserUpdateInput:
+      $ref: './components/schemas/UserUpdateInput.yaml'
+    VerifyEmail:
+      $ref: './components/schemas/VerifyEmail.yaml'
+    VirtualCircuit:
+      $ref: './components/schemas/VirtualCircuit.yaml'
+    VirtualCircuitCreateInput:
+      $ref: './components/schemas/VirtualCircuitCreateInput.yaml'
+    VirtualCircuitList:
+      $ref: './components/schemas/VirtualCircuitList.yaml'
+    VirtualCircuitUpdateInput:
+      $ref: './components/schemas/VirtualCircuitUpdateInput.yaml'
+    VirtualNetwork:
+      $ref: './components/schemas/VirtualNetwork.yaml'
+    VirtualNetworkCreateInput:
+      $ref: './components/schemas/VirtualNetworkCreateInput.yaml'
+    VirtualNetworkList:
+      $ref: './components/schemas/VirtualNetworkList.yaml'
+    Vrf:
+      $ref: './components/schemas/Vrf.yaml'
+    VrfCreateInput:
+      $ref: './components/schemas//VrfCreateInput.yaml'
+    VrfIpRangeCreateInput:
+      $ref: './components/schemas//VrfIpRangeCreateInput.yaml'
+    VrfIpRangeList:
+      $ref: './components/schemas/VrfIpRangeList.yaml'
+    VrfIpRangeUpdateInput:
+      $ref: './components/schemas/VrfIpRangeUpdateInput.yaml'
+    VrfIpReservation:
+      $ref: './components/schemas/VrfIpReservation.yaml'
+    VrfIpReservationCreateInput:
+      $ref: './components/schemas/VrfIpReservationCreateInput.yaml'
+    VrfIpReservationList:
+      $ref: './components/schemas/VrfIpReservationList.yaml'
+    VrfList:
+      $ref: './components/schemas/VrfList.yaml'
+    VrfMetalGateway:
+      $ref: './components/schemas/VrfMetalGateway.yaml'
+    VrfMetalGatewayCreateInput:
+      $ref: './components/schemas/VrfMetalGatewayCreateInput.yaml'
+    VrfUpdateInput:
+      $ref: './components/schemas/VrfUpdateInput.yaml'
+    VrfVirtualCircuit:
+      $ref: './components/schemas/VrfVirtualCircuit.yaml'
+    VrfVirtualCircuitCreateInput:
+      $ref: './components/schemas/VrfVirtualCircuitCreateInput.yaml'
+    VrfVirtualCircuitUpdateInput:
+      $ref: './components/schemas/VrfVirtualCircuitUpdateInput.yaml'
+  securitySchemes:
+    x_auth_token:
+      in: header
+      name: X-Auth-Token
+      type: apiKey
+      x-displayName: X-Auth-Token
+      description: |+
+        HTTP header containing the User or Project API key that will be used to authenticate the request.
+paths:
+  /api-keys/{id}:
+    $ref: ./paths/api-keys/id.yaml
+  /batches/{id}:
+    $ref: ./paths/batches/id.yaml
+  /bgp/sessions/{id}:
+    $ref: ./paths/bgp/sessions/id.yaml
+  /capacity:
+    $ref: ./paths/capacity.yaml
+  /capacity/metros:
+    $ref: ./paths/capacity/metros.yaml
+  /connections/{connection_id}:
+    $ref: ./paths/connections/connection_id.yaml
+  /connections/{connection_id}/events:
+    $ref: ./paths/connections/connection_id/events.yaml
+  /connections/{connection_id}/ports:
+    $ref: ./paths/connections/connection_id/ports.yaml
+  /connections/{connection_id}/ports/{id}:
+    $ref: ./paths/connections/connection_id/ports/id.yaml
+  /connections/{connection_id}/ports/{id}/events:
+    $ref: ./paths/connections/connection_id/ports/id/events.yaml
+  /connections/{connection_id}/ports/{port_id}/virtual-circuits:
+    $ref: ./paths/connections/connection_id/ports/port_id/virtual-circuits.yaml
+  /devices/{id}:
+    $ref: ./paths/devices/id.yaml
+  /devices/{id}/actions:
+    $ref: ./paths/devices/id/actions.yaml
+  /devices/{id}/bandwidth:
+    $ref: ./paths/devices/id/bandwidth.yaml
+  /devices/{id}/bgp/neighbors:
+    $ref: ./paths/devices/id/bgp/neighbors.yaml
+  /devices/{id}/bgp/sessions:
+    $ref: ./paths/devices/id/bgp/sessions.yaml
+  /devices/{id}/customdata:
+    $ref: ./paths/devices/id/customdata.yaml
+  /devices/{id}/events:
+    $ref: ./paths/devices/id/events.yaml
+  /devices/{id}/ips:
+    $ref: ./paths/devices/id/ips.yaml
+  /devices/{id}/metadata:
+    $ref: ./paths/devices/id/metadata.yaml
+  /devices/{id}/ssh-keys:
+    $ref: ./paths/devices/id/ssh-keys.yaml
+  /devices/{id}/traffic:
+    $ref: ./paths/devices/id/traffic.yaml
+  /devices/{id}/usages:
+    $ref: ./paths/devices/id/usages.yaml
+  /devices/{id}/userdata:
+    $ref: ./paths/devices/id/userdata.yaml
+  /devices/{instance_id}/ips/{id}/customdata:
+    $ref: ./paths/devices/instance_id/ips/id/customdata.yaml
+  /emails:
+    $ref: ./paths/emails.yaml
+  /emails/{id}:
+    $ref: ./paths/emails/id.yaml
+  /events:
+    $ref: ./paths/events.yaml
+  /events/{id}:
+    $ref: ./paths/events/id.yaml
+  /facilities:
+    $ref: ./paths/facilities.yaml
+  /hardware-reservations/{id}:
+    $ref: ./paths/hardware-reservations/id.yaml
+  /hardware-reservations/{id}/move:
+    $ref: ./paths/hardware-reservations/id/move.yaml
+  /incidents:
+    $ref: ./paths/incidents.yaml
+  /invitations:
+    $ref: ./paths/invitations.yaml
+  /invitations/{id}:
+    $ref: ./paths/invitations/id.yaml
+  /ips/{id}:
+    $ref: ./paths/ips/id.yaml
+  /ips/{id}/available:
+    $ref: ./paths/ips/id/available.yaml
+  /ips/{id}/customdata:
+    $ref: ./paths/ips/id/customdata.yaml
+  /licenses/{id}:
+    $ref: ./paths/licenses/id.yaml
+  /locations/metros:
+    $ref: ./paths/locations/metros.yaml
+  /locations/metros/{id}:
+    $ref: ./paths/locations/metros/id.yaml
+  /market/spot/prices:
+    $ref: ./paths/market/spot/prices.yaml
+  /market/spot/prices/history:
+    $ref: ./paths/market/spot/prices/history.yaml
+  /market/spot/prices/metros:
+    $ref: ./paths/market/spot/prices/metros.yaml
+  /memberships/{id}:
+    $ref: ./paths/memberships/id.yaml
+  /metal-gateways/{id}:
+    $ref: ./paths/metal-gateways/id.yaml
+  /operating-system-versions:
+    $ref: ./paths/operating-system-versions.yaml
+  /operating-systems:
+    $ref: ./paths/operating-systems.yaml
+  /organizations:
+    $ref: ./paths/organizations.yaml
+  /organizations/{id}:
+    $ref: ./paths/organizations/id.yaml
+  /organizations/{id}/capacity:
+    $ref: ./paths/organizations/id/capacity.yaml
+  /organizations/{id}/capacity/metros:
+    $ref: ./paths/organizations/id/capacity/metros.yaml
+  /organizations/{id}/customdata:
+    $ref: ./paths/organizations/id/customdata.yaml
+  /organizations/{id}/devices:
+    $ref: ./paths/organizations/id/devices.yaml
+  /organizations/{id}/events:
+    $ref: ./paths/organizations/id/events.yaml
+  /organizations/{id}/facilities:
+    $ref: ./paths/organizations/id/facilities.yaml
+  /organizations/{id}/invitations:
+    $ref: ./paths/organizations/id/invitations.yaml
+  /organizations/{id}/operating-systems:
+    $ref: ./paths/organizations/id/operating-systems.yaml
+  /organizations/{id}/payment-methods:
+    $ref: ./paths/organizations/id/payment-methods.yaml
+  /organizations/{id}/plans:
+    $ref: ./paths/organizations/id/plans.yaml
+  /organizations/{id}/projects:
+    $ref: ./paths/organizations/id/projects.yaml
+  /organizations/{id}/transfers:
+    $ref: ./paths/organizations/id/transfers.yaml
+  /organizations/{organization_id}/connections:
+    $ref: ./paths/organizations/organization_id/connections.yaml
+  /payment-methods/{id}:
+    $ref: ./paths/payment-methods/id.yaml
+  /plans:
+    $ref: ./paths/plans.yaml
+  /ports/{id}:
+    $ref: ./paths/ports/id.yaml
+  /ports/{id}/assign:
+    $ref: ./paths/ports/id/assign.yaml
+  /ports/{id}/bond:
+    $ref: ./paths/ports/id/bond.yaml
+  /ports/{id}/convert/layer-2:
+    $ref: ./paths/ports/id/convert/layer-2.yaml
+  /ports/{id}/convert/layer-3:
+    $ref: ./paths/ports/id/convert/layer-3.yaml
+  /ports/{id}/disbond:
+    $ref: ./paths/ports/id/disbond.yaml
+  /ports/{id}/native-vlan:
+    $ref: ./paths/ports/id/native-vlan.yaml
+  /ports/{id}/unassign:
+    $ref: ./paths/ports/id/unassign.yaml
+  /ports/{id}/vlan-assignments:
+    $ref: ./paths/ports/id/vlan-assignments.yaml
+  /ports/{id}/vlan-assignments/{assignment_id}:
+    $ref: ./paths/ports/id/vlan-assignments/assignment_id.yaml
+  /ports/{id}/vlan-assignments/batches:
+    $ref: ./paths/ports/id/vlan-assignments/batches.yaml
+  /ports/{id}/vlan-assignments/batches/{batch_id}:
+    $ref: ./paths/ports/id/vlan-assignments/batches/batch_id.yaml
+  /projects:
+    $ref: ./paths/projects.yaml
+  /projects/{id}:
+    $ref: ./paths/projects/id.yaml
+  /projects/{id}/api-keys:
+    $ref: ./paths/projects/id/api-keys.yaml
+  /projects/{id}/batches:
+    $ref: ./paths/projects/id/batches.yaml
+  /projects/{id}/bgp-config:
+    $ref: ./paths/projects/id/bgp-config.yaml
+  /projects/{id}/bgp-configs:
+    $ref: ./paths/projects/id/bgp-configs.yaml
+  /projects/{id}/bgp/sessions:
+    $ref: ./paths/projects/id/bgp/sessions.yaml
+  /projects/{id}/customdata:
+    $ref: ./paths/projects/id/customdata.yaml
+  /projects/{id}/devices:
+    $ref: ./paths/projects/id/devices.yaml
+  /projects/{id}/devices/batch:
+    $ref: ./paths/projects/id/devices/batch.yaml
+  /projects/{id}/events:
+    $ref: ./paths/projects/id/events.yaml
+  /projects/{id}/facilities:
+    $ref: ./paths/projects/id/facilities.yaml
+  /projects/{id}/global-bgp-ranges:
+    $ref: ./paths/projects/id/global-bgp-ranges.yaml
+  /projects/{id}/hardware-reservations:
+    $ref: ./paths/projects/id/hardware-reservations.yaml
+  /projects/{id}/ips:
+    $ref: ./paths/projects/id/ips.yaml
+  /projects/{id}/licenses:
+    $ref: ./paths/projects/id/licenses.yaml
+  /projects/{id}/plans:
+    $ref: ./paths/projects/id/plans.yaml
+  /projects/{id}/spot-market-requests:
+    $ref: ./paths/projects/id/spot-market-requests.yaml
+  /projects/{id}/ssh-keys:
+    $ref: ./paths/projects/id/ssh-keys.yaml
+  /projects/{id}/transfers:
+    $ref: ./paths/projects/id/transfers.yaml
+  /projects/{id}/usages:
+    $ref: ./paths/projects/id/usages.yaml
+  /projects/{id}/virtual-networks:
+    $ref: ./paths/projects/id/virtual-networks.yaml
+  /projects/{id}/vrfs:
+    $ref: ./paths/projects/id/vrfs.yaml
+  /projects/{project_id}/connections:
+    $ref: ./paths/projects/project_id/connections.yaml
+  /projects/{project_id}/invitations:
+    $ref: ./paths/projects/project_id/invitations.yaml
+  /projects/{project_id}/ips/{id}/customdata:
+    $ref: ./paths/projects/project_id/ips/id/customdata.yaml
+  /projects/{project_id}/memberships:
+    $ref: ./paths/projects/project_id/memberships.yaml
+  /projects/{project_id}/metal-gateways:
+    $ref: ./paths/projects/project_id/metal-gateways.yaml
+  /projects/{project_id}/self-service/reservations:
+    $ref: ./paths/projects/project_id/self-service/reservations.yaml
+  /projects/{project_id}/self-service/reservations/{id}:
+    $ref: ./paths/projects/project_id/self-service/reservations/id.yaml
+  /reset-password:
+    $ref: ./paths/reset-password.yaml
+  /spot-market-requests/{id}:
+    $ref: ./paths/spot-market-requests/id.yaml
+  /ssh-keys:
+    $ref: ./paths/ssh-keys.yaml
+  /ssh-keys/{id}:
+    $ref: ./paths/ssh-keys/id.yaml
+  /support-requests:
+    $ref: ./paths/support-requests.yaml
+  /transfers/{id}:
+    $ref: ./paths/transfers/id.yaml
+  /user:
+    $ref: ./paths/user.yaml
+  /user/api-keys:
+    $ref: ./paths/user/api-keys.yaml
+  /user/api-keys/{id}:
+    $ref: ./paths/user/api-keys/id.yaml
+  /user/otp/app:
+    $ref: ./paths/user/otp/app.yaml
+  /user/otp/recovery-codes:
+    $ref: ./paths/user/otp/recovery-codes.yaml
+  /user/otp/sms:
+    $ref: ./paths/user/otp/sms.yaml
+  /user/otp/sms/receive:
+    $ref: ./paths/user/otp/sms/receive.yaml
+  /user/otp/verify/{otp}:
+    $ref: ./paths/user/otp/verify/otp.yaml
+  /userdata/validate:
+    $ref: ./paths/userdata/validate.yaml
+  /users:
+    $ref: ./paths/users.yaml
+  /users/{id}:
+    $ref: ./paths/users/id.yaml
+  /users/{id}/customdata:
+    $ref: ./paths/users/id/customdata.yaml
+  /verify-email:
+    $ref: ./paths/verify-email.yaml
+  /virtual-circuit/{id}/events:
+    $ref: ./paths/virtual-circuit/id/events.yaml
+  /virtual-circuits/{id}:
+    $ref: ./paths/virtual-circuits/id.yaml
+  /virtual-networks/{id}:
+    $ref: ./paths/virtual-networks/id.yaml
+  /vrfs/{id}:
+    $ref: ./paths/vrfs/id.yaml
+  /vrfs/{id}/ips:
+    $ref: ./paths/vrfs/id/ips.yaml
+tags:
+  - description: |+
+      Nearly all of the endpoints in the API require authentication. Authentication is performed by providing an authentication token (interchangeably referred to as an API key) in the `X-Auth-Token` HTTP request header.
+
+      <!-- ReDoc-Inject: <security-definitions> -->
+
+      User API keys can be obtained by creating them in the Equinix Metal Portal or by using the [Create a User API Key](#operation/createAPIKey) endpoint.
+
+      Project API keys can also be obtained by creating them in the Equinix Metal Portal or by using the [Create a Project API Key](#operation/createProjectAPIKey) endpoint. Project API keys are scoped to a single project and can only be used to access resources within that project.
+
+      For example, to use an authenticated API token, you would make a request like the following:
+
+      ```bash
+      curl -H 'X-Auth-Token: my_authentication_token' \
+        https://api.equinix.com/metal/v1/user/api-keys
+      ```
+
+      Applications can take advantage of the Equinix Metal API and API keys to perform any of the actions that can be performed in the Equinix Metal Portal. For example, you can use the API to create and manage devices, projects, and other resources.
+
+      API keys can be deleted without affecting any of the resources created with them. Access to applications using the API can be revoked by deleting the API key used to authenticate the application.
+    name: Authentication
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/users/#api-keys
+  - description: |
+      Equinix Metal uses conventional HTTP response codes to indicate the success or failure of an API request.
+
+      In general: Codes in the 2xx range indicate success. Codes in the 4xx range indicate an error that failed given the information provided (e.g., a required parameter was omitted, a charge failed, etc.). Codes in the 5xx range indicate an error with Equinix Metal's servers (these are rare).
+
+      | Code                               | Summary
+      | ---------------------------------- | ------------------------------------------------------
+      | 200 OK                             | Everything worked as expected.
+      | 201 Create                         | Everything worked as expected, the resource was created.
+      | 422 Bad Request                    | The request was unacceptable, often due to missing a required parameter.
+      | 401 Unauthorized                   | No valid API key provided.
+      | 404 Not Found                      | The requested resource doesn't exist.
+      | 500, 502, 503, 504 - Server Errors | Something went wrong on Equinix Metal's end. (These are rare.)
+
+      Errors (4xx, 5xx) reported by the API will include a JSON error response.  This response will be structured as one of the following:
+
+      ```json
+      {"error": "the error message"}
+      ```
+
+      or
+
+      ```json
+      {"errors": ["one error", "another error"}
+      ```
+
+      The JSON response is not guaranteed so check the HTTP status message. JSON may not be included if the error is reported by an API intermediary, like a loadbalancer service.
+    name: Errors
+  - description: >
+      Manage device batches. See project endpoints to list batches for a
+      particular project. Check out the product docs to learn more about [Batch
+      Deployment](https://metal.equinix.com/developers/docs/deploy/batch-deployment/).
+    name: Batches
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/deploy/batch-deployment/
+  - description: >
+      Manage BGP configs and sessions. See device endpoints to create and list BGP
+      sessions for a particular device. Check out the product docs to learn more
+      about [Local and Global
+      BGP](https://metal.equinix.com/developers/docs/networking/local-global-bgp/).
+    name: BGP
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/bgp/bgp-on-equinix-metal/
+  - description: >
+      Capacity Management. Check out the product docs to learn more about
+      [Capacity](https://metal.equinix.com/developers/docs/locations/capacity/).
+    name: Capacity
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/locations/capacity/
+  - description: >
+      Network Interconnections. See Instructions to create Network
+      Interconnections at Check out the product docs to learn more about [Equinix
+      Fabric](https://metal.equinix.com/developers/docs/networking/fabric/).
+    name: Interconnections
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/equinix-interconnect/introduction/
+  - description: >
+      Device Management. Check out the product docs to learn more about [Server
+      Devices](https://metal.equinix.com/developers/docs/servers/).
+    name: Devices
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/deploy/on-demand/
+  - description: Email Management
+    name: Emails
+  - description: Event Management
+    name: Events
+  - description: >
+      Facility Management. Check out the product docs to learn more about
+      [Facilities](https://metal.equinix.com/developers/docs/locations/).
+    name: Facilities
+  - description: >
+      Global BGP Range Management
+    name: GlobalBgpRanges
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/bgp/global-bgp/
+  - description: >
+      Hardware Reservation Management. Check out the product docs to learn more
+      about [Reserved
+      Hardware](https://metal.equinix.com/developers/docs/deploy/reserved/).
+    name: HardwareReservations
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/deploy/reserved/
+  - description: >
+      Incident Management
+    name: Incidents
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/locations/maintenance/
+  - description: >
+      Manage invitations. See project endpoints to create a new invitation. Check
+      out the product docs to learn more about
+      [Invitations](https://metal.equinix.com/developers/docs/accounts/).
+    name: Invitations
+  - description: >
+      Manage IP addresses. See device and project endpoints to list and create IP
+      assignments for a particular project or device. Check out the product docs
+      to learn more about [the basic networking
+      features](https://metal.equinix.com/developers/docs/networking/standard-ips/).
+    name: IPAddresses
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/networking/
+  - description: >
+      Manage licenses. See project endpoints to list and create licenses for a
+      particular project.
+    name: Licenses
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/operating-systems/licensed/
+  - description: >
+      Membership Management (Project). Check out the product docs to learn more
+      about [Membership](https://metal.equinix.com/developers/docs/accounts/).
+    name: Memberships
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/projects/#inviting-a-user-to-a-project
+  - description: >
+      Device Metadata
+    name: Metadata
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/server-metadata/metadata/
+  - description: >
+      Metal Gateway Management.Check out the product docs to learn more about
+      [Metal
+      Gateways](https://metal.equinix.com/developers/docs/networking/metal-gateway/).
+    name: MetalGateways
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/networking/metal-gateway/
+  - description: Metro Management. Check out the product docs to learn more about [Metros](https://metal.equinix.com/developers/docs/locations/metros/).
+    name: Metros
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/locations/metros/
+  - description: >
+      Operating System Management. Check out the product docs to learn more about
+      [Operating Systems
+      choices](https://metal.equinix.com/developers/docs/operating-systems/).
+    name: OperatingSystems
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/operating-systems/supported/
+  - description:
+      Organizations Management. Check out the product docs to learn more
+      about [Organizations](https://metal.equinix.com/developers/docs/accounts/).
+    name: Organizations
+  - description: >
+      OTP Management. Check out the product docs to learn more about [OTP](https://metal.equinix.com/developers/docs/accounts/two-factor-authentication/).
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/two-factor-authentication/
+    name: OTPs
+  - description: >
+      Password Reset Token Management
+    name: PasswordResetTokens
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/users/#security-settings
+  - description: >
+      Payment Method Management
+    name: PaymentMethods
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/billing/payment-methods/
+  - description: >
+      Plan Management (Device). Check out the product docs to learn more
+      about [Device Plans](https://metal.equinix.com/developers/docs/servers/).
+    name: Plans
+  - description: >
+      Port ManagementCheck out the product docs to learn more about [Port
+      configurations](https://metal.equinix.com/developers/docs/layer2-networking/overview/).
+    name: Ports
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/layer2-networking/overview/
+  - description: >
+      Project Management. Check out the product docs to learn more about
+      [Projects](https://metal.equinix.com/developers/docs/accounts/projects/).
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/projects/
+    name: Projects
+  - description: >
+      Self Service Reservations
+    name: SelfServiceReservations
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/deploy/reserved/
+  - description: >
+      Spot Market Pricing and Requests Management. Check out the product docs to learn more
+      about [Spot Market
+      features](https://metal.equinix.com/developers/docs/deploy/spot-market/).
+    name: SpotMarket
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/deploy/spot-market/
+  - description: >
+      Manage SSH keys. See project endpoints to list and create project-level SSH
+      keys.
+    name: SSHKeys
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/ssh-keys/
+  - description: >
+      Support request
+    name: SupportRequest
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/support/
+  - description: >
+      Project Transfer Requests Management
+    name: TransferRequests
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/projects/#transferring-a-project
+  - description: >
+      Two Factor Authentication Management. Check out the product docs to learn
+      more about
+      [2FA](https://metal.equinix.com/developers/docs/accounts/two-factor-authentication/).
+    name: TwoFactorAuth
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/two-factor-authentication/
+  - description: Usage Management
+    name: Usages
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/billing/checking-usage/
+  - description: >
+      Userdata Management
+    name: Userdata
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/server-metadata/user-data/
+  - description: >
+      User Management
+    name: Users
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/users/
+  - description: >
+      User Verification Token Management
+    name: UserVerificationTokens
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/accounts/organizations/#managing-team-members
+  - description: >
+      Manage virtual networks (VLANs). See project endpoints to list and create
+      virtual networks. Check out the product docs to learn more about
+      [VLANs](https://metal.equinix.com/developers/docs/networking/layer2/).
+    name: VLANs
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/networking/layer2/
+  - description: >
+      Volume Management (Block Storage). Notice: Block storage support will
+      be deprecated soon. Please check here: https://metal.equinix.com/developers/docs/resilience-recovery/elastic-block-storage/
+      for more details.
+    name: Volumes
+    externalDocs:
+      url: https://metal.equinix.com/developers/docs/resilience-recovery/elastic-block-storage/
+  - description: >
+      VRF Management. A VRF is a project-scoped virtual router resource that defines a collection of customer-managed IP blocks that can be used in BGP peering on one or more virtual networks. Metal Gateways and Interconnection Virtual Circuits can take advantage of VRFs to enable Layer 3 routing with bespoke network ranges. Notice: VRFs are a test feature currently under active development, and only available to certain users. Please contact Customer Success for more information.
+    name: VRFs
+x-tagGroups:
+  - name: Accounts and Organization
+    tags:
+      - Authentication
+      - Emails
+      - Invitations
+      - Memberships
+      - Organizations
+      - OTPs
+      - PasswordResetTokens
+      - PaymentMethods
+      - Projects
+      - SSHKeys
+      - SupportRequest
+      - TransferRequests
+      - TwoFactorAuth
+      - Users
+      - UserVerificationTokens
+  - name: Services and Billing
+    tags:
+      - Events
+      - Facilities
+      - Incidents
+      - Licenses
+      - Metros
+      - Plans
+      - Usages
+  - name: Servers
+    tags:
+      - Devices
+      - Batches
+      - Capacity
+      - HardwareReservations
+      - OperatingSystems
+      - Ports
+      - SelfServiceReservations
+      - SpotMarket
+      - Userdata
+      - Volumes
+  - name: Networking
+    tags:
+      - BGP
+      - Interconnections
+      - IPAddresses
+      - MetalGateways
+      - VLANs
+      - VRFs

--- a/spec/docs/openapi/public/paths/api-keys/id.yaml
+++ b/spec/docs/openapi/public/paths/api-keys/id.yaml
@@ -1,0 +1,29 @@
+delete:
+  description: Deletes the API key.
+  operationId: deleteAPIKey
+  parameters:
+  - description: API Key UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the API key
+  tags:
+  - Authentication

--- a/spec/docs/openapi/public/paths/batches/id.yaml
+++ b/spec/docs/openapi/public/paths/batches/id.yaml
@@ -1,0 +1,70 @@
+delete:
+  description: Deletes the Batch.
+  operationId: deleteBatch
+  parameters:
+  - description: Batch UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Delete all instances created from this batch
+    in: query
+    name: remove_associated_instances
+    schema:
+      default: false
+      type: boolean
+  responses:
+    "204":
+      description: no content
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the Batch
+  tags:
+  - Batches
+get:
+  description: Returns a Batch
+  operationId: findBatchById
+  parameters:
+  - description: Batch UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Batch.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a Batch
+  tags:
+  - Batches

--- a/spec/docs/openapi/public/paths/bgp/sessions/id.yaml
+++ b/spec/docs/openapi/public/paths/bgp/sessions/id.yaml
@@ -1,0 +1,125 @@
+delete:
+  description: Deletes the BGP session.
+  operationId: deleteBgpSession
+  parameters:
+  - description: BGP session UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the BGP session
+  tags:
+  - BGP
+get:
+  description: Returns a BGP session
+  operationId: findBgpSessionById
+  parameters:
+  - description: BGP session UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/BgpSession.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a BGP session
+  tags:
+  - BGP
+put:
+  description: Updates the BGP session by either enabling or disabling the default
+    route functionality.
+  operationId: updateBgpSession
+  parameters:
+  - description: BGP session UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: boolean
+    description: Default route
+    required: true
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the BGP session
+  tags:
+  - BGP

--- a/spec/docs/openapi/public/paths/capacity.yaml
+++ b/spec/docs/openapi/public/paths/capacity.yaml
@@ -1,0 +1,51 @@
+get:
+  description: Returns a list of facilities and plans with their current capacity.
+  operationId: findCapacityForFacility
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/CapacityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: View capacity
+  tags:
+  - Capacity
+post:
+  description: Validates if a deploy can be fulfilled.
+  operationId: checkCapacityForFacility
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/CapacityInput.yaml'
+    description: Facility to check capacity in
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/CapacityCheckPerFacilityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Check capacity
+  tags:
+  - Capacity

--- a/spec/docs/openapi/public/paths/capacity/metros.yaml
+++ b/spec/docs/openapi/public/paths/capacity/metros.yaml
@@ -1,0 +1,51 @@
+get:
+  description: Returns a list of metros and plans with their current capacity.
+  operationId: findCapacityForMetro
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/MetroCapacityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: View capacity for metros
+  tags:
+  - Capacity
+post:
+  description: Validates if a deploy can be fulfilled in a metro.
+  operationId: checkCapacityForMetro
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/CapacityPerMetroInput.yaml'
+    description: Metro to check capacity in
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/CapacityCheckPerMetroList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Check capacity for a metro
+  tags:
+  - Capacity

--- a/spec/docs/openapi/public/paths/connections/connection_id.yaml
+++ b/spec/docs/openapi/public/paths/connections/connection_id.yaml
@@ -1,0 +1,106 @@
+delete:
+  description: Delete a interconnection, its associated ports and virtual circuits.
+  operationId: deleteInterconnection
+  parameters:
+  - description: Interconnection UUID
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "202":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Interconnection.yaml'
+      description: accepted
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete interconnection
+  tags:
+  - Interconnections
+get:
+  description: Get the details of a interconnection
+  operationId: getInterconnection
+  parameters:
+  - description: Interconnection UUID
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Interconnection.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Get interconnection
+  tags:
+  - Interconnections
+put:
+  description: Update the details of a interconnection
+  operationId: updateInterconnection
+  parameters:
+  - description: Interconnection UUID
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/InterconnectionUpdateInput.yaml'
+    description: Updated interconnection details
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Interconnection.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Update interconnection
+  tags:
+  - Interconnections

--- a/spec/docs/openapi/public/paths/connections/connection_id/events.yaml
+++ b/spec/docs/openapi/public/paths/connections/connection_id/events.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Returns a list of the interconnection events
+  operationId: findInterconnectionEvents
+  parameters:
+  - description: Interconnection UUID
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Event.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve interconnection events
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/connections/connection_id/ports.yaml
+++ b/spec/docs/openapi/public/paths/connections/connection_id/ports.yaml
@@ -1,0 +1,33 @@
+get:
+  description: List the ports associated to an interconnection.
+  operationId: listInterconnectionPorts
+  parameters:
+  - description: UUID of the interconnection
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/InterconnectionPortList.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: List a interconnection's ports
+  tags:
+  - Interconnections

--- a/spec/docs/openapi/public/paths/connections/connection_id/ports/id.yaml
+++ b/spec/docs/openapi/public/paths/connections/connection_id/ports/id.yaml
@@ -1,0 +1,40 @@
+get:
+  description: Get the details of an interconnection port.
+  operationId: getInterconnectionPort
+  parameters:
+  - description: UUID of the interconnection
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/InterconnectionPort.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Get a interconnection port
+  tags:
+  - Interconnections

--- a/spec/docs/openapi/public/paths/connections/connection_id/ports/id/events.yaml
+++ b/spec/docs/openapi/public/paths/connections/connection_id/ports/id/events.yaml
@@ -1,0 +1,50 @@
+get:
+  description: Returns a list of the interconnection port events
+  operationId: findInterconnectionPortEvents
+  parameters:
+  - description: Interconnection UUID
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Interconnection Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../../../components/parameters/Include.yaml'
+  - $ref: '../../../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../../../components/parameters/Page.yaml'
+  - $ref: '../../../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Event.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve interconnection port events
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/connections/connection_id/ports/port_id/virtual-circuits.yaml
+++ b/spec/docs/openapi/public/paths/connections/connection_id/ports/port_id/virtual-circuits.yaml
@@ -1,0 +1,94 @@
+get:
+  description: List the virtual circuit record(s) associatiated with a particular
+    interconnection port.
+  operationId: listInterconnectionPortVirtualCircuits
+  parameters:
+  - description: UUID of the interconnection
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: UUID of the interconnection port
+    in: path
+    name: port_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/VirtualCircuitList.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: List a interconnection port's virtual circuits
+  tags:
+  - Interconnections
+post:
+  description: Create a new Virtual Circuit on a Dedicated Port. To create a regular Virtual Circuit, specify
+    a Virtual Network record and an NNI VLAN value. To create a VRF-based Virtual Circuit, specify the VRF ID and subnet,
+    along with the NNI VLAN value.
+  operationId: createInterconnectionPortVirtualCircuit
+  parameters:
+  - description: UUID of the interconnection
+    in: path
+    name: connection_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: UUID of the interconnection port
+    in: path
+    name: port_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          oneOf:
+          - $ref: '../../../../../components/schemas/VirtualCircuitCreateInput.yaml'
+          - $ref: '../../../../../components/schemas/VrfVirtualCircuitCreateInput.yaml'
+    description: Virtual Circuit details
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../../../../components/schemas/VirtualCircuit.yaml'
+            - $ref: '../../../../../components/schemas/VrfVirtualCircuit.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Create a new Virtual Circuit
+  tags:
+  - Interconnections

--- a/spec/docs/openapi/public/paths/devices/id.yaml
+++ b/spec/docs/openapi/public/paths/devices/id.yaml
@@ -1,0 +1,142 @@
+delete:
+  description: Deletes a device and deprovisions it in our datacenter.
+  operationId: deleteDevice
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Force the deletion of the device, by detaching any storage volume
+      still active.
+    in: query
+    name: force_delete
+    schema:
+      type: boolean
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Delete the device
+  tags:
+  - Devices
+get:
+  description: |-
+    Type-specific options (such as facility for baremetal devices) will be included as part of the main data structure.
+                             State value can be one of: active inactive queued or provisioning
+  operationId: findDeviceById
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Device.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a device
+  tags:
+  - Devices
+put:
+  description: Updates the device.
+  operationId: updateDevice
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/DeviceUpdateInput.yaml'
+    description: Facility to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Device.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the device
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/actions.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/actions.yaml
@@ -1,0 +1,44 @@
+post:
+  description: 'Performs an action for the given device.  Possible actions include:
+    power_on, power_off, reboot, reinstall, and rescue (reboot the device into rescue
+    OS.)'
+  operationId: performAction
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/DeviceActionInput.yaml'
+    description: Action to perform
+    required: true
+  responses:
+    "202":
+      description: accepted
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Perform an action
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/bandwidth.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/bandwidth.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Retrieve an instance bandwidth for a given period of time.
+  operationId: findInstanceBandwidth
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Timestamp from range
+    in: query
+    name: from
+    required: true
+    schema:
+      type: string
+  - description: Timestamp to range
+    in: query
+    name: until
+    required: true
+    schema:
+      type: string
+  responses:
+    "200":
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve an instance bandwidth
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/bgp/neighbors.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/bgp/neighbors.yaml
@@ -1,0 +1,40 @@
+get:
+  description: Provides a summary of the BGP neighbor data associated to the BGP sessions
+    for this device.
+  operationId: getBgpNeighborData
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/BgpSessionNeighbors.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve BGP neighbor data for this device
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/bgp/sessions.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/bgp/sessions.yaml
@@ -1,0 +1,79 @@
+get:
+  description: Provides a listing of available BGP sessions for the device.
+  operationId: findBgpSessions
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/BgpSessionList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+  summary: Retrieve all BGP sessions
+  tags:
+  - Devices
+post:
+  description: Creates a BGP session.
+  operationId: createBgpSession
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../components/schemas/BGPSessionInput.yaml'
+    description: BGP session to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/BgpSession.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a BGP session
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/customdata.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/customdata.yaml
@@ -1,0 +1,35 @@
+get:
+  description: Provides the custom metadata stored for this instance in json format
+  operationId: findDeviceCustomdata
+  parameters:
+  - description: Instance UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve the custom metadata of an instance
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/events.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/events.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Returns a list of events pertaining to a specific device
+  operationId: findDeviceEvents
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/EventList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve device's events
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/devices/id/ips.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/ips.yaml
@@ -1,0 +1,81 @@
+get:
+  description: Returns all ip assignments for a device.
+  operationId: findIPAssignments
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/IPAssignmentList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all ip assignments
+  tags:
+  - Devices
+post:
+  description: Creates an ip assignment for a device.
+  operationId: createIPAssignment
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/IPAssignmentInput.yaml'
+    description: IPAssignment to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/IPAssignment.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an ip assignment
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/metadata.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/metadata.yaml
@@ -1,0 +1,39 @@
+get:
+  description: Retrieve device metadata
+  operationId: findDeviceMetadataByID
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    schema:
+      type: string
+      format: uuid
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Metadata.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Retrieve metadata
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/ssh-keys.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/ssh-keys.yaml
@@ -1,0 +1,34 @@
+get:
+  description: Returns a collection of the device's ssh keys.
+  operationId: findDeviceSSHKeys
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Search by key, label, or fingerprint
+    in: query
+    name: Search string
+    schema:
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/SSHKeyList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve a device's ssh keys
+  tags:
+  - SSHKeys

--- a/spec/docs/openapi/public/paths/devices/id/traffic.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/traffic.yaml
@@ -1,0 +1,84 @@
+get:
+  description: Returns traffic for a specific device.
+  operationId: findTraffic
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Traffic direction
+    in: query
+    name: direction
+    required: true
+    schema:
+      enum:
+      - inbound
+      - outbound
+      type: string
+  - description: Traffic interval
+    in: query
+    name: interval
+    schema:
+      enum:
+      - minute
+      - hour
+      - day
+      - week
+      - month
+      - year
+      - hour_of_day
+      - day_of_week
+      - day_of_month
+      - month_of_year
+      type: string
+  - description: Traffic bucket
+    in: query
+    name: bucket
+    schema:
+      enum:
+      - internal
+      - external
+      type: string
+  - name: timeframe
+    in: query
+    schema:
+      properties:
+        ended_at:
+          format: date-time
+          type: string
+        started_at:
+          format: date-time
+          type: string
+      required:
+      - started_at
+      - ended_at
+      type: object
+    style: deepObject
+    explode: true
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve device traffic
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/id/usages.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/usages.yaml
@@ -1,0 +1,45 @@
+get:
+  description: Returns all usages for a device.
+  operationId: findDeviceUsages
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Filter usages created after this date
+    in: query
+    name: created[after]
+    schema:
+      format: datetime
+      type: string
+  - description: Filter usages created before this date
+    in: query
+    name: created[before]
+    schema:
+      format: datetime
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/DeviceUsageList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all usages for device
+  tags:
+  - Usages

--- a/spec/docs/openapi/public/paths/devices/id/userdata.yaml
+++ b/spec/docs/openapi/public/paths/devices/id/userdata.yaml
@@ -1,0 +1,39 @@
+get:
+  description: Retrieve device userdata
+  operationId: findDeviceUserdataByID
+  parameters:
+  - description: Device UUID
+    in: path
+    name: id
+    schema:
+      type: string
+      format: uuid
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Userdata.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Retrieve userdata
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/devices/instance_id/ips/id/customdata.yaml
+++ b/spec/docs/openapi/public/paths/devices/instance_id/ips/id/customdata.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Provides the custom metadata stored for this IP Assignment in json
+    format
+  operationId: findIPAssignmentCustomdata
+  parameters:
+  - description: Instance UUID
+    in: path
+    name: instance_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Ip Assignment UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve the custom metadata of an IP Assignment
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/emails.yaml
+++ b/spec/docs/openapi/public/paths/emails.yaml
@@ -1,0 +1,32 @@
+post:
+  description: Add a new email address to the current user.
+  operationId: createEmail
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/CreateEmailInput.yaml'
+    description: Email to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Email.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an email
+  tags:
+  - Emails

--- a/spec/docs/openapi/public/paths/emails/id.yaml
+++ b/spec/docs/openapi/public/paths/emails/id.yaml
@@ -1,0 +1,128 @@
+delete:
+  description: Deletes the email.
+  operationId: deleteEmail
+  parameters:
+  - description: Email UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the email
+  tags:
+  - Emails
+get:
+  description: Provides one of the user’s emails.
+  operationId: findEmailById
+  parameters:
+  - description: Email UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Email.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve an email
+  tags:
+  - Emails
+put:
+  description: Updates the email.
+  operationId: updateEmail
+  parameters:
+  - description: Email UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/UpdateEmailInput.yaml'
+    description: email to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Email.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the email
+  tags:
+  - Emails

--- a/spec/docs/openapi/public/paths/events.yaml
+++ b/spec/docs/openapi/public/paths/events.yaml
@@ -1,0 +1,24 @@
+get:
+  description: Returns a list of the current user’s events
+  operationId: findEvents
+  parameters:
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  - $ref: '../components/parameters/Page.yaml'
+  - $ref: '../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/EventList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve current user's events
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/events/id.yaml
+++ b/spec/docs/openapi/public/paths/events/id.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a single event if the user has access
+  operationId: findEventById
+  parameters:
+  - description: Event UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Event.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve an event
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/facilities.yaml
+++ b/spec/docs/openapi/public/paths/facilities.yaml
@@ -1,0 +1,49 @@
+get:
+  description: Provides a listing of available datacenters where you can provision
+    Packet devices.
+  operationId: findFacilities
+  parameters:
+  - description: Nested attributes to include. Included objects will return their
+      full attributes. Attribute names can be dotted (up to 3 levels) to included
+      deeply nested objects.
+    in: query
+    name: include
+    schema:
+      items:
+        enum:
+        - address
+        - labels
+        type: string
+      type: array
+    style: form
+  - description: Nested attributes to exclude. Excluded objects will return only the
+      href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+      nested objects.
+    in: query
+    name: exclude
+    schema:
+      default:
+      - address
+      items:
+        enum:
+        - address
+        - labels
+        type: string
+      type: array
+    style: form
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/FacilityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all facilities
+  tags:
+  - Facilities

--- a/spec/docs/openapi/public/paths/hardware-reservations/id.yaml
+++ b/spec/docs/openapi/public/paths/hardware-reservations/id.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a single hardware reservation
+  operationId: findHardwareReservationById
+  parameters:
+  - description: HardwareReservation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Device.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a hardware reservation
+  tags:
+  - HardwareReservations

--- a/spec/docs/openapi/public/paths/hardware-reservations/id/move.yaml
+++ b/spec/docs/openapi/public/paths/hardware-reservations/id/move.yaml
@@ -1,0 +1,47 @@
+post:
+  description: Move a hardware reservation to another project
+  operationId: moveHardwareReservation
+  parameters:
+  - description: Hardware Reservation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          format: uuid
+          type: string
+    description: Project UUID
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/HardwareReservation.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Move a hardware reservation
+  tags:
+  - HardwareReservations

--- a/spec/docs/openapi/public/paths/incidents.yaml
+++ b/spec/docs/openapi/public/paths/incidents.yaml
@@ -1,0 +1,18 @@
+get:
+  description: Retrieve the number of incidents.
+  operationId: findIncidents
+  parameters:
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve the number of incidents
+  tags:
+  - Incidents

--- a/spec/docs/openapi/public/paths/invitations.yaml
+++ b/spec/docs/openapi/public/paths/invitations.yaml
@@ -1,0 +1,36 @@
+get:
+  description: Returns all invitations in current user.
+  operationId: findInvitations
+  parameters:
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  - $ref: '../components/parameters/Page.yaml'
+  - $ref: '../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/InvitationList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve current user invitations
+  tags:
+  - Users

--- a/spec/docs/openapi/public/paths/invitations/id.yaml
+++ b/spec/docs/openapi/public/paths/invitations/id.yaml
@@ -1,0 +1,116 @@
+delete:
+  description: Decline an invitation.
+  operationId: declineInvitation
+  parameters:
+  - description: Invitation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Decline an invitation
+  tags:
+  - Invitations
+get:
+  description: Returns a single invitation. (It include the `invitable` to maintain
+    backward compatibility but will be removed soon)
+  operationId: findInvitationById
+  parameters:
+  - description: Invitation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Invitation.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: View an invitation
+  tags:
+  - Invitations
+put:
+  description: Accept an invitation.
+  operationId: acceptInvitation
+  parameters:
+  - description: Invitation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Membership.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Accept an invitation
+  tags:
+  - Invitations

--- a/spec/docs/openapi/public/paths/ips/id.yaml
+++ b/spec/docs/openapi/public/paths/ips/id.yaml
@@ -1,0 +1,140 @@
+delete:
+  description: Note! This call can be used to un-assign an IP assignment or delete
+    an IP reservation. Un-assign an IP address record. Use the assignment UUID you
+    get after attaching the IP. This will remove the relationship between an IP and
+    the device and will make the IP address available to be assigned to another device.
+    Delete and IP reservation. Use the reservation UUID you get after adding the IP
+    to the project. This will permanently delete the IP block reservation from the
+    project.
+  operationId: deleteIPAddress
+  parameters:
+  - description: IP Address UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Unassign an ip address
+  tags:
+  - IPAddresses
+get:
+  description: Returns a single ip address if the user has access.
+  operationId: findIPAddressById
+  parameters:
+  - description: IP Address UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../components/schemas/IPAssignment.yaml'
+            - $ref: '../../components/schemas/IPReservation.yaml'
+            - $ref: '../../components/schemas/VrfIpReservation.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve an ip address
+  tags:
+  - IPAddresses
+patch:
+  description: Update details about an ip address
+  operationId: updateIPAddress
+  parameters:
+  - description: IP Address UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Notes for this IP Assignment
+    in: query
+    name: details
+    required: true
+    schema:
+      type: string
+  - description: Provides the custom metadata stored for this IP Assignment in json
+      format
+    in: query
+    name: customdata
+    required: true
+    schema:
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../components/schemas/IPAssignment.yaml'
+            - $ref: '../../components/schemas/IPReservation.yaml'
+            - $ref: '../../components/schemas/VrfIpReservation.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Update an ip address
+  tags:
+  - IPAddresses

--- a/spec/docs/openapi/public/paths/ips/id/available.yaml
+++ b/spec/docs/openapi/public/paths/ips/id/available.yaml
@@ -1,0 +1,155 @@
+get:
+  description: Provides a list of IP resevations for a single project.
+  operationId: findIPAvailabilities
+  parameters:
+  - description: IP Reservation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Size of subnets in bits
+    in: query
+    name: cidr
+    required: true
+    schema:
+      enum:
+      - "20"
+      - "21"
+      - "22"
+      - "23"
+      - "24"
+      - "25"
+      - "26"
+      - "27"
+      - "28"
+      - "29"
+      - "30"
+      - "31"
+      - "32"
+      - "33"
+      - "34"
+      - "35"
+      - "36"
+      - "37"
+      - "38"
+      - "39"
+      - "40"
+      - "41"
+      - "42"
+      - "43"
+      - "44"
+      - "45"
+      - "46"
+      - "47"
+      - "48"
+      - "49"
+      - "50"
+      - "51"
+      - "52"
+      - "53"
+      - "54"
+      - "55"
+      - "56"
+      - "57"
+      - "58"
+      - "59"
+      - "60"
+      - "61"
+      - "62"
+      - "63"
+      - "64"
+      - "65"
+      - "66"
+      - "67"
+      - "68"
+      - "69"
+      - "70"
+      - "71"
+      - "72"
+      - "73"
+      - "74"
+      - "75"
+      - "76"
+      - "77"
+      - "78"
+      - "79"
+      - "80"
+      - "81"
+      - "82"
+      - "83"
+      - "84"
+      - "85"
+      - "86"
+      - "87"
+      - "88"
+      - "89"
+      - "90"
+      - "91"
+      - "92"
+      - "93"
+      - "94"
+      - "95"
+      - "96"
+      - "97"
+      - "98"
+      - "99"
+      - "100"
+      - "101"
+      - "102"
+      - "103"
+      - "104"
+      - "105"
+      - "106"
+      - "107"
+      - "108"
+      - "109"
+      - "110"
+      - "111"
+      - "112"
+      - "113"
+      - "114"
+      - "115"
+      - "116"
+      - "117"
+      - "118"
+      - "119"
+      - "120"
+      - "121"
+      - "122"
+      - "123"
+      - "124"
+      - "125"
+      - "126"
+      - "127"
+      - "128"
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/IPAvailabilitiesList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all available subnets of a particular reservation
+  tags:
+  - IPAddresses

--- a/spec/docs/openapi/public/paths/ips/id/customdata.yaml
+++ b/spec/docs/openapi/public/paths/ips/id/customdata.yaml
@@ -1,0 +1,36 @@
+get:
+  description: Provides the custom metadata stored for this IP Reservation or IP Assignment
+    in json format
+  operationId: findIPAddressCustomdata
+  parameters:
+  - description: Ip Reservation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve the custom metadata of an IP Reservation or IP Assignment
+  tags:
+  - IPAddresses

--- a/spec/docs/openapi/public/paths/licenses/id.yaml
+++ b/spec/docs/openapi/public/paths/licenses/id.yaml
@@ -1,0 +1,128 @@
+delete:
+  description: Deletes a license.
+  operationId: deleteLicense
+  parameters:
+  - description: License UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the license
+  tags:
+  - Licenses
+get:
+  description: Returns a license
+  operationId: findLicenseById
+  parameters:
+  - description: License UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/License.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a license
+  tags:
+  - Licenses
+put:
+  description: Updates the license.
+  operationId: updateLicense
+  parameters:
+  - description: License UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/LicenseUpdateInput.yaml'
+    description: License to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/License.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the license
+  tags:
+  - Licenses

--- a/spec/docs/openapi/public/paths/locations/metros.yaml
+++ b/spec/docs/openapi/public/paths/locations/metros.yaml
@@ -1,0 +1,19 @@
+get:
+  description: Provides a listing of available metros
+  operationId: findMetros
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/MetroList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all metros
+  tags:
+  - Metros

--- a/spec/docs/openapi/public/paths/locations/metros/id.yaml
+++ b/spec/docs/openapi/public/paths/locations/metros/id.yaml
@@ -1,0 +1,27 @@
+get:
+  description: Show the details for a metro, including name, code, and country.
+  operationId: getMetro
+  parameters:
+  - description: Metro UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Metro.yaml'
+      description: ok
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a specific Metro's details
+  tags:
+  - Metros

--- a/spec/docs/openapi/public/paths/market/spot/prices.yaml
+++ b/spec/docs/openapi/public/paths/market/spot/prices.yaml
@@ -1,0 +1,36 @@
+get:
+  description: Get Equinix Metal current spot market prices.
+  operationId: findSpotMarketPrices
+  parameters:
+  - description: Facility to check spot market prices
+    in: query
+    name: facility
+    schema:
+      type: string
+  - description: Plan to check spot market prices
+    in: query
+    name: plan
+    schema:
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/SpotMarketPricesList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Get current spot market prices
+  tags:
+  - SpotMarket

--- a/spec/docs/openapi/public/paths/market/spot/prices/history.yaml
+++ b/spec/docs/openapi/public/paths/market/spot/prices/history.yaml
@@ -1,0 +1,58 @@
+get:
+  description: |-
+    Get spot market prices for a given plan and facility in a fixed period of time
+
+    *Note: In the `200` response, the property `datapoints` contains arrays of `[float, integer]`.*
+  operationId: findSpotMarketPricesHistory
+  parameters:
+  - description: Facility to check spot market prices
+    in: query
+    name: facility
+    required: true
+    schema:
+      type: string
+  - description: Plan to check spot market prices
+    in: query
+    name: plan
+    required: true
+    schema:
+      type: string
+  - description: Metro to check spot market price history
+    in: query
+    name: metro
+    schema:
+      type: string
+  - description: Timestamp from range
+    in: query
+    name: from
+    required: true
+    schema:
+      type: string
+  - description: Timestamp to range
+    in: query
+    name: until
+    required: true
+    schema:
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/SpotPricesHistoryReport.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Get spot market prices for a given period of time
+  tags:
+  - SpotMarket

--- a/spec/docs/openapi/public/paths/market/spot/prices/metros.yaml
+++ b/spec/docs/openapi/public/paths/market/spot/prices/metros.yaml
@@ -1,0 +1,36 @@
+get:
+  description: Get Equinix Metal current spot market prices for all metros.
+  operationId: findMetroSpotMarketPrices
+  parameters:
+  - description: Metro to filter spot market prices
+    in: query
+    name: metro
+    schema:
+      type: string
+  - description: Plan to filter spot market prices
+    in: query
+    name: plan
+    schema:
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/SpotMarketPricesPerMetroList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Get current spot market prices for metros
+  tags:
+  - SpotMarket

--- a/spec/docs/openapi/public/paths/memberships/id.yaml
+++ b/spec/docs/openapi/public/paths/memberships/id.yaml
@@ -1,0 +1,128 @@
+delete:
+  description: Deletes the membership.
+  operationId: deleteMembership
+  parameters:
+  - description: Membership UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the membership
+  tags:
+  - Memberships
+get:
+  description: Returns a single membership.
+  operationId: findMembershipById
+  parameters:
+  - description: Membership UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Membership.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a membership
+  tags:
+  - Memberships
+put:
+  description: Updates the membership.
+  operationId: updateMembership
+  parameters:
+  - description: Membership UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/MembershipInput.yaml'
+    description: Membership to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Membership.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the membership
+  tags:
+  - Memberships

--- a/spec/docs/openapi/public/paths/metal-gateways/id.yaml
+++ b/spec/docs/openapi/public/paths/metal-gateways/id.yaml
@@ -1,0 +1,66 @@
+delete:
+  description: Deletes a specific metal gateway
+  operationId: deleteMetalGateway
+  parameters:
+  - description: Metal Gateway UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Deletes the metal gateway
+  tags:
+  - MetalGateways
+get:
+  description: Returns a specific metal gateway
+  operationId: findMetalGatewayById
+  parameters:
+  - description: Metal Gateway UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../components/schemas/MetalGateway.yaml'
+            - $ref: '../../components/schemas/VrfMetalGateway.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Returns the metal gateway
+  tags:
+  - MetalGateways

--- a/spec/docs/openapi/public/paths/operating-system-versions.yaml
+++ b/spec/docs/openapi/public/paths/operating-system-versions.yaml
@@ -1,0 +1,19 @@
+get:
+  description: Provides a listing of available operating system versions.
+  operationId: findOperatingSystemVersion
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/OperatingSystemList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all operating system versions
+  tags:
+  - OperatingSystems

--- a/spec/docs/openapi/public/paths/operating-systems.yaml
+++ b/spec/docs/openapi/public/paths/operating-systems.yaml
@@ -1,0 +1,20 @@
+get:
+  description: Provides a listing of available operating systems to provision your
+    new device with.
+  operationId: findOperatingSystems
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/OperatingSystemList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all operating systems
+  tags:
+  - OperatingSystems

--- a/spec/docs/openapi/public/paths/organizations.yaml
+++ b/spec/docs/openapi/public/paths/organizations.yaml
@@ -1,0 +1,81 @@
+get:
+  description: Returns a list of organizations that are accessible to the current
+    user.
+  operationId: findOrganizations
+  parameters:
+  - description: Include, exclude or show only personal organizations.
+    in: query
+    name: personal
+    schema:
+      enum:
+      - include
+      - exclude
+      - only
+      type: string
+  - description: Include, exclude or show only organizations that have no projects.
+    in: query
+    name: without_projects
+    schema:
+      enum:
+      - include
+      - exclude
+      - only
+      type: string
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  - $ref: '../components/parameters/Page.yaml'
+  - $ref: '../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/OrganizationList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all organizations
+  tags:
+  - Organizations
+post:
+  description: Creates an organization.
+  operationId: createOrganization
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/OrganizationInput.yaml'
+    description: Organization to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Organization.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id.yaml
@@ -1,0 +1,123 @@
+delete:
+  description: Deletes the organization.
+  operationId: deleteOrganization
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the organization
+  tags:
+  - Organizations
+get:
+  description: Returns a single organization's details, if the user is authorized
+    to view it.
+  operationId: findOrganizationById
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Organization.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve an organization's details
+  tags:
+  - Organizations
+put:
+  description: Updates the organization.
+  operationId: updateOrganization
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/OrganizationInput.yaml'
+    description: Organization to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Organization.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id/capacity.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/capacity.yaml
@@ -1,0 +1,33 @@
+get:
+  description: Returns a list of facilities and plans with their current capacity.
+  operationId: findOrganizationCapacityPerFacility
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/CapacityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+  summary: View available hardware plans per Facility for given organization
+  tags:
+  - Capacity

--- a/spec/docs/openapi/public/paths/organizations/id/capacity/metros.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/capacity/metros.yaml
@@ -1,0 +1,33 @@
+get:
+  description: Returns a list of metros and plans with their current capacity.
+  operationId: findOrganizationCapacityPerMetro
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/MetroCapacityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+  summary: View available hardware plans per Metro for given organization
+  tags:
+  - Capacity

--- a/spec/docs/openapi/public/paths/organizations/id/customdata.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/customdata.yaml
@@ -1,0 +1,35 @@
+get:
+  description: Provides the custom metadata stored for this organization in json format
+  operationId: findOrganizationCustomdata
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve the custom metadata of an organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id/devices.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/devices.yaml
@@ -1,0 +1,68 @@
+get:
+  description: Provides a collection of devices for a given organization.
+  operationId: findOrganizationDevices
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Filter by device facility
+    in: query
+    name: facility
+    schema:
+      type: string
+  - description: Filter by partial hostname
+    in: query
+    name: hostname
+    schema:
+      type: string
+  - description: Filter only reserved instances
+    in: query
+    name: reserved
+    schema:
+      type: boolean
+  - description: Filter by device tag
+    in: query
+    name: tag
+    schema:
+      type: string
+  - description: Filter by instance type (ondemand,spot,reserved)
+    in: query
+    name: type
+    schema:
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/DeviceList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all devices of an organization
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/organizations/id/events.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/events.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Returns a list of events for a single organization
+  operationId: findOrganizationEvents
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/EventList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve organization's events
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/organizations/id/facilities.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/facilities.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a listing of available datacenters for the given organization
+  operationId: findFacilitiesByOrganization
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/FacilityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all facilities visible by the organization
+  tags:
+  - Facilities

--- a/spec/docs/openapi/public/paths/organizations/id/invitations.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/invitations.yaml
@@ -1,0 +1,92 @@
+get:
+  description: Returns all invitations in an organization.
+  operationId: findOrganizationInvitations
+  parameters:
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/InvitationList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve organization invitations
+  tags:
+  - Organizations
+post:
+  description: |-
+    In order to add a user to an organization, they must first be invited.
+    To invite to several projects the parameter `projects_ids:[a,b,c]` can be used
+  operationId: createOrganizationInvitation
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    $ref: '../../../components/requestBodies/InvitationInput.yaml'
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Invitation.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an invitation for an organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id/operating-systems.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/operating-systems.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a listing of available operating systems for the given organization
+  operationId: findOperatingSystemsByOrganization
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/OperatingSystemList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all operating systems visible by the organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id/payment-methods.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/payment-methods.yaml
@@ -1,0 +1,83 @@
+get:
+  description: Returns all payment methods of an organization.
+  operationId: findOrganizationPaymentMethods
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/PaymentMethodList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all payment methods of an organization
+  tags:
+  - Organizations
+post:
+  description: Creates a payment method.
+  operationId: createPaymentMethod
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/PaymentMethodCreateInput.yaml'
+    description: Payment Method to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/PaymentMethod.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a payment method for the given organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id/plans.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/plans.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a listing of available plans for the given organization
+  operationId: findPlansByOrganization
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/PlanList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all plans visible by the organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id/projects.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/projects.yaml
@@ -1,0 +1,71 @@
+get:
+  description: Returns a collection of projects that belong to the organization.
+  operationId: findOrganizationProjects
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/ProjectList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all projects of an organization
+  tags:
+  - Organizations
+post:
+  description: Creates a new project for the organization
+  operationId: createOrganizationProject
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/ProjectCreateInput.yaml'
+    description: Project to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Project.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a project for the organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/id/transfers.yaml
+++ b/spec/docs/openapi/public/paths/organizations/id/transfers.yaml
@@ -1,0 +1,35 @@
+get:
+  description: Provides a collection of project transfer requests from or to the organization.
+  operationId: findOrganizationTransfers
+  parameters:
+  - description: Organization UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/TransferRequestList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+  summary: Retrieve all project transfer requests from or to an organization
+  tags:
+  - Organizations

--- a/spec/docs/openapi/public/paths/organizations/organization_id/connections.yaml
+++ b/spec/docs/openapi/public/paths/organizations/organization_id/connections.yaml
@@ -1,0 +1,75 @@
+get:
+  description: List the connections belonging to the organization
+  operationId: organizationListInterconnections
+  parameters:
+  - description: UUID of the organization
+    in: path
+    name: organization_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/InterconnectionList.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: List organization connections
+  tags:
+  - Interconnections
+post:
+  description: Creates a new interconnection request. A Project ID must be specified in
+    the request body for connections on shared ports.
+  operationId: createOrganizationInterconnection
+  parameters:
+  - description: UUID of the organization
+    in: path
+    name: organization_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    $ref: '../../../components/requestBodies/InterconnectionCreateInput.yaml'
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Interconnection.yaml'
+      description: created
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Request a new interconnection for the organization
+  tags:
+  - Interconnections

--- a/spec/docs/openapi/public/paths/payment-methods/id.yaml
+++ b/spec/docs/openapi/public/paths/payment-methods/id.yaml
@@ -1,0 +1,110 @@
+delete:
+  description: Deletes the payment method.
+  operationId: deletePaymentMethod
+  parameters:
+  - description: Payment Method UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the payment method
+  tags:
+  - PaymentMethods
+get:
+  description: Returns a payment method
+  operationId: findPaymentMethodById
+  parameters:
+  - description: Payment Method UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/PaymentMethod.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a payment method
+  tags:
+  - PaymentMethods
+put:
+  description: Updates the payment method.
+  operationId: updatePaymentMethod
+  parameters:
+  - description: Payment Method UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/PaymentMethodUpdateInput.yaml'
+    description: Payment Method to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/PaymentMethod.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the payment method
+  tags:
+  - PaymentMethods

--- a/spec/docs/openapi/public/paths/plans.yaml
+++ b/spec/docs/openapi/public/paths/plans.yaml
@@ -1,0 +1,33 @@
+get:
+  description: Provides a listing of available plans to provision your device on.
+  operationId: findPlans
+  parameters:
+  - description: Filter plans by its plan type
+    in: query
+    name: type
+    schema:
+      type: string
+      enum:
+        - standard
+        - workload_optimized
+        - custom
+      example: standard
+
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/PlanList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all plans
+  tags:
+  - Plans

--- a/spec/docs/openapi/public/paths/ports/id.yaml
+++ b/spec/docs/openapi/public/paths/ports/id.yaml
@@ -1,0 +1,35 @@
+get:
+  description: Returns a port
+  operationId: findPortById
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a port
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/assign.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/assign.yaml
@@ -1,0 +1,47 @@
+post:
+  description: Assign a hardware port to a virtual network.
+  operationId: assignPort
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+     $ref: '../../../components/requestBodies/PortAssignInput.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Assign a port to virtual network
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/bond.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/bond.yaml
@@ -1,0 +1,50 @@
+post:
+  description: Enabling bonding for one or all ports
+  operationId: bondPort
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: enable both ports
+    in: query
+    name: bulk_enable
+    schema:
+      type: boolean
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Enabling bonding
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/convert/layer-2.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/convert/layer-2.yaml
@@ -1,0 +1,48 @@
+post:
+  description: Converts a bond port to Layer 2. IP assignments of the port will be
+    removed.
+  operationId: convertLayer2
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    $ref: '../../../../components/requestBodies/PortAssignInput.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Convert to Layer 2
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/convert/layer-3.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/convert/layer-3.yaml
@@ -1,0 +1,51 @@
+post:
+  description: Converts a bond port to Layer 3. VLANs must first be unassigned.
+  operationId: convertLayer3
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../components/schemas/PortConvertLayer3Input.yaml'
+    description: IPs to request
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Convert to Layer 3
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/disbond.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/disbond.yaml
@@ -1,0 +1,50 @@
+post:
+  description: Disabling bonding for one or all ports
+  operationId: disbondPort
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: disable both ports
+    in: query
+    name: bulk_disable
+    schema:
+      type: boolean
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Disabling bonding
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/native-vlan.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/native-vlan.yaml
@@ -1,0 +1,87 @@
+delete:
+  description: Removes the native VLAN from this port
+  operationId: deleteNativeVlan
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Remove native VLAN
+  tags:
+  - Ports
+post:
+  description: Sets a virtual network on this port as a "native VLAN". The VLAN must
+    have already been assigned using the using the "Assign a port to a virtual network"
+    operation.
+  operationId: assignNativeVlan
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: 'Virtual Network ID. May be the UUID of the Virtual Network record,
+      or the VLAN value itself (ex: ''1001'').'
+    in: query
+    name: vnid
+    required: true
+    schema:
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Assign a native VLAN
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/unassign.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/unassign.yaml
@@ -1,0 +1,47 @@
+post:
+  description: Unassign a port for a hardware.
+  operationId: unassignPort
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    $ref: '../../../components/requestBodies/PortAssignInput.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Port.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Unassign a port
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/vlan-assignments.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/vlan-assignments.yaml
@@ -1,0 +1,63 @@
+get:
+  description: Show the port's current VLAN assignments, including if this VLAN is
+    set as native, and the current state of the assignment (ex. 'assigned' or 'unassigning')
+  operationId: findPortVlanAssignments
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Nested attributes to include. Included objects will return their
+      full attributes. Attribute names can be dotted (up to 3 levels) to included
+      deeply nested objects.
+    in: query
+    name: include
+    schema:
+      default:
+      - port
+      - virtual_network
+      items:
+        type: string
+      type: array
+    style: form
+  - description: Nested attributes to exclude. Excluded objects will return only the
+      href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+      nested objects.
+    in: query
+    name: exclude
+    schema:
+      items:
+        type: string
+      type: array
+    style: form
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/PortVlanAssignmentList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: List Current VLAN assignments for a port
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/vlan-assignments/assignment_id.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/vlan-assignments/assignment_id.yaml
@@ -1,0 +1,70 @@
+get:
+  description: Show the details of a specific Port-VLAN assignment, including the
+    current state and if the VLAN is set as native.
+  operationId: findPortVlanAssignmentByPortIdAndAssignmentId
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Assignment ID
+    in: path
+    name: assignment_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Nested attributes to include. Included objects will return their
+      full attributes. Attribute names can be dotted (up to 3 levels) to included
+      deeply nested objects.
+    in: query
+    name: include
+    schema:
+      default:
+      - port
+      - virtual_network
+      items:
+        type: string
+      type: array
+    style: form
+  - description: Nested attributes to exclude. Excluded objects will return only the
+      href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+      nested objects.
+    in: query
+    name: exclude
+    schema:
+      items:
+        type: string
+      type: array
+    style: form
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/PortVlanAssignment.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Show a particular Port VLAN assignment's details
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/ports/id/vlan-assignments/batches.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/vlan-assignments/batches.yaml
@@ -1,0 +1,94 @@
+get:
+  description: Show all the VLAN assignment batches that have been created for managing
+    this port's VLAN assignments
+  operationId: findPortVlanAssignmentBatches
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/PortVlanAssignmentBatchList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: List the VLAN Assignment Batches for a port
+  tags:
+  - Ports
+post:
+  description: Create a new asynchronous batch request which handles adding and/or
+    removing the VLANs to which the port is assigned.
+  operationId: createPortVlanAssignmentBatch
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../components/schemas/PortVlanAssignmentBatchCreateInput.yaml'
+    description: VLAN Assignment batch details
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/PortVlanAssignmentBatch.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a new Port-VLAN Assignment management batch
+  tags:
+  - Ports
+

--- a/spec/docs/openapi/public/paths/ports/id/vlan-assignments/batches/batch_id.yaml
+++ b/spec/docs/openapi/public/paths/ports/id/vlan-assignments/batches/batch_id.yaml
@@ -1,0 +1,47 @@
+get:
+  description: Returns the details of an existing Port-VLAN Assignment batch, including
+    the list of VLANs to assign or unassign, and the current state of the batch.
+  operationId: findPortVlanAssignmentBatchByPortIdAndBatchId
+  parameters:
+  - description: Port UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Batch ID
+    in: path
+    name: batch_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/PortVlanAssignmentBatch.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a VLAN Assignment Batch's details
+  tags:
+  - Ports

--- a/spec/docs/openapi/public/paths/projects.yaml
+++ b/spec/docs/openapi/public/paths/projects.yaml
@@ -1,0 +1,58 @@
+get:
+  description: Returns a collection of projects that the current user is a member
+    of.
+  operationId: findProjects
+  parameters:
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  - $ref: '../components/parameters/Page.yaml'
+  - $ref: '../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/ProjectList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all projects
+  tags:
+  - Projects
+post:
+  description: Creates a new project for the user default organization. If the user
+    don't have an organization, a new one will be created.
+  operationId: createProject
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/ProjectCreateFromRootInput.yaml'
+    description: Project to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Project.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a project
+  tags:
+  - Projects

--- a/spec/docs/openapi/public/paths/projects/id.yaml
+++ b/spec/docs/openapi/public/paths/projects/id.yaml
@@ -1,0 +1,128 @@
+delete:
+  description: Deletes the project.
+  operationId: deleteProject
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the project
+  tags:
+  - Projects
+get:
+  description: Returns a single project if the user has access
+  operationId: findProjectById
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Project.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a project
+  tags:
+  - Projects
+put:
+  description: Updates the project.
+  operationId: updateProject
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/ProjectUpdateInput.yaml'
+    description: Project to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Project.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the project
+  tags:
+  - Projects

--- a/spec/docs/openapi/public/paths/projects/id/api-keys.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/api-keys.yaml
@@ -1,0 +1,81 @@
+get:
+  description: Returns all API keys for a specific project.
+  operationId: findProjectAPIKeys
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/AuthTokenList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all API keys for the project.
+  tags:
+  - Authentication
+post:
+  description: Creates an API key for a project.
+  operationId: createProjectAPIKey
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/AuthTokenInput.yaml'
+    description: API Key to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/AuthToken.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an API key for a project.
+  tags:
+  - Authentication

--- a/spec/docs/openapi/public/paths/projects/id/batches.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/batches.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns all batches for the given project
+  operationId: findBatchesByProject
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/BatchesList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all batches by project
+  tags:
+  - Batches

--- a/spec/docs/openapi/public/paths/projects/id/bgp-config.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/bgp-config.yaml
@@ -1,0 +1,48 @@
+get:
+  description: Returns a bgp config
+  operationId: findBgpConfigByProject
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/BgpConfig.yaml'
+      description: |
+        ok
+
+        When BGP configuration is not enabled empty structure is returned.
+        When BGP configuration is disabled after being enabled BGP configuration data is returned with status disabled.
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: |
+        not found
+
+        The project was not found.
+  summary: Retrieve a bgp config
+  tags:
+  - BGP

--- a/spec/docs/openapi/public/paths/projects/id/bgp-configs.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/bgp-configs.yaml
@@ -1,0 +1,48 @@
+post:
+  description: Requests to enable bgp configuration for a project.
+  operationId: requestBgpConfig
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/BgpConfigRequestInput.yaml'
+    description: BGP config Request to create
+    required: true
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Requesting bgp config
+  tags:
+  - BGP

--- a/spec/docs/openapi/public/paths/projects/id/bgp/sessions.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/bgp/sessions.yaml
@@ -1,0 +1,33 @@
+get:
+  description: Provides a listing of available BGP sessions for the project.
+  operationId: findProjectBgpSessions
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/BgpSessionList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all BGP sessions for project
+  tags:
+  - BGP

--- a/spec/docs/openapi/public/paths/projects/id/customdata.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/customdata.yaml
@@ -1,0 +1,35 @@
+get:
+  description: Provides the custom metadata stored for this project in json format
+  operationId: findProjectCustomdata
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve the custom metadata of a project
+  tags:
+  - Projects

--- a/spec/docs/openapi/public/paths/projects/id/devices.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/devices.yaml
@@ -1,0 +1,125 @@
+get:
+  description: Provides a collection of devices for a given project.
+  operationId: findProjectDevices
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Filter by device facility
+    in: query
+    name: facility
+    schema:
+      type: string
+  - description: Filter by partial hostname
+    in: query
+    name: hostname
+    schema:
+      type: string
+  - description: Filter only reserved instances
+    in: query
+    name: reserved
+    schema:
+      type: boolean
+  - description: Filter by device tag
+    in: query
+    name: tag
+    schema:
+      type: string
+  - description: Filter by instance type (ondemand,spot,reserved)
+    in: query
+    name: type
+    schema:
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/DeviceList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all devices of a project
+  tags:
+  - Devices
+post:
+  description: |-
+    Creates a new device and provisions it in the specified location.
+
+    Device type-specific options are accepted.  For example, `baremetal` devices accept `operating_system`, `hostname`, and `plan`. These parameters may not be accepted for other device types. The default device type is `baremetal`.
+  operationId: createDevice
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          oneOf:
+          - $ref: '../../../components/schemas/DeviceCreateInMetroInput.yaml'
+          - $ref: '../../../components/schemas/DeviceCreateInFacilityInput.yaml'
+    description: Device to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Device.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a device
+  tags:
+  - Devices

--- a/spec/docs/openapi/public/paths/projects/id/devices/batch.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/devices/batch.yaml
@@ -1,0 +1,53 @@
+post:
+  description: |-
+    Creates new devices in batch and provisions them in our datacenter.
+  operationId: createDeviceBatch
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../components/schemas/InstancesBatchCreateInput.yaml'
+    description: Batches to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/BatchesList.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a devices batch
+  tags:
+  - Batches

--- a/spec/docs/openapi/public/paths/projects/id/events.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/events.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Returns a list of events for a single project
+  operationId: findProjectEvents
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/EventList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve project's events
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/projects/id/facilities.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/facilities.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a listing of available datacenters for the given project
+  operationId: findFacilitiesByProject
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/FacilityList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all facilities visible by the project
+  tags:
+  - Facilities

--- a/spec/docs/openapi/public/paths/projects/id/global-bgp-ranges.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/global-bgp-ranges.yaml
@@ -1,0 +1,39 @@
+get:
+  description: Returns all global bgp ranges for a project
+  operationId: findGlobalBgpRanges
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/GlobalBgpRangeList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all global bgp ranges
+  tags:
+  - BGP

--- a/spec/docs/openapi/public/paths/projects/id/hardware-reservations.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/hardware-reservations.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Provides a collection of hardware reservations for a given project.
+  operationId: findProjectHardwareReservations
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/HardwareReservationList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all hardware reservations for a given project
+  tags:
+  - HardwareReservations

--- a/spec/docs/openapi/public/paths/projects/id/ips.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/ips.yaml
@@ -1,0 +1,126 @@
+get:
+  description: Provides a paginated list of IP reservations for a single project.
+  operationId: findIPReservations
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Filter project IP reservations by reservation type
+    in: query
+    name: types
+    schema:
+      items:
+        type: string
+        enum:
+          - global_ipv4
+          - private_ipv4
+          - public_ipv4
+          - public_ipv6
+          - vrf
+      type: array
+    style: form
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - description: Items returned per page
+    in: query
+    name: per_page
+    schema:
+      default: 250 
+      format: int32
+      maximum: 1000
+      minimum: 1
+      type: integer
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/IPReservationList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all ip reservations
+  tags:
+  - IPAddresses
+post:
+  description: Request more IP space for a project in order to have additional IP
+    addresses to assign to devices.  If the request is within the max quota, an IP
+    reservation will be created. If the project will exceed its IP quota, a request
+    will be submitted for review, and will return an IP Reservation with a `state`
+    of `pending`. You can automatically have the request fail with HTTP status 422
+    instead of triggering the review process by providing the `fail_on_approval_required`
+    parameter set to `true` in the request.
+  operationId: requestIPReservation
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          oneOf:
+          - $ref: '../../../components/schemas/IPReservationRequestInput.yaml'
+          - $ref: '../../../components/schemas/VrfIpReservationCreateInput.yaml'
+    description: IP Reservation Request to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../../components/schemas/IPReservation.yaml'
+            - $ref: '../../../components/schemas/VrfIpReservation.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Requesting IP reservations
+  tags:
+  - IPAddresses

--- a/spec/docs/openapi/public/paths/projects/id/licenses.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/licenses.yaml
@@ -1,0 +1,95 @@
+get:
+  description: Provides a collection of licenses for a given project.
+  operationId: findProjectLicenses
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/LicenseList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all licenses
+  tags:
+  - Licenses
+post:
+  description: Creates a new license for the given project
+  operationId: createLicense
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/LicenseCreateInput.yaml'
+    description: License to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/License.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a License
+  tags:
+  - Licenses

--- a/spec/docs/openapi/public/paths/projects/id/plans.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/plans.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a listing of available plans for the given project
+  operationId: findPlansByProject
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/PlanList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all plans visible by the project
+  tags:
+  - Plans

--- a/spec/docs/openapi/public/paths/projects/id/spot-market-requests.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/spot-market-requests.yaml
@@ -1,0 +1,88 @@
+get:
+  description: View all spot market requests for a given project.
+  operationId: listSpotMarketRequests
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/SpotMarketRequestList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: List spot market requests
+  tags:
+  - SpotMarket
+post:
+  description: |-
+    Creates a new spot market request.
+
+    Type-specific options (such as operating_system for baremetal devices) should be included in the main data structure alongside hostname and plan.
+
+    The features attribute allows you to optionally specify what features your server should have. For example, if you require a server with a TPM chip, you may specify `{ "features": { "tpm": "required" } }` (or `{ "features": ["tpm"] }` in shorthand).
+
+    The request will fail if there are no available servers matching your criteria. Alternatively, if you do not require a certain feature, but would prefer to be assigned a server with that feature if there are any available, you may specify that feature with a preferred value (see the example request below).
+
+    The request will not fail if we have no servers with that feature in our inventory.
+  operationId: createSpotMarketRequest
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/SpotMarketRequestCreateInput.yaml'
+    description: Spot Market Request to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/SpotMarketRequest.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a spot market request
+  tags:
+  - SpotMarket

--- a/spec/docs/openapi/public/paths/projects/id/ssh-keys.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/ssh-keys.yaml
@@ -1,0 +1,74 @@
+get:
+  description: Returns a collection of the project's ssh keys.
+  operationId: findProjectSSHKeys
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Search by key, label, or fingerprint
+    in: query
+    name: Search string
+    schema:
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/SSHKeyList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve a project's ssh keys
+  tags:
+  - SSHKeys
+post:
+  description: Creates a ssh key.
+  operationId: createProjectSSHKey
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/SSHKeyCreateInput.yaml'
+    description: ssh key to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/SSHKey.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a ssh key for the given project
+  tags:
+  - SSHKeys

--- a/spec/docs/openapi/public/paths/projects/id/transfers.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/transfers.yaml
@@ -1,0 +1,52 @@
+post:
+  description: Organization owners can transfer their projects to other organizations.
+  operationId: createTransferRequest
+  parameters:
+  - description: UUID of the project to be transferred
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/TransferRequestInput.yaml'
+    description: Transfer Request to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/TransferRequest.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a transfer request
+  tags:
+  - Projects

--- a/spec/docs/openapi/public/paths/projects/id/usages.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/usages.yaml
@@ -1,0 +1,45 @@
+get:
+  description: Returns all usages for a project.
+  operationId: findProjectUsage
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Filter usages created after this date
+    in: query
+    name: created[after]
+    schema:
+      format: datetime
+      type: string
+  - description: Filter usages created before this date
+    in: query
+    name: created[before]
+    schema:
+      format: datetime
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/ProjectUsageList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all usages for project
+  tags:
+  - Usages

--- a/spec/docs/openapi/public/paths/projects/id/virtual-networks.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/virtual-networks.yaml
@@ -1,0 +1,103 @@
+get:
+  description: Provides a list of virtual networks for a single project.
+  operationId: findVirtualNetworks
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - description: Filter by Facility ID (uuid) or Facility Code
+    in: query
+    name: facility
+    schema:
+      type: string
+  - description: Filter by Metro ID (uuid) or Metro Code
+    in: query
+    name: metro
+    schema:
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/VirtualNetworkList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all virtual networks
+  tags:
+  - VLANs
+post:
+  description: Creates an virtual network.
+  operationId: createVirtualNetwork
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/VirtualNetworkCreateInput.yaml'
+    description: Virtual Network to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/VirtualNetwork.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a virtual network
+  tags:
+  - VLANs

--- a/spec/docs/openapi/public/paths/projects/id/vrfs.yaml
+++ b/spec/docs/openapi/public/paths/projects/id/vrfs.yaml
@@ -1,0 +1,86 @@
+get:
+  description: Returns the list of VRFs for a single project.
+  operationId: findVrfs
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - description: Filter by Metro ID (uuid) or Metro Code
+    in: query
+    name: metro
+    schema:
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/VrfList.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all VRFs in the project
+  tags:
+  - VRFs
+post:
+  description: Creates a new VRF in the specified project
+  operationId: createVrf
+  parameters:
+  - description: Project UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../components/schemas/VrfCreateInput.yaml'
+    description: VRF to create
+    required: true
+  responses:
+    "201":
+        content:
+          application/json:
+            schema:
+              $ref: '../../../components/schemas/Vrf.yaml'
+        description: created
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a new VRF in the specified project
+  tags:
+  - VRFs

--- a/spec/docs/openapi/public/paths/projects/project_id/connections.yaml
+++ b/spec/docs/openapi/public/paths/projects/project_id/connections.yaml
@@ -1,0 +1,68 @@
+get:
+  description: List the connections belonging to the project
+  operationId: projectListInterconnections
+  parameters:
+  - description: UUID of the project
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/InterconnectionList.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: List project connections
+  tags:
+  - Interconnections
+post:
+  description: Creates a new interconnection request
+  operationId: createProjectInterconnection
+  parameters:
+  - description: UUID of the project
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    $ref: '../../../components/requestBodies/InterconnectionCreateInput.yaml'
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Interconnection.yaml'
+      description: created
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Request a new interconnection for the project's organization
+  tags:
+  - Interconnections

--- a/spec/docs/openapi/public/paths/projects/project_id/invitations.yaml
+++ b/spec/docs/openapi/public/paths/projects/project_id/invitations.yaml
@@ -1,0 +1,90 @@
+get:
+  description: Returns all invitations in a project.
+  operationId: findProjectInvitations
+  parameters:
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/InvitationList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve project invitations
+  tags:
+  - Projects
+post:
+  description: In order to add a user to a project, they must first be invited.
+  operationId: createProjectInvitation
+  parameters:
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    $ref: '../../../components/requestBodies/InvitationInput.yaml'
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Invitation.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an invitation for a project
+  tags:
+  - Projects

--- a/spec/docs/openapi/public/paths/projects/project_id/ips/id/customdata.yaml
+++ b/spec/docs/openapi/public/paths/projects/project_id/ips/id/customdata.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Provides the custom metadata stored for this IP Reservation in json
+    format
+  operationId: findIPReservationCustomdata
+  parameters:
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Ip Reservation UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve the custom metadata of an IP Reservation
+  tags:
+  - Projects

--- a/spec/docs/openapi/public/paths/projects/project_id/memberships.yaml
+++ b/spec/docs/openapi/public/paths/projects/project_id/memberships.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Returns all memberships in a project.
+  operationId: findProjectMemberships
+  parameters:
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/MembershipList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve project memberships
+  tags:
+  - Projects

--- a/spec/docs/openapi/public/paths/projects/project_id/metal-gateways.yaml
+++ b/spec/docs/openapi/public/paths/projects/project_id/metal-gateways.yaml
@@ -1,0 +1,87 @@
+get:
+  description: Return all metal gateways for a project
+  operationId: findMetalGatewaysByProject
+  parameters:
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/MetalGatewayList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Returns all metal gateways for a project
+  tags:
+  - MetalGateways
+post:
+  description: Create a metal gateway in a project
+  operationId: createMetalGateway
+  parameters:
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          oneOf:
+          - $ref: '../../../components/schemas/MetalGatewayCreateInput.yaml'
+          - $ref: '../../../components/schemas/VrfMetalGatewayCreateInput.yaml'
+    description: Metal Gateway to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../../components/schemas/MetalGateway.yaml'
+            - $ref: '../../../components/schemas/VrfMetalGateway.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a metal gateway
+  tags:
+  - MetalGateways

--- a/spec/docs/openapi/public/paths/projects/project_id/self-service/reservations.yaml
+++ b/spec/docs/openapi/public/paths/projects/project_id/self-service/reservations.yaml
@@ -1,0 +1,69 @@
+get:
+  description: Returns all reservations.
+  operationId: findSelfServiceReservations
+  parameters:
+  - $ref: '../../../../components/parameters/Page.yaml'
+  - $ref: '../../../../components/parameters/PerPage.yaml'
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/SelfServiceReservationList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all reservations
+  tags:
+  - SelfServiceReservations
+post:
+  description: Creates a reservation.
+  operationId: createSelfServiceReservation
+  parameters:
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../components/schemas/CreateSelfServiceReservationRequest.yaml'
+    description: reservation to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/SelfServiceReservationResponse.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a reservation
+  tags:
+  - SelfServiceReservations

--- a/spec/docs/openapi/public/paths/projects/project_id/self-service/reservations/id.yaml
+++ b/spec/docs/openapi/public/paths/projects/project_id/self-service/reservations/id.yaml
@@ -1,0 +1,40 @@
+get:
+  description: Returns a reservation
+  operationId: findSelfServiceReservation
+  parameters:
+  - description: Reservation short_id
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Project UUID
+    in: path
+    name: project_id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/SelfServiceReservationResponse.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a reservation
+  tags:
+  - SelfServiceReservations

--- a/spec/docs/openapi/public/paths/reset-password.yaml
+++ b/spec/docs/openapi/public/paths/reset-password.yaml
@@ -1,0 +1,53 @@
+delete:
+  description: Resets current user password.
+  operationId: resetPassword
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/NewPassword.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Reset current user password
+  tags:
+  - PasswordResetTokens
+post:
+  description: Creates a password reset token
+  operationId: createPasswordResetToken
+  parameters:
+  - description: Email of user to create password reset token
+    in: query
+    name: email
+    required: true
+    schema:
+      type: string
+  responses:
+    "201":
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a password reset token
+  tags:
+  - PasswordResetTokens

--- a/spec/docs/openapi/public/paths/spot-market-requests/id.yaml
+++ b/spec/docs/openapi/public/paths/spot-market-requests/id.yaml
@@ -1,0 +1,81 @@
+delete:
+  description: Deletes the spot market request.
+  operationId: deleteSpotMarketRequest
+  parameters:
+  - description: SpotMarketRequest UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - description: Terminate associated spot instances
+    in: query
+    name: force_termination
+    schema:
+      type: boolean
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the spot market request
+  tags:
+  - SpotMarket
+get:
+  description: Returns a single spot market request
+  operationId: findSpotMarketRequestById
+  parameters:
+  - description: SpotMarketRequest UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/SpotMarketRequest.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a spot market request
+  tags:
+  - SpotMarket

--- a/spec/docs/openapi/public/paths/ssh-keys.yaml
+++ b/spec/docs/openapi/public/paths/ssh-keys.yaml
@@ -1,0 +1,54 @@
+get:
+  description: Returns a collection of the user’s ssh keys.
+  operationId: findSSHKeys
+  parameters:
+  - description: Search by key, label, or fingerprint
+    in: query
+    name: Search string
+    schema:
+      type: string
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/SSHKeyList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all ssh keys
+  tags:
+  - SSHKeys
+post:
+  description: Creates a ssh key.
+  operationId: createSSHKey
+  requestBody:
+    $ref: '../components/requestBodies/SSHKeyCreateInput.yaml'
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/SSHKey.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a ssh key for the current user
+  tags:
+  - SSHKeys

--- a/spec/docs/openapi/public/paths/ssh-keys/id.yaml
+++ b/spec/docs/openapi/public/paths/ssh-keys/id.yaml
@@ -1,0 +1,128 @@
+delete:
+  description: Deletes the ssh key.
+  operationId: deleteSSHKey
+  parameters:
+  - description: ssh key UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the ssh key
+  tags:
+  - SSHKeys
+get:
+  description: Returns a single ssh key if the user has access
+  operationId: findSSHKeyById
+  parameters:
+  - description: SSH Key UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/SSHKey.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a ssh key
+  tags:
+  - SSHKeys
+put:
+  description: Updates the ssh key.
+  operationId: updateSSHKey
+  parameters:
+  - description: SSH Key UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/SSHKeyInput.yaml'
+    description: ssh key to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/SSHKey.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the ssh key
+  tags:
+  - SSHKeys

--- a/spec/docs/openapi/public/paths/support-requests.yaml
+++ b/spec/docs/openapi/public/paths/support-requests.yaml
@@ -1,0 +1,40 @@
+post:
+  description: Support Ticket.
+  operationId: requestSuppert
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/SupportRequestInput.yaml'
+    description: Support Request to create
+    required: true
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create a support ticket
+  tags:
+  - SupportRequest

--- a/spec/docs/openapi/public/paths/transfers/id.yaml
+++ b/spec/docs/openapi/public/paths/transfers/id.yaml
@@ -1,0 +1,111 @@
+delete:
+  description: Decline a transfer request.
+  operationId: declineTransferRequest
+  parameters:
+  - description: Transfer request UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Decline a transfer request
+  tags:
+  - TransferRequests
+get:
+  description: Returns a single transfer request.
+  operationId: findTransferRequestById
+  parameters:
+  - description: Transfer request UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/TransferRequest.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: View a transfer request
+  tags:
+  - TransferRequests
+put:
+  description: Accept a transfer request.
+  operationId: acceptTransferRequest
+  parameters:
+  - description: Transfer request UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Accept a transfer request
+  tags:
+  - TransferRequests

--- a/spec/docs/openapi/public/paths/user.yaml
+++ b/spec/docs/openapi/public/paths/user.yaml
@@ -1,0 +1,54 @@
+get:
+  description: Returns the user object for the currently logged-in user.
+  operationId: findCurrentUser
+  parameters:
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/User.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve the current user
+  tags:
+  - Users
+put:
+  description: Updates the currently logged-in user.
+  operationId: updateCurrentUser
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/UserUpdateInput.yaml'
+    description: User to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/User.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the current user
+  tags:
+  - Users

--- a/spec/docs/openapi/public/paths/user/api-keys.yaml
+++ b/spec/docs/openapi/public/paths/user/api-keys.yaml
@@ -1,0 +1,66 @@
+post:
+  description: Creates a API key for the current user.
+  operationId: createAPIKey
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/AuthTokenInput.yaml'
+    description: API key to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/AuthToken.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an API key
+  tags:
+  - Authentication
+get:
+  description: Returns all API keys for the current user.
+  operationId: findAPIKeys
+  parameters:
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/AuthTokenList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all user API keys
+  tags:
+  - Authentication

--- a/spec/docs/openapi/public/paths/user/api-keys/id.yaml
+++ b/spec/docs/openapi/public/paths/user/api-keys/id.yaml
@@ -1,0 +1,29 @@
+delete:
+  description: Deletes the current user API key.
+  operationId: deleteUserAPIKey
+  parameters:
+  - description: API Key UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the API key
+  tags:
+  - Authentication

--- a/spec/docs/openapi/public/paths/user/otp/app.yaml
+++ b/spec/docs/openapi/public/paths/user/otp/app.yaml
@@ -1,0 +1,36 @@
+delete:
+  description: Disables two factor authentication.
+  operationId: disableTfaApp
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Disable two factor authentication
+  tags:
+  - TwoFactorAuth
+post:
+  description: Enables two factor authentication using authenticator app.
+  operationId: enableTfaApp
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Enable two factor auth using app
+  tags:
+  - TwoFactorAuth

--- a/spec/docs/openapi/public/paths/user/otp/recovery-codes.yaml
+++ b/spec/docs/openapi/public/paths/user/otp/recovery-codes.yaml
@@ -1,0 +1,62 @@
+get:
+  description: Returns my recovery codes.
+  operationId: findRecoveryCodes
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/RecoveryCodeList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Retrieve my recovery codes
+  tags:
+  - OTPs
+post:
+  description: Generate a new set of recovery codes.
+  operationId: regenerateCodes
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/RecoveryCodeList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Generate new recovery codes
+  tags:
+  - OTPs

--- a/spec/docs/openapi/public/paths/user/otp/sms.yaml
+++ b/spec/docs/openapi/public/paths/user/otp/sms.yaml
@@ -1,0 +1,36 @@
+delete:
+  description: Disables two factor authentication.
+  operationId: disableTfaSms
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Disable two factor authentication
+  tags:
+  - TwoFactorAuth
+post:
+  description: Enables two factor authentication with sms.
+  operationId: enableTfaSms
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Enable two factor auth using sms
+  tags:
+  - TwoFactorAuth

--- a/spec/docs/openapi/public/paths/user/otp/sms/receive.yaml
+++ b/spec/docs/openapi/public/paths/user/otp/sms/receive.yaml
@@ -1,0 +1,33 @@
+post:
+  description: Sends an OTP to the user's mobile phone.
+  operationId: receiveCodes
+  responses:
+    "204":
+      description: no content
+    "400":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: bad request
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unprocessable entity
+    "500":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: internal server error
+  summary: Receive an OTP per sms
+  tags:
+  - OTPs

--- a/spec/docs/openapi/public/paths/user/otp/verify/otp.yaml
+++ b/spec/docs/openapi/public/paths/user/otp/verify/otp.yaml
@@ -1,0 +1,29 @@
+post:
+  description: It verifies the user once a valid OTP is provided. It gives back a
+    session token, essentially logging in the user.
+  operationId: findEnsureOtp
+  parameters:
+  - description: OTP
+    in: path
+    name: otp
+    required: true
+    schema:
+      type: string
+  responses:
+    "204":
+      description: no content
+    "400":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: bad request
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Verify user by providing an OTP
+  tags:
+  - OTPs

--- a/spec/docs/openapi/public/paths/userdata/validate.yaml
+++ b/spec/docs/openapi/public/paths/userdata/validate.yaml
@@ -1,0 +1,27 @@
+post:
+  description: Validates user data (Userdata)
+  operationId: validateUserdata
+  parameters:
+  - description: Userdata to validate
+    in: query
+    name: userdata
+    schema:
+      type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Validate user data
+  tags:
+  - Userdata

--- a/spec/docs/openapi/public/paths/users.yaml
+++ b/spec/docs/openapi/public/paths/users.yaml
@@ -1,0 +1,60 @@
+get:
+  description: Returns a list of users that the are accessible to the current user
+    (all users in the current user’s projects, essentially).
+  operationId: findUsers
+  parameters:
+  - $ref: '../components/parameters/Include.yaml'
+  - $ref: '../components/parameters/Exclude.yaml'
+  - $ref: '../components/parameters/Page.yaml'
+  - $ref: '../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/UserList.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+  summary: Retrieve all users
+  tags:
+  - Users
+post:
+  description: Creates a user.
+  operationId: createUser
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/UserCreateInput.yaml'
+    description: User to create
+    required: true
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/User.yaml'
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+          example:
+            errors:
+              - "Email address username@example.com has already been taken"
+      description: unprocessable entity
+  summary: Create a user
+  tags:
+  - Users

--- a/spec/docs/openapi/public/paths/users/id.yaml
+++ b/spec/docs/openapi/public/paths/users/id.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a single user if the user has access
+  operationId: findUserById
+  parameters:
+  - description: User UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/User.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a user
+  tags:
+  - Users

--- a/spec/docs/openapi/public/paths/users/id/customdata.yaml
+++ b/spec/docs/openapi/public/paths/users/id/customdata.yaml
@@ -1,0 +1,35 @@
+get:
+  description: Provides the custom metadata stored for this user in json format
+  operationId: findUserCustomdata
+  parameters:
+  - description: User UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve the custom metadata of a user
+  tags:
+  - Users

--- a/spec/docs/openapi/public/paths/verify-email.yaml
+++ b/spec/docs/openapi/public/paths/verify-email.yaml
@@ -1,0 +1,57 @@
+post:
+  description: Creates an email verification request
+  operationId: createValidationRequest
+  parameters:
+  - description: Email for verification request
+    in: query
+    name: login
+    required: true
+    schema:
+      type: string
+  responses:
+    "201":
+      description: created
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Create an email verification request
+  tags:
+  - UserVerificationTokens
+put:
+  description: Consumes an email verification token and verifies the user associated
+    with it.
+  operationId: consumeVerificationRequest
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/VerifyEmail.yaml'
+    description: Email to create
+    required: true
+  responses:
+    "200":
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unauthorized
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Verify a user using an email verification token
+  tags:
+  - UserVerificationTokens

--- a/spec/docs/openapi/public/paths/virtual-circuit/id/events.yaml
+++ b/spec/docs/openapi/public/paths/virtual-circuit/id/events.yaml
@@ -1,0 +1,43 @@
+get:
+  description: Returns a list of the virtual circuit events
+  operationId: findVirtualCircuitEvents
+  parameters:
+  - description: Virtual Circuit UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Event.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve interconnection events
+  tags:
+  - Events

--- a/spec/docs/openapi/public/paths/virtual-circuits/id.yaml
+++ b/spec/docs/openapi/public/paths/virtual-circuits/id.yaml
@@ -1,0 +1,122 @@
+delete:
+  description: Delete a virtual circuit from a Dedicated Port.
+  operationId: deleteVirtualCircuit
+  parameters:
+  - description: Virtual Circuit UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "202":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../components/schemas/VirtualCircuit.yaml'
+            - $ref: '../../components/schemas/VrfVirtualCircuit.yaml'
+      description: accepted
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete a virtual circuit
+  tags:
+  - Interconnections
+get:
+  description: Get the details of a virtual circuit
+  operationId: getVirtualCircuit
+  parameters:
+  - description: Virtual Circuit UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../components/schemas/VirtualCircuit.yaml'
+            - $ref: '../../components/schemas/VrfVirtualCircuit.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Get a virtual circuit
+  tags:
+  - Interconnections
+put:
+  description: Update the details of a virtual circuit.
+  operationId: updateVirtualCircuit
+  parameters:
+  - description: Virtual Circuit UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          oneOf:
+          - $ref: '../../components/schemas/VirtualCircuitUpdateInput.yaml'
+          - $ref: '../../components/schemas/VrfVirtualCircuitUpdateInput.yaml'
+    description: Updated Virtual Circuit details
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../components/schemas/VirtualCircuit.yaml'
+            - $ref: '../../components/schemas/VrfVirtualCircuit.yaml'
+      description: ok
+    "202":
+      content:
+        application/json:
+          schema:
+            oneOf:
+            - $ref: '../../components/schemas/VirtualCircuit.yaml'
+            - $ref: '../../components/schemas/VrfVirtualCircuit.yaml'
+      description: accepted
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Update a virtual circuit
+  tags:
+  - Interconnections

--- a/spec/docs/openapi/public/paths/virtual-networks/id.yaml
+++ b/spec/docs/openapi/public/paths/virtual-networks/id.yaml
@@ -1,0 +1,90 @@
+delete:
+  description: Deletes a virtual network.
+  operationId: deleteVirtualNetwork
+  parameters:
+  - description: Virtual Network UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/VirtualNetwork.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Delete a virtual network
+  tags:
+  - VLANs
+get:
+  description: Get a virtual network.
+  operationId: getVirtualNetwork
+  parameters:
+  - description: Virtual Network UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/VirtualNetwork.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Get a virtual network
+  tags:
+  - VLANs

--- a/spec/docs/openapi/public/paths/vrfs/id.yaml
+++ b/spec/docs/openapi/public/paths/vrfs/id.yaml
@@ -1,0 +1,128 @@
+delete:
+  description: Deletes the VRF
+  operationId: deleteVrf
+  parameters:
+    - description: VRF UUID
+      in: path
+      name: id
+      required: true
+      schema:
+        format: uuid
+        type: string
+  responses:
+    "204":
+      description: no content
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Delete the VRF
+  tags:
+  - VRFs
+get:
+  description: Returns a single VRF resource
+  operationId: findVrfById
+  parameters:
+  - description: VRF UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  - $ref: '../../components/parameters/Include.yaml'
+  - $ref: '../../components/parameters/Exclude.yaml'
+  responses:
+    "200":
+        content:
+          application/json:
+            schema:
+              $ref: '../../components/schemas/Vrf.yaml'
+        description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve a VRF
+  tags:
+  - VRFs
+put:
+  description: Updates the VRF.
+  operationId: updateVrf
+  parameters:
+  - description: VRF UUID
+    in: path
+    name: id
+    required: true
+    schema:
+      format: uuid
+      type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../components/schemas/VrfUpdateInput.yaml'
+    description: VRF to update
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Vrf.yaml'
+      description: ok
+    "401":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unauthorized
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: not found
+    "422":
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/Error.yaml'
+      description: unprocessable entity
+  summary: Update the VRF
+  tags:
+  - VRFs

--- a/spec/docs/openapi/public/paths/vrfs/id/ips.yaml
+++ b/spec/docs/openapi/public/paths/vrfs/id/ips.yaml
@@ -1,0 +1,53 @@
+get:
+  description: Returns the list of VRF IP Reservations for the VRF.
+  operationId: findVrfIpReservations
+  parameters:
+    - description: VRF UUID
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - description: Nested attributes to include. Included objects will return their
+        full attributes. Attribute names can be dotted (up to 3 levels) to included
+        deeply nested objects.
+      in: query
+      name: include
+      schema:
+        items:
+          type: string
+        type: array
+      style: form
+    - description: Nested attributes to exclude. Excluded objects will return only the
+        href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+        nested objects.
+      in: query
+      name: exclude
+      schema:
+        items:
+          type: string
+        type: array
+      style: form
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/VrfIpReservationList.yaml'
+      description: ok
+    "403":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: forbidden
+    "404":
+      content:
+        application/json:
+          schema:
+            $ref: '../../../components/schemas/Error.yaml'
+      description: not found
+  summary: Retrieve all VRF IP Reservations in the VRF
+  tags:
+  - VRFs


### PR DESCRIPTION
This branch contains individual files for each schema, path, parameter, and other components of the Equinix Metal API spec.

This is split from the spec in a similar fashion to what can be done using https://github.com/displague/openapi-axe.

The expectation is that the EM API spec will be made available in this format so that we can fetch and crawl the individual files and keep this docs/ directory in-sync with upstream changes, thus simplifying the patch process.

Signed-off-by: Marques Johansson <mjohansson@equinix.com>