### PR TITLE
feat: Add delete_failed enum to InterconnectionPort

### DIFF
--- a/equinix-openapi-metal/api/openapi.yaml
+++ b/equinix-openapi-metal/api/openapi.yaml
@@ -18159,6 +18159,7 @@ components:
           - active
           - deleting
           - expired
+          - delete_failed
           type: string
         switch_id:
           description: A switch 'short ID'

--- a/equinix-openapi-metal/docs/InterconnectionPort.md
+++ b/equinix-openapi-metal/docs/InterconnectionPort.md
@@ -37,6 +37,7 @@
 | ACTIVE | &quot;active&quot; |
 | DELETING | &quot;deleting&quot; |
 | EXPIRED | &quot;expired&quot; |
+| DELETE_FAILED | &quot;delete_failed&quot; |
 
 
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPort.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPort.java
@@ -123,7 +123,9 @@ public class InterconnectionPort {
     
     DELETING("deleting"),
     
-    EXPIRED("expired");
+    EXPIRED("expired"),
+    
+    DELETE_FAILED("delete_failed");
 
     private String value;
 

--- a/patches/spec.fetched.json/11-add-delete-failed-enum-to-interconnectionport.patch
+++ b/patches/spec.fetched.json/11-add-delete-failed-enum-to-interconnectionport.patch
@@ -1,0 +1,12 @@
+diff --git a/spec/oas3.patched/openapi/public/components/schemas/InterconnectionPort.yaml b/spec/oas3.patched/openapi/public/components/schemas/InterconnectionPort.yaml
+index 090f95a..be1d7f5 100644
+--- a/spec/oas3.patched/openapi/public/components/schemas/InterconnectionPort.yaml
++++ b/spec/oas3.patched/openapi/public/components/schemas/InterconnectionPort.yaml
+@@ -20,6 +20,7 @@ properties:
+     - active
+     - deleting
+     - expired
++    - delete_failed
+   switch_id:
+     description: A switch 'short ID'
+     type: string

--- a/spec/oas3.patched/openapi/public/components/schemas/InterconnectionPort.yaml
+++ b/spec/oas3.patched/openapi/public/components/schemas/InterconnectionPort.yaml
@@ -20,6 +20,7 @@ properties:
     - active
     - deleting
     - expired
+    - delete_failed
   switch_id:
     description: A switch 'short ID'
     type: string


### PR DESCRIPTION
Add delete_failed enum to InterconnectionPort.yaml to support upstream API change detected in #110 