### PR TITLE
chore(ci): add more paths to assets for semantic-release/git plugin

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -35,7 +35,14 @@
         "@semantic-release/git",
         {
           "message": "ci: regenerate code for version ${nextRelease.version}",
-          "assets": ["version", "equinix-openapi-metal/src"]
+          "assets": [
+            "version",
+            "equinix-openapi-metal/src",
+            "equinix-openapi-metal/README.md",
+            "equinix-openapi-metal/build.gradle",
+            "equinix-openapi-metal/build.sbt",
+            "equinix-openapi-metal/pom.xml"
+          ]
         }
       ]
     ]

--- a/equinix-openapi-metal/README.md
+++ b/equinix-openapi-metal/README.md
@@ -120,7 +120,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.equinix</groupId>
   <artifactId>equinix-openapi-metal</artifactId>
-  <version>0.7.0</version>
+  <version>0.8.0</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -136,7 +136,7 @@ Add this dependency to your project's build file:
   }
 
   dependencies {
-     implementation "com.equinix:equinix-openapi-metal:0.7.0"
+     implementation "com.equinix:equinix-openapi-metal:0.8.0"
   }
 ```
 
@@ -150,7 +150,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/equinix-openapi-metal-0.7.0.jar`
+* `target/equinix-openapi-metal-0.8.0.jar`
 * `target/lib/*.jar`
 
 ## Getting Started

--- a/equinix-openapi-metal/build.gradle
+++ b/equinix-openapi-metal/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'java'
 apply plugin: 'com.diffplug.spotless'
 
 group = 'com.equinix'
-version = '0.7.0'
+version = '0.8.0'
 
 buildscript {
     repositories {

--- a/equinix-openapi-metal/build.sbt
+++ b/equinix-openapi-metal/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.equinix",
     name := "equinix-openapi-metal",
-    version := "0.7.0",
+    version := "0.8.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/equinix-openapi-metal/pom.xml
+++ b/equinix-openapi-metal/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>equinix-openapi-metal</artifactId>
     <packaging>jar</packaging>
     <name>equinix-openapi-metal</name>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <url>https://github.com/openapitools/openapi-generator</url>
     <description>OpenAPI Java</description>
     <scm>


### PR DESCRIPTION
I haven't had any luck figuring out how to get negative-matching globs to work for semantic-release/git.  For now I'm punting and adding entries to the assets config to cover the files that were missed in the most recent release job run.