### PR TITLE
Add missing parameters to projectListInterconnections endpoint

### DIFF
--- a/equinix-openapi-metal/api/openapi.yaml
+++ b/equinix-openapi-metal/api/openapi.yaml
@@ -8803,6 +8803,56 @@ paths:
           format: uuid
           type: string
         style: simple
+      - description: |-
+          Nested attributes to include. Included objects will return their full
+          attributes. Attribute names can be dotted (up to 3 levels) to included deeply
+          nested objects.
+        explode: false
+        in: query
+        name: include
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: |-
+          Nested attributes to exclude. Excluded objects will return only the href
+          attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+          nested objects.
+        explode: false
+        in: query
+        name: exclude
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: Page to return
+        explode: true
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 1
+          format: int32
+          maximum: 100000
+          minimum: 1
+          type: integer
+        style: form
+      - description: Items returned per page
+        explode: true
+        in: query
+        name: per_page
+        required: false
+        schema:
+          default: 10
+          format: int32
+          maximum: 1000
+          minimum: 1
+          type: integer
+        style: form
       responses:
         "200":
           content:

--- a/equinix-openapi-metal/docs/InterconnectionsApi.md
+++ b/equinix-openapi-metal/docs/InterconnectionsApi.md
@@ -888,7 +888,7 @@ public class Example {
 
 <a name="projectListInterconnections"></a>
 # **projectListInterconnections**
-> InterconnectionList projectListInterconnections(projectId)
+> InterconnectionList projectListInterconnections(projectId, include, exclude, page, perPage)
 
 List project connections
 
@@ -917,8 +917,12 @@ public class Example {
 
     InterconnectionsApi apiInstance = new InterconnectionsApi(defaultClient);
     UUID projectId = UUID.randomUUID(); // UUID | UUID of the project
+    List<String> include = Arrays.asList(); // List<String> | Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects.
+    List<String> exclude = Arrays.asList(); // List<String> | Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects.
+    Integer page = 1; // Integer | Page to return
+    Integer perPage = 10; // Integer | Items returned per page
     try {
-      InterconnectionList result = apiInstance.projectListInterconnections(projectId);
+      InterconnectionList result = apiInstance.projectListInterconnections(projectId, include, exclude, page, perPage);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling InterconnectionsApi#projectListInterconnections");
@@ -936,6 +940,10 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **projectId** | **UUID**| UUID of the project | |
+| **include** | [**List&lt;String&gt;**](String.md)| Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. | [optional] |
+| **exclude** | [**List&lt;String&gt;**](String.md)| Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. | [optional] |
+| **page** | **Integer**| Page to return | [optional] [default to 1] |
+| **perPage** | **Integer**| Items returned per page | [optional] [default to 10] |
 
 ### Return type
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/api/InterconnectionsApi.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/api/InterconnectionsApi.java
@@ -1723,6 +1723,10 @@ public class InterconnectionsApi {
     /**
      * Build call for projectListInterconnections
      * @param projectId UUID of the project (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
+     * @param page Page to return (optional, default to 1)
+     * @param perPage Items returned per page (optional, default to 10)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -1734,7 +1738,7 @@ public class InterconnectionsApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call projectListInterconnectionsCall(UUID projectId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call projectListInterconnectionsCall(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -1760,6 +1764,22 @@ public class InterconnectionsApi {
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
+        if (include != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "include", include));
+        }
+
+        if (exclude != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "exclude", exclude));
+        }
+
+        if (page != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("page", page));
+        }
+
+        if (perPage != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("per_page", perPage));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -1780,13 +1800,13 @@ public class InterconnectionsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call projectListInterconnectionsValidateBeforeCall(UUID projectId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call projectListInterconnectionsValidateBeforeCall(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage, final ApiCallback _callback) throws ApiException {
         // verify the required parameter 'projectId' is set
         if (projectId == null) {
             throw new ApiException("Missing the required parameter 'projectId' when calling projectListInterconnections(Async)");
         }
 
-        return projectListInterconnectionsCall(projectId, _callback);
+        return projectListInterconnectionsCall(projectId, include, exclude, page, perPage, _callback);
 
     }
 
@@ -1794,6 +1814,10 @@ public class InterconnectionsApi {
      * List project connections
      * List the connections belonging to the project
      * @param projectId UUID of the project (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
+     * @param page Page to return (optional, default to 1)
+     * @param perPage Items returned per page (optional, default to 10)
      * @return InterconnectionList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1804,8 +1828,8 @@ public class InterconnectionsApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public InterconnectionList projectListInterconnections(UUID projectId) throws ApiException {
-        ApiResponse<InterconnectionList> localVarResp = projectListInterconnectionsWithHttpInfo(projectId);
+    public InterconnectionList projectListInterconnections(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage) throws ApiException {
+        ApiResponse<InterconnectionList> localVarResp = projectListInterconnectionsWithHttpInfo(projectId, include, exclude, page, perPage);
         return localVarResp.getData();
     }
 
@@ -1813,6 +1837,10 @@ public class InterconnectionsApi {
      * List project connections
      * List the connections belonging to the project
      * @param projectId UUID of the project (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
+     * @param page Page to return (optional, default to 1)
+     * @param perPage Items returned per page (optional, default to 10)
      * @return ApiResponse&lt;InterconnectionList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1823,8 +1851,8 @@ public class InterconnectionsApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<InterconnectionList> projectListInterconnectionsWithHttpInfo(UUID projectId) throws ApiException {
-        okhttp3.Call localVarCall = projectListInterconnectionsValidateBeforeCall(projectId, null);
+    public ApiResponse<InterconnectionList> projectListInterconnectionsWithHttpInfo(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage) throws ApiException {
+        okhttp3.Call localVarCall = projectListInterconnectionsValidateBeforeCall(projectId, include, exclude, page, perPage, null);
         Type localVarReturnType = new TypeToken<InterconnectionList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -1833,6 +1861,10 @@ public class InterconnectionsApi {
      * List project connections (asynchronously)
      * List the connections belonging to the project
      * @param projectId UUID of the project (required)
+     * @param include Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
+     * @param exclude Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
+     * @param page Page to return (optional, default to 1)
+     * @param perPage Items returned per page (optional, default to 10)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -1844,9 +1876,9 @@ public class InterconnectionsApi {
         <tr><td> 404 </td><td> not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call projectListInterconnectionsAsync(UUID projectId, final ApiCallback<InterconnectionList> _callback) throws ApiException {
+    public okhttp3.Call projectListInterconnectionsAsync(UUID projectId, List<String> include, List<String> exclude, Integer page, Integer perPage, final ApiCallback<InterconnectionList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = projectListInterconnectionsValidateBeforeCall(projectId, _callback);
+        okhttp3.Call localVarCall = projectListInterconnectionsValidateBeforeCall(projectId, include, exclude, page, perPage, _callback);
         Type localVarReturnType = new TypeToken<InterconnectionList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/api/InterconnectionsApiTest.java
+++ b/equinix-openapi-metal/src/test/java/com/equinix/openapi/metal/v1/api/InterconnectionsApiTest.java
@@ -226,7 +226,11 @@ public class InterconnectionsApiTest {
     @Test
     public void projectListInterconnectionsTest() throws ApiException {
         UUID projectId = null;
-        InterconnectionList response = api.projectListInterconnections(projectId);
+        List<String> include = null;
+        List<String> exclude = null;
+        Integer page = null;
+        Integer perPage = null;
+        InterconnectionList response = api.projectListInterconnections(projectId, include, exclude, page, perPage);
         // TODO: test validations
     }
 

--- a/patches/spec.fetched.json/20230426-fix-interconnection-pagination.patch
+++ b/patches/spec.fetched.json/20230426-fix-interconnection-pagination.patch
@@ -1,0 +1,15 @@
+diff --git a/spec/oas3.patched/openapi/public/paths/projects/project_id/connections.yaml b/spec/oas3.patched/openapi/public/paths/projects/project_id/connections.yaml
+index e1034d2..3bdcf69 100644
+--- a/spec/oas3.patched/openapi/public/paths/projects/project_id/connections.yaml
++++ b/spec/oas3.patched/openapi/public/paths/projects/project_id/connections.yaml
+@@ -9,6 +9,10 @@ get:
+     schema:
+       format: uuid
+       type: string
++  - $ref: '../../../components/parameters/Include.yaml'
++  - $ref: '../../../components/parameters/Exclude.yaml'
++  - $ref: '../../../components/parameters/Page.yaml'
++  - $ref: '../../../components/parameters/PerPage.yaml'
+   responses:
+     "200":
+       content:

--- a/spec/oas3.patched/openapi/public/paths/projects/project_id/connections.yaml
+++ b/spec/oas3.patched/openapi/public/paths/projects/project_id/connections.yaml
@@ -9,6 +9,10 @@ get:
     schema:
       format: uuid
       type: string
+  - $ref: '../../../components/parameters/Include.yaml'
+  - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
+  - $ref: '../../../components/parameters/PerPage.yaml'
   responses:
     "200":
       content:

--- a/spec/oas3.stitched/oas3.stitched.metal.yaml
+++ b/spec/oas3.stitched/oas3.stitched.metal.yaml
@@ -8005,6 +8005,48 @@ paths:
         schema:
           format: uuid
           type: string
+      - description: |-
+          Nested attributes to include. Included objects will return their full
+          attributes. Attribute names can be dotted (up to 3 levels) to included deeply
+          nested objects.
+        explode: false
+        in: query
+        name: include
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: |-
+          Nested attributes to exclude. Excluded objects will return only the href
+          attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply
+          nested objects.
+        explode: false
+        in: query
+        name: exclude
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: Page to return
+        in: query
+        name: page
+        schema:
+          default: 1
+          format: int32
+          maximum: 100000
+          minimum: 1
+          type: integer
+      - description: Items returned per page
+        in: query
+        name: per_page
+        schema:
+          default: 10
+          format: int32
+          maximum: 1000
+          minimum: 1
+          type: integer
       responses:
         "200":
           content:


### PR DESCRIPTION
This updates the spec to define include, exclude, and pagination paremeters for the projectListInterconnection endpoints so that the generated SDK will allow those parameters to be passed in.