### PR TITLE
chore: bump yq version to 4.35.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SPEC_ROOT_FILE:=openapi3.yaml
 PATCHED_SPEC_ENTRY_POINT=spec/oas3.patched/openapi/public/${SPEC_ROOT_FILE}
 PATCHED_SPEC_OUTPUT_DIR=spec/oas3.stitched/
 
-SPEC_FETCHER=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
+SPEC_FETCHER=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.35.1 script/download_spec.sh
 
 SPEC_DIR_FETCHED_FILE=spec/oas3.fetched/
 SPEC_DIR_PATCHED_FILE=spec/oas3.patched/


### PR DESCRIPTION
Bump yq to the latest released version just as a maintenance task.