### PR TITLE
Add manual workflow to fetch latest API spec

### DIFF
--- a/.github/workflows/auto-commit-client-updates.yml
+++ b/.github/workflows/auto-commit-client-updates.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: GitHub user
+      run: |
+        git config --global user.name 'equinix-labs@auto-commit-workflow'
+        git config --global user.email 'bot@equinix.noreply.github.com'
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
@@ -24,12 +28,9 @@ jobs:
       
     - name: Commit to branch if client is updated after executing make.
       run: |
-        git config --global user.name 'equinix-labs@auto-commit-workflow'
-        git config --global user.email 'bot@equinix.noreply.github.com'
-        git config advice.addIgnoredFile false
         git fetch
-        echo -e "\nThis is executing for branch: ${GITHUB_REF##*/}."
-        git checkout ${GITHUB_REF##*/}
+        echo -e "\nThis is executing for branch: ${GITHUB_REF_NAME}."
+        git checkout ${GITHUB_REF_NAME}
         make docker_run
         echo -e "Make execution completed."
         git add spec/oas3.patched/.

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,14 +14,26 @@ jobs:
       uses: actions/checkout@v3
     - name: GitHub user
       run: |
-        # https://api.github.com/users/github-actions[bot]
         git config user.name 'github-actions[bot]'
-        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git config user.email 'bot@equinix.noreply.github.com'
     - name: Sync
       run: |
         make fetch
         git add spec/oas3.fetched
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec' spec/oas3.fetched
+    - name: Generate code
+      run: |
+        make docker_run
+        echo -e "Make execution completed."
+        git add spec/oas3.patched/.
+        git add spec/oas3.stitched/.
+        git add equinix-openapi-metal/.
+        echo -e "\nGit status:"
+        echo `git status`
+        cmsg='sync: generate code for ${{ steps.date.outputs.date }} spec'
+        echo -e "\nCommit message created : $cmsg"
+        echo -e "\nCommitting if there are files to update in client dir:"
+        echo `git commit -m "$cmsg"`
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,40 @@
+on: ["workflow_dispatch"]
+name: Sync
+jobs:
+  sync:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: GitHub user
+      run: |
+        # https://api.github.com/users/github-actions[bot]
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+    - name: Sync
+      run: |
+        make fetch
+        git add spec/oas3.fetched
+        git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec' spec/oas3.fetched
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        branch: sync/gh
+        branch-suffix: timestamp
+        title: API Sync by GitHub Action (${{ steps.date.outputs.date }})
+        body: |
+          This API Sync PR was automated through [GitHub Actions workflow_displatch](https://github.com/equinix-labs/metal-go/actions?query=event%3Aworkflow_dispatch)
+          on ${{ steps.date.outputs.date }}.
+
+          * latest Swagger is fetched
+        delete-branch: true
+    - name: Check outputs
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SPEC_ROOT_FILE:=openapi3.yaml
 PATCHED_SPEC_ENTRY_POINT=spec/oas3.patched/openapi/public/${SPEC_ROOT_FILE}
 PATCHED_SPEC_OUTPUT_DIR=spec/oas3.stitched/
 
-SPEC_FETCHER=${CRI} run --rm -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
+SPEC_FETCHER=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
 SPEC_PATCHED_FILE=oas3.stitched.metal.yaml
 
 SPEC_DIR_FETCHED_FILE=spec/oas3.fetched/

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,8 @@ pre-spec-patch-dir:
 	cp -r ${SPEC_DIR_FETCHED_FILE} ${SPEC_DIR_PATCHED_FILE}
 
 	for diff in $(shell find ${SPEC_FETCHED_PATCHES} -name \*.patch | sort -n); do \
-		patch -p1 < $$diff; \
+		patch --no-backup-if-mismatch -N -t -p1 -i $$diff; \
 	done
-
 
 move-workflow:
 	cp -r internal/workflow equinix-openapi-metal/src/main/java/com/equinix/


### PR DESCRIPTION
The new `sync` workflow can be run manually in order to have GitHub fetch the latest spec, regenerate the code using the latest spec, and open a PR with the changes.

Fixes #72 