### PR TITLE
chore: bring release job in line with old maven-publish job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
             conventional-changelog-conventionalcommits@4.6.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SETTINGS_PATH: ${{ github.workspace }}/settings.xml
           GIT_AUTHOR_NAME: equinix-labs@auto-commit-workflow
           GIT_AUTHOR_EMAIL: bot@equinix.noreply.github.com
           GIT_COMMITTER_NAME: equinix-labs@auto-commit-workflow

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -28,14 +28,14 @@
         "@semantic-release/exec",
         {
           "prepareCmd": "echo -n '${nextRelease.version}' > version && make generate",
-          "publishCmd": "mvn -f equinix-openapi-metal -B package && mvn -f equinix-openapi-metal deploy -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/equinix-labs/metal-java"
+          "publishCmd": "export GITHUB_TOKEN='${process.env.GITHUB_TOKEN}'; cd equinix-openapi-metal && mvn -B package --file pom.xml && mvn deploy -s ${process.env.SETTINGS_PATH} -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/ctreatma/metal-java"
         }
       ],
       [
         "@semantic-release/git",
         {
           "message": "ci: regenerate code for version ${nextRelease.version}",
-          "assets": ["."]
+          "assets": ["version", "equinix-openapi-metal/src"]
         }
       ]
     ]


### PR DESCRIPTION
When the `mvn` commands for building and publishing were moved from the maven-publish workflow to the release workflow, they were changed, which causes the release workflow to fail to publish the metal-java JARs to GitHub Maven.

This updates the release job to use the `mvn` commands that were in the maven-publish job so that we can successfully release this SDK.