### PR TITLE
fix: add make clean to sync action

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,6 +20,9 @@ jobs:
         # https://api.github.com/users/github-actions[bot]
         git config user.name 'github-actions[bot]'
         git config user.email 'bot@equinix.noreply.github.com'
+    - name: Clean
+      id: clean
+      run: make clean
     - name: Fetch latest spec
       id: fetch
       run: |


### PR DESCRIPTION
Add a 'make clean' run to the Sync action. Otherwise pre-existing .java files exist and cause problems.