### PR TITLE
chore: Add patch 6 back to remove IP address examples

### DIFF
--- a/equinix-openapi-metal/api/openapi.yaml
+++ b/equinix-openapi-metal/api/openapi.yaml
@@ -15177,13 +15177,6 @@ components:
             may be used on multiple devices within a project.
           type: string
         ip_addresses:
-          default:
-          - address_family: 4
-            public: true
-          - address_family: 4
-            public: false
-          - address_family: 6
-            public: true
           description: |-
             The `ip_addresses attribute will allow you to specify the addresses you want created with your device.
 

--- a/patches/spec.fetched.json/06-openapi-gen-latest-creates-invalid-code-with-default-values.patch
+++ b/patches/spec.fetched.json/06-openapi-gen-latest-creates-invalid-code-with-default-values.patch
@@ -1,0 +1,18 @@
+diff --git a/spec/oas3.patched/openapi/public/components/schemas/DeviceCreateInput.yaml b/spec/oas3.patched/openapi/public/components/schemas/DeviceCreateInput.yaml
+index 21ad54d..8e160ee 100644
+--- a/spec/oas3.patched/openapi/public/components/schemas/DeviceCreateInput.yaml
++++ b/spec/oas3.patched/openapi/public/components/schemas/DeviceCreateInput.yaml
+@@ -59,13 +59,6 @@ properties:
+       may be used on multiple devices within a project.
+     type: string
+   ip_addresses:
+-    default:
+-    - address_family: 4
+-      public: true
+-    - address_family: 4
+-      public: false
+-    - address_family: 6
+-      public: true
+     description: |-
+       The `ip_addresses attribute will allow you to specify the addresses you want created with your device.
+ 

--- a/spec/oas3.patched/openapi/public/components/schemas/DeviceCreateInput.yaml
+++ b/spec/oas3.patched/openapi/public/components/schemas/DeviceCreateInput.yaml
@@ -59,13 +59,6 @@ properties:
       may be used on multiple devices within a project.
     type: string
   ip_addresses:
-    default:
-    - address_family: 4
-      public: true
-    - address_family: 4
-      public: false
-    - address_family: 6
-      public: true
     description: |-
       The `ip_addresses attribute will allow you to specify the addresses you want created with your device.
 

--- a/spec/oas3.stitched/oas3.stitched.metal.yaml
+++ b/spec/oas3.stitched/oas3.stitched.metal.yaml
@@ -12368,13 +12368,6 @@ components:
             may be used on multiple devices within a project.
           type: string
         ip_addresses:
-          default:
-          - address_family: 4
-            public: true
-          - address_family: 4
-            public: false
-          - address_family: 6
-            public: true
           description: |-
             The `ip_addresses attribute will allow you to specify the addresses you want created with your device.
 


### PR DESCRIPTION
It turns out we did need this patch after all in order to move to a later version of the openapi generator. 