### PR TITLE
fix:  validate enum values in nested models

### DIFF
--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenProject.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/AuthTokenProject.java
@@ -167,6 +167,11 @@ public class AuthTokenProject {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -879,6 +884,10 @@ public class AuthTokenProject {
       }
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BGPSessionInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BGPSessionInput.java
@@ -97,6 +97,11 @@ public class BGPSessionInput {
         return AddressFamilyEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      AddressFamilyEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_ADDRESS_FAMILY = "address_family";
@@ -267,6 +272,10 @@ public class BGPSessionInput {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("address_family") != null && !jsonObj.get("address_family").isJsonNull()) && !jsonObj.get("address_family").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address_family` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address_family").toString()));
+      }
+      // validate the optional field `address_family`
+      if (jsonObj.get("address_family") != null && !jsonObj.get("address_family").isJsonNull()) {
+        AddressFamilyEnum.validateJsonElement(jsonObj.get("address_family"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfig.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfig.java
@@ -113,6 +113,11 @@ public class BgpConfig {
         return DeploymentTypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      DeploymentTypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_DEPLOYMENT_TYPE = "deployment_type";
@@ -201,6 +206,11 @@ public class BgpConfig {
         String value =  jsonReader.nextString();
         return StatusEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StatusEnum.fromValue(value);
     }
   }
 
@@ -660,6 +670,10 @@ public class BgpConfig {
       if ((jsonObj.get("deployment_type") != null && !jsonObj.get("deployment_type").isJsonNull()) && !jsonObj.get("deployment_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `deployment_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("deployment_type").toString()));
       }
+      // validate the optional field `deployment_type`
+      if (jsonObj.get("deployment_type") != null && !jsonObj.get("deployment_type").isJsonNull()) {
+        DeploymentTypeEnum.validateJsonElement(jsonObj.get("deployment_type"));
+      }
       if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));
       }
@@ -706,6 +720,10 @@ public class BgpConfig {
       }
       if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
+      }
+      // validate the optional field `status`
+      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {
+        StatusEnum.validateJsonElement(jsonObj.get("status"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfigRequestInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpConfigRequestInput.java
@@ -101,6 +101,11 @@ public class BgpConfigRequestInput {
         return DeploymentTypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      DeploymentTypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_DEPLOYMENT_TYPE = "deployment_type";
@@ -335,6 +340,8 @@ public class BgpConfigRequestInput {
       if (!jsonObj.get("deployment_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `deployment_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("deployment_type").toString()));
       }
+      // validate the required field `deployment_type`
+      DeploymentTypeEnum.validateJsonElement(jsonObj.get("deployment_type"));
       if ((jsonObj.get("md5") != null && !jsonObj.get("md5").isJsonNull()) && !jsonObj.get("md5").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `md5` to be a primitive type in the JSON string but got `%s`", jsonObj.get("md5").toString()));
       }

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpDynamicNeighbor.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpDynamicNeighbor.java
@@ -123,6 +123,11 @@ public class BgpDynamicNeighbor {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -490,6 +495,10 @@ public class BgpDynamicNeighbor {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       if ((jsonObj.get("href") != null && !jsonObj.get("href").isJsonNull()) && !jsonObj.get("href").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `href` to be a primitive type in the JSON string but got `%s`", jsonObj.get("href").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSession.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/BgpSession.java
@@ -102,6 +102,11 @@ public class BgpSession {
         return AddressFamilyEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      AddressFamilyEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_ADDRESS_FAMILY = "address_family";
@@ -178,6 +183,11 @@ public class BgpSession {
         String value =  jsonReader.nextString();
         return StatusEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StatusEnum.fromValue(value);
     }
   }
 
@@ -534,6 +544,8 @@ public class BgpSession {
       if (!jsonObj.get("address_family").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `address_family` to be a primitive type in the JSON string but got `%s`", jsonObj.get("address_family").toString()));
       }
+      // validate the required field `address_family`
+      AddressFamilyEnum.validateJsonElement(jsonObj.get("address_family"));
       // validate the optional field `device`
       if (jsonObj.get("device") != null && !jsonObj.get("device").isJsonNull()) {
         Href.validateJsonElement(jsonObj.get("device"));
@@ -550,6 +562,10 @@ public class BgpSession {
       }
       if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
+      }
+      // validate the optional field `status`
+      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {
+        StatusEnum.validateJsonElement(jsonObj.get("status"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateSelfServiceReservationRequestPeriod.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/CreateSelfServiceReservationRequestPeriod.java
@@ -97,6 +97,11 @@ public class CreateSelfServiceReservationRequestPeriod {
         return CountEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      Integer value = jsonElement.getAsInt();
+      CountEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_COUNT = "count";
@@ -145,6 +150,11 @@ public class CreateSelfServiceReservationRequestPeriod {
         String value =  jsonReader.nextString();
         return UnitEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      UnitEnum.fromValue(value);
     }
   }
 
@@ -310,8 +320,16 @@ public class CreateSelfServiceReservationRequestPeriod {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
+      // validate the optional field `count`
+      if (jsonObj.get("count") != null && !jsonObj.get("count").isJsonNull()) {
+        CountEnum.validateJsonElement(jsonObj.get("count"));
+      }
       if ((jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonNull()) && !jsonObj.get("unit").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `unit` to be a primitive type in the JSON string but got `%s`", jsonObj.get("unit").toString()));
+      }
+      // validate the optional field `unit`
+      if (jsonObj.get("unit") != null && !jsonObj.get("unit").isJsonNull()) {
+        UnitEnum.validateJsonElement(jsonObj.get("unit"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DedicatedPortCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DedicatedPortCreateInput.java
@@ -115,6 +115,11 @@ public class DedicatedPortCreateInput {
         return ModeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      ModeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_MODE = "mode";
@@ -183,6 +188,11 @@ public class DedicatedPortCreateInput {
         String value =  jsonReader.nextString();
         return TypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
     }
   }
 
@@ -626,6 +636,10 @@ public class DedicatedPortCreateInput {
       if ((jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) && !jsonObj.get("mode").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `mode` to be a primitive type in the JSON string but got `%s`", jsonObj.get("mode").toString()));
       }
+      // validate the optional field `mode`
+      if (jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) {
+        ModeEnum.validateJsonElement(jsonObj.get("mode"));
+      }
       if (!jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
@@ -642,6 +656,8 @@ public class DedicatedPortCreateInput {
       if (!jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the required field `type`
+      TypeEnum.validateJsonElement(jsonObj.get("type"));
       if ((jsonObj.get("use_case") != null && !jsonObj.get("use_case").isJsonNull()) && !jsonObj.get("use_case").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `use_case` to be a primitive type in the JSON string but got `%s`", jsonObj.get("use_case").toString()));
       }

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Device.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Device.java
@@ -265,6 +265,11 @@ public class Device {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -1650,6 +1655,10 @@ public class Device {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       // validate the optional field `storage`
       if (jsonObj.get("storage") != null && !jsonObj.get("storage").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceActionInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceActionInput.java
@@ -103,6 +103,11 @@ public class DeviceActionInput {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -394,6 +399,8 @@ public class DeviceActionInput {
       if (!jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the required field `type`
+      TypeEnum.validateJsonElement(jsonObj.get("type"));
       if ((jsonObj.get("operating_system") != null && !jsonObj.get("operating_system").isJsonNull()) && !jsonObj.get("operating_system").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `operating_system` to be a primitive type in the JSON string but got `%s`", jsonObj.get("operating_system").toString()));
       }

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInFacilityInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInFacilityInput.java
@@ -119,6 +119,11 @@ public class DeviceCreateInFacilityInput {
         return BillingCycleEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      BillingCycleEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_BILLING_CYCLE = "billing_cycle";
@@ -1037,6 +1042,10 @@ public class DeviceCreateInFacilityInput {
       }
       if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
+      }
+      // validate the optional field `billing_cycle`
+      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) {
+        BillingCycleEnum.validateJsonElement(jsonObj.get("billing_cycle"));
       }
       if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInMetroInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInMetroInput.java
@@ -118,6 +118,11 @@ public class DeviceCreateInMetroInput {
         return BillingCycleEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      BillingCycleEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_BILLING_CYCLE = "billing_cycle";
@@ -1021,6 +1026,10 @@ public class DeviceCreateInMetroInput {
       }
       if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
+      }
+      // validate the optional field `billing_cycle`
+      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) {
+        BillingCycleEnum.validateJsonElement(jsonObj.get("billing_cycle"));
       }
       if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceCreateInput.java
@@ -114,6 +114,11 @@ public class DeviceCreateInput {
         return BillingCycleEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      BillingCycleEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_BILLING_CYCLE = "billing_cycle";
@@ -989,6 +994,10 @@ public class DeviceCreateInput {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
+      }
+      // validate the optional field `billing_cycle`
+      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) {
+        BillingCycleEnum.validateJsonElement(jsonObj.get("billing_cycle"));
       }
       if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceHealthRollup.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/DeviceHealthRollup.java
@@ -100,6 +100,11 @@ public class DeviceHealthRollup {
         return HealthRollupEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      HealthRollupEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_HEALTH_ROLLUP = "health_rollup";
@@ -262,6 +267,10 @@ public class DeviceHealthRollup {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("health_rollup") != null && !jsonObj.get("health_rollup").isJsonNull()) && !jsonObj.get("health_rollup").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `health_rollup` to be a primitive type in the JSON string but got `%s`", jsonObj.get("health_rollup").toString()));
+      }
+      // validate the optional field `health_rollup`
+      if (jsonObj.get("health_rollup") != null && !jsonObj.get("health_rollup").isJsonNull()) {
+        HealthRollupEnum.validateJsonElement(jsonObj.get("health_rollup"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/FabricServiceToken.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/FabricServiceToken.java
@@ -111,6 +111,11 @@ public class FabricServiceToken {
         return RoleEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      RoleEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_ROLE = "role";
@@ -161,6 +166,11 @@ public class FabricServiceToken {
         String value =  jsonReader.nextString();
         return ServiceTokenTypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      ServiceTokenTypeEnum.fromValue(value);
     }
   }
 
@@ -214,6 +224,11 @@ public class FabricServiceToken {
         String value =  jsonReader.nextString();
         return StateEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
     }
   }
 
@@ -481,11 +496,23 @@ public class FabricServiceToken {
       if ((jsonObj.get("role") != null && !jsonObj.get("role").isJsonNull()) && !jsonObj.get("role").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `role` to be a primitive type in the JSON string but got `%s`", jsonObj.get("role").toString()));
       }
+      // validate the optional field `role`
+      if (jsonObj.get("role") != null && !jsonObj.get("role").isJsonNull()) {
+        RoleEnum.validateJsonElement(jsonObj.get("role"));
+      }
       if ((jsonObj.get("service_token_type") != null && !jsonObj.get("service_token_type").isJsonNull()) && !jsonObj.get("service_token_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `service_token_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("service_token_type").toString()));
       }
+      // validate the optional field `service_token_type`
+      if (jsonObj.get("service_token_type") != null && !jsonObj.get("service_token_type").isJsonNull()) {
+        ServiceTokenTypeEnum.validateJsonElement(jsonObj.get("service_token_type"));
+      }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Facility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Facility.java
@@ -116,6 +116,11 @@ public class Facility {
         return FeaturesEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      FeaturesEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_FEATURES = "features";

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAddress.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAddress.java
@@ -99,6 +99,11 @@ public class IPAddress {
         return AddressFamilyEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      Integer value = jsonElement.getAsInt();
+      AddressFamilyEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_ADDRESS_FAMILY = "address_family";
@@ -331,6 +336,10 @@ public class IPAddress {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
+      // validate the optional field `address_family`
+      if (jsonObj.get("address_family") != null && !jsonObj.get("address_family").isJsonNull()) {
+        AddressFamilyEnum.validateJsonElement(jsonObj.get("address_family"));
+      }
       // ensure the optional json data is an array if present
       if (jsonObj.get("ip_reservations") != null && !jsonObj.get("ip_reservations").isJsonNull() && !jsonObj.get("ip_reservations").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `ip_reservations` to be an array in the JSON string but got `%s`", jsonObj.get("ip_reservations").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignment.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPAssignment.java
@@ -172,6 +172,11 @@ public class IPAssignment {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -780,6 +785,10 @@ public class IPAssignment {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       if ((jsonObj.get("next_hop") != null && !jsonObj.get("next_hop").isJsonNull()) && !jsonObj.get("next_hop").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `next_hop` to be a primitive type in the JSON string but got `%s`", jsonObj.get("next_hop").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservation.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservation.java
@@ -223,6 +223,11 @@ public class IPReservation {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -1093,6 +1098,8 @@ public class IPReservation {
       if (!jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the required field `type`
+      TypeEnum.validateJsonElement(jsonObj.get("type"));
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationFacility.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/IPReservationFacility.java
@@ -116,6 +116,11 @@ public class IPReservationFacility {
         return FeaturesEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      FeaturesEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_FEATURES = "features";

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInputBatchesInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InstancesBatchCreateInputBatchesInner.java
@@ -126,6 +126,11 @@ public class InstancesBatchCreateInputBatchesInner {
         return BillingCycleEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      BillingCycleEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_BILLING_CYCLE = "billing_cycle";
@@ -1131,6 +1136,10 @@ public class InstancesBatchCreateInputBatchesInner {
       }
       if ((jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) && !jsonObj.get("billing_cycle").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `billing_cycle` to be a primitive type in the JSON string but got `%s`", jsonObj.get("billing_cycle").toString()));
+      }
+      // validate the optional field `billing_cycle`
+      if (jsonObj.get("billing_cycle") != null && !jsonObj.get("billing_cycle").isJsonNull()) {
+        BillingCycleEnum.validateJsonElement(jsonObj.get("billing_cycle"));
       }
       if ((jsonObj.get("description") != null && !jsonObj.get("description").isJsonNull()) && !jsonObj.get("description").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `description` to be a primitive type in the JSON string but got `%s`", jsonObj.get("description").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Interconnection.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Interconnection.java
@@ -125,6 +125,11 @@ public class Interconnection {
         return ModeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      ModeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_MODE = "mode";
@@ -187,6 +192,11 @@ public class Interconnection {
         String value =  jsonReader.nextString();
         return RedundancyEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      RedundancyEnum.fromValue(value);
     }
   }
 
@@ -258,6 +268,11 @@ public class Interconnection {
         String value =  jsonReader.nextString();
         return TypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
     }
   }
 
@@ -887,6 +902,10 @@ public class Interconnection {
       if ((jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) && !jsonObj.get("mode").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `mode` to be a primitive type in the JSON string but got `%s`", jsonObj.get("mode").toString()));
       }
+      // validate the optional field `mode`
+      if (jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) {
+        ModeEnum.validateJsonElement(jsonObj.get("mode"));
+      }
       if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
@@ -910,6 +929,10 @@ public class Interconnection {
       }
       if ((jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonNull()) && !jsonObj.get("redundancy").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `redundancy` to be a primitive type in the JSON string but got `%s`", jsonObj.get("redundancy").toString()));
+      }
+      // validate the optional field `redundancy`
+      if (jsonObj.get("redundancy") != null && !jsonObj.get("redundancy").isJsonNull()) {
+        RedundancyEnum.validateJsonElement(jsonObj.get("redundancy"));
       }
       if (jsonObj.get("service_tokens") != null && !jsonObj.get("service_tokens").isJsonNull()) {
         JsonArray jsonArrayserviceTokens = jsonObj.getAsJsonArray("service_tokens");
@@ -937,6 +960,10 @@ public class Interconnection {
       }
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
       // validate the optional field `requested_by`
       if (jsonObj.get("requested_by") != null && !jsonObj.get("requested_by").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPort.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionPort.java
@@ -110,6 +110,11 @@ public class InterconnectionPort {
         return RoleEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      RoleEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_ROLE = "role";
@@ -166,6 +171,11 @@ public class InterconnectionPort {
         String value =  jsonReader.nextString();
         return StatusEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StatusEnum.fromValue(value);
     }
   }
 
@@ -565,8 +575,16 @@ public class InterconnectionPort {
       if ((jsonObj.get("role") != null && !jsonObj.get("role").isJsonNull()) && !jsonObj.get("role").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `role` to be a primitive type in the JSON string but got `%s`", jsonObj.get("role").toString()));
       }
+      // validate the optional field `role`
+      if (jsonObj.get("role") != null && !jsonObj.get("role").isJsonNull()) {
+        RoleEnum.validateJsonElement(jsonObj.get("role"));
+      }
       if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
+      }
+      // validate the optional field `status`
+      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {
+        StatusEnum.validateJsonElement(jsonObj.get("status"));
       }
       if ((jsonObj.get("switch_id") != null && !jsonObj.get("switch_id").isJsonNull()) && !jsonObj.get("switch_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `switch_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("switch_id").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionUpdateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InterconnectionUpdateInput.java
@@ -107,6 +107,11 @@ public class InterconnectionUpdateInput {
         return ModeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      ModeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_MODE = "mode";
@@ -395,6 +400,10 @@ public class InterconnectionUpdateInput {
       }
       if ((jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) && !jsonObj.get("mode").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `mode` to be a primitive type in the JSON string but got `%s`", jsonObj.get("mode").toString()));
+      }
+      // validate the optional field `mode`
+      if (jsonObj.get("mode") != null && !jsonObj.get("mode").isJsonNull()) {
+        ModeEnum.validateJsonElement(jsonObj.get("mode"));
       }
       if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Invitation.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Invitation.java
@@ -142,6 +142,11 @@ public class Invitation {
         return RolesEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      RolesEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_ROLES = "roles";

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InvitationInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/InvitationInput.java
@@ -120,6 +120,11 @@ public class InvitationInput {
         return RolesEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      RolesEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_ROLES = "roles";

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Metadata.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Metadata.java
@@ -179,6 +179,11 @@ public class Metadata {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -813,6 +818,10 @@ public class Metadata {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGateway.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGateway.java
@@ -129,6 +129,11 @@ public class MetalGateway {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -451,6 +456,10 @@ public class MetalGateway {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       // validate the optional field `virtual_network`
       if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayLite.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/MetalGatewayLite.java
@@ -117,6 +117,11 @@ public class MetalGatewayLite {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -420,6 +425,10 @@ public class MetalGatewayLite {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Plan.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Plan.java
@@ -125,6 +125,11 @@ public class Plan {
         return DeploymentTypesEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      DeploymentTypesEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_DEPLOYMENT_TYPES = "deployment_types";
@@ -205,6 +210,11 @@ public class Plan {
         String value =  jsonReader.nextString();
         return TypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
     }
   }
 
@@ -750,6 +760,10 @@ public class Plan {
       }
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PlanSpecsDrivesInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PlanSpecsDrivesInner.java
@@ -103,6 +103,11 @@ public class PlanSpecsDrivesInner {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -159,6 +164,11 @@ public class PlanSpecsDrivesInner {
         String value =  jsonReader.nextString();
         return CategoryEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      CategoryEnum.fromValue(value);
     }
   }
 
@@ -375,11 +385,19 @@ public class PlanSpecsDrivesInner {
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
+      }
       if ((jsonObj.get("size") != null && !jsonObj.get("size").isJsonNull()) && !jsonObj.get("size").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `size` to be a primitive type in the JSON string but got `%s`", jsonObj.get("size").toString()));
       }
       if ((jsonObj.get("category") != null && !jsonObj.get("category").isJsonNull()) && !jsonObj.get("category").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `category` to be a primitive type in the JSON string but got `%s`", jsonObj.get("category").toString()));
+      }
+      // validate the optional field `category`
+      if (jsonObj.get("category") != null && !jsonObj.get("category").isJsonNull()) {
+        CategoryEnum.validateJsonElement(jsonObj.get("category"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PlanSpecsNicsInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PlanSpecsNicsInner.java
@@ -103,6 +103,11 @@ public class PlanSpecsNicsInner {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -269,6 +274,10 @@ public class PlanSpecsNicsInner {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Port.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Port.java
@@ -128,6 +128,11 @@ public class Port {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -184,6 +189,11 @@ public class Port {
         String value =  jsonReader.nextString();
         return NetworkTypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      NetworkTypeEnum.fromValue(value);
     }
   }
 
@@ -577,8 +587,16 @@ public class Port {
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
+      }
       if ((jsonObj.get("network_type") != null && !jsonObj.get("network_type").isJsonNull()) && !jsonObj.get("network_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `network_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("network_type").toString()));
+      }
+      // validate the optional field `network_type`
+      if (jsonObj.get("network_type") != null && !jsonObj.get("network_type").isJsonNull()) {
+        NetworkTypeEnum.validateJsonElement(jsonObj.get("network_type"));
       }
       // validate the optional field `native_virtual_network`
       if (jsonObj.get("native_virtual_network") != null && !jsonObj.get("native_virtual_network").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignment.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignment.java
@@ -116,6 +116,11 @@ public class PortVlanAssignment {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -445,6 +450,10 @@ public class PortVlanAssignment {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       // validate the optional field `virtual_network`
       if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatch.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatch.java
@@ -128,6 +128,11 @@ public class PortVlanAssignmentBatch {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -501,6 +506,10 @@ public class PortVlanAssignmentBatch {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       if (jsonObj.get("vlan_assignments") != null && !jsonObj.get("vlan_assignments").isJsonNull()) {
         JsonArray jsonArrayvlanAssignments = jsonObj.getAsJsonArray("vlan_assignments");

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchCreateInputVlanAssignmentsInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchCreateInputVlanAssignmentsInner.java
@@ -101,6 +101,11 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -295,6 +300,10 @@ public class PortVlanAssignmentBatchCreateInputVlanAssignmentsInner {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       if ((jsonObj.get("vlan") != null && !jsonObj.get("vlan").isJsonNull()) && !jsonObj.get("vlan").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `vlan` to be a primitive type in the JSON string but got `%s`", jsonObj.get("vlan").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchVlanAssignmentsInner.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/PortVlanAssignmentBatchVlanAssignmentsInner.java
@@ -106,6 +106,11 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -327,6 +332,10 @@ public class PortVlanAssignmentBatchVlanAssignmentsInner {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
   }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Project.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/Project.java
@@ -167,6 +167,11 @@ public class Project {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -879,6 +884,10 @@ public class Project {
       }
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateFromRootInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateFromRootInput.java
@@ -116,6 +116,11 @@ public class ProjectCreateFromRootInput {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -407,6 +412,10 @@ public class ProjectCreateFromRootInput {
       }
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/ProjectCreateInput.java
@@ -112,6 +112,11 @@ public class ProjectCreateInput {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -376,6 +381,10 @@ public class ProjectCreateInput {
       }
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SupportRequestInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/SupportRequestInput.java
@@ -109,6 +109,11 @@ public class SupportRequestInput {
         return PriorityEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      PriorityEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_PRIORITY = "priority";
@@ -370,6 +375,10 @@ public class SupportRequestInput {
       }
       if ((jsonObj.get("priority") != null && !jsonObj.get("priority").isJsonNull()) && !jsonObj.get("priority").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `priority` to be a primitive type in the JSON string but got `%s`", jsonObj.get("priority").toString()));
+      }
+      // validate the optional field `priority`
+      if (jsonObj.get("priority") != null && !jsonObj.get("priority").isJsonNull()) {
+        PriorityEnum.validateJsonElement(jsonObj.get("priority"));
       }
       if ((jsonObj.get("project_id") != null && !jsonObj.get("project_id").isJsonNull()) && !jsonObj.get("project_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `project_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("project_id").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VlanFabricVcCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VlanFabricVcCreateInput.java
@@ -123,6 +123,11 @@ public class VlanFabricVcCreateInput {
         return ServiceTokenTypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      ServiceTokenTypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_SERVICE_TOKEN_TYPE = "service_token_type";
@@ -179,6 +184,11 @@ public class VlanFabricVcCreateInput {
         String value =  jsonReader.nextString();
         return TypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
     }
   }
 
@@ -613,6 +623,8 @@ public class VlanFabricVcCreateInput {
       if (!jsonObj.get("service_token_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `service_token_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("service_token_type").toString()));
       }
+      // validate the required field `service_token_type`
+      ServiceTokenTypeEnum.validateJsonElement(jsonObj.get("service_token_type"));
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
@@ -620,6 +632,8 @@ public class VlanFabricVcCreateInput {
       if (!jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the required field `type`
+      TypeEnum.validateJsonElement(jsonObj.get("type"));
       // ensure the optional json data is an array if present
       if (jsonObj.get("vlans") != null && !jsonObj.get("vlans").isJsonNull() && !jsonObj.get("vlans").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `vlans` to be an array in the JSON string but got `%s`", jsonObj.get("vlans").toString()));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VlanVirtualCircuit.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VlanVirtualCircuit.java
@@ -155,6 +155,11 @@ public class VlanVirtualCircuit {
         return StatusEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StatusEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATUS = "status";
@@ -683,9 +688,17 @@ public class VlanVirtualCircuit {
       if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
+      // validate the optional field `status`
+      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {
+        StatusEnum.validateJsonElement(jsonObj.get("status"));
+      }
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        VlanVirtualCircuitType.validateJsonElement(jsonObj.get("type"));
       }
       // validate the optional field `virtual_network`
       if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VlanVirtualCircuitType.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VlanVirtualCircuitType.java
@@ -18,6 +18,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;
 import com.google.gson.TypeAdapter;
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -65,6 +66,11 @@ public enum VlanVirtualCircuitType {
       String value = jsonReader.nextString();
       return VlanVirtualCircuitType.fromValue(value);
     }
+  }
+
+  public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+    String value = jsonElement.getAsString();
+    VlanVirtualCircuitType.fromValue(value);
   }
 }
 

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfFabricVcCreateInput.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfFabricVcCreateInput.java
@@ -124,6 +124,11 @@ public class VrfFabricVcCreateInput {
         return ServiceTokenTypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      ServiceTokenTypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_SERVICE_TOKEN_TYPE = "service_token_type";
@@ -180,6 +185,11 @@ public class VrfFabricVcCreateInput {
         String value =  jsonReader.nextString();
         return TypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
     }
   }
 
@@ -615,6 +625,8 @@ public class VrfFabricVcCreateInput {
       if (!jsonObj.get("service_token_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `service_token_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("service_token_type").toString()));
       }
+      // validate the required field `service_token_type`
+      ServiceTokenTypeEnum.validateJsonElement(jsonObj.get("service_token_type"));
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
@@ -622,6 +634,8 @@ public class VrfFabricVcCreateInput {
       if (!jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the required field `type`
+      TypeEnum.validateJsonElement(jsonObj.get("type"));
       // ensure the required json array is present
       if (jsonObj.get("vrfs") == null) {
         throw new IllegalArgumentException("Expected the field `linkedContent` to be an array in the JSON string but got `null`");

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservation.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfIpReservation.java
@@ -156,6 +156,11 @@ public class VrfIpReservation {
         return TypeEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_TYPE = "type";
@@ -942,6 +947,8 @@ public class VrfIpReservation {
       if (!jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
       }
+      // validate the required field `type`
+      TypeEnum.validateJsonElement(jsonObj.get("type"));
       // validate the required field `vrf`
       Vrf.validateJsonElement(jsonObj.get("vrf"));
       // validate the optional field `project_lite`

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfMetalGateway.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfMetalGateway.java
@@ -130,6 +130,11 @@ public class VrfMetalGateway {
         return StateEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StateEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATE = "state";
@@ -526,6 +531,10 @@ public class VrfMetalGateway {
       }
       if ((jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) && !jsonObj.get("state").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `state` to be a primitive type in the JSON string but got `%s`", jsonObj.get("state").toString()));
+      }
+      // validate the optional field `state`
+      if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {
+        StateEnum.validateJsonElement(jsonObj.get("state"));
       }
       // validate the optional field `virtual_network`
       if (jsonObj.get("virtual_network") != null && !jsonObj.get("virtual_network").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfRoute.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfRoute.java
@@ -112,6 +112,11 @@ public class VrfRoute {
         return StatusEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StatusEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATUS = "status";
@@ -168,6 +173,11 @@ public class VrfRoute {
         String value =  jsonReader.nextString();
         return TypeEnum.fromValue(value);
       }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TypeEnum.fromValue(value);
     }
   }
 
@@ -579,6 +589,10 @@ public class VrfRoute {
       if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
+      // validate the optional field `status`
+      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {
+        StatusEnum.validateJsonElement(jsonObj.get("status"));
+      }
       if ((jsonObj.get("prefix") != null && !jsonObj.get("prefix").isJsonNull()) && !jsonObj.get("prefix").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `prefix` to be a primitive type in the JSON string but got `%s`", jsonObj.get("prefix").toString()));
       }
@@ -587,6 +601,10 @@ public class VrfRoute {
       }
       if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        TypeEnum.validateJsonElement(jsonObj.get("type"));
       }
       // validate the optional field `metal_gateway`
       if (jsonObj.get("metal_gateway") != null && !jsonObj.get("metal_gateway").isJsonNull()) {

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuit.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuit.java
@@ -168,6 +168,11 @@ public class VrfVirtualCircuit {
         return StatusEnum.fromValue(value);
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      StatusEnum.fromValue(value);
+    }
   }
 
   public static final String SERIALIZED_NAME_STATUS = "status";
@@ -785,12 +790,20 @@ public class VrfVirtualCircuit {
       if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
+      // validate the optional field `status`
+      if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {
+        StatusEnum.validateJsonElement(jsonObj.get("status"));
+      }
       if ((jsonObj.get("subnet") != null && !jsonObj.get("subnet").isJsonNull()) && !jsonObj.get("subnet").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `subnet` to be a primitive type in the JSON string but got `%s`", jsonObj.get("subnet").toString()));
       }
       // ensure the optional json data is an array if present
       if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
+      }
+      // validate the optional field `type`
+      if (jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) {
+        VrfVirtualCircuitType.validateJsonElement(jsonObj.get("type"));
       }
       // validate the required field `vrf`
       Vrf.validateJsonElement(jsonObj.get("vrf"));

--- a/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuitType.java
+++ b/equinix-openapi-metal/src/main/java/com/equinix/openapi/metal/v1/model/VrfVirtualCircuitType.java
@@ -18,6 +18,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;
 import com.google.gson.TypeAdapter;
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -65,6 +66,11 @@ public enum VrfVirtualCircuitType {
       String value = jsonReader.nextString();
       return VrfVirtualCircuitType.fromValue(value);
     }
+  }
+
+  public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+    String value = jsonElement.getAsString();
+    VrfVirtualCircuitType.fromValue(value);
   }
 }
 

--- a/examples/VirtualCircuit.java
+++ b/examples/VirtualCircuit.java
@@ -1,0 +1,63 @@
+import com.equinix.openapi.ApiClient;
+import com.equinix.openapi.ApiException;
+import com.equinix.openapi.Configuration;
+import com.equinix.openapi.JSON;
+import com.equinix.openapi.auth.ApiKeyAuth;
+import com.equinix.openapi.metal.v1.model.VirtualCircuit;
+import com.equinix.openapi.metal.v1.model.VrfVirtualCircuit;
+import com.equinix.openapi.metal.v1.model.VlanVirtualCircuit;
+import com.equinix.openapi.metal.v1.model.InterconnectionPort;
+
+import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
+
+import java.lang.reflect.Type;
+import com.google.gson.reflect.TypeToken;
+
+public class ValidateVirtualCircuit {
+   public static void main(String[] args) {
+      String vrfVcString = "{\"id\": \"22A111DD-5EE3-4188-9163-78284363CA73\",\"name\": \"SDDC-2-pop_vpc-VC-primary\",\"status\": \"active\",\"bill\": true,\"nni_vnid\": 264,\"nni_vlan\": 264,\"project\": {\"href\": \"/metal/v1/projects/11CCA184-DB21-4659-A029-B704CDC8D5BA\"},\"vrf\": {\"href\": \"/metal/v1/vrfs/E3DEC139-F2A7-401F-BA12-890F206EF3FD\"},\"type\": \"vrf\",\"vnid\": null}";
+      String vlanVcString = "{\"id\": \"22A111DD-5EE3-4188-9163-78284363CA73\",\"name\": \"SDDC-2-pop_vpc-VC-primary\",\"status\": \"active\",\"bill\": true,\"nni_vnid\": 264,\"nni_vlan\": 264,\"project\": {\"href\": \"/metal/v1/projects/11CCA184-DB21-4659-A029-B704CDC8D5BA\"},\"vrf\": {\"href\": \"/metal/v1/vrfs/E3DEC139-F2A7-401F-BA12-890F206EF3FD\"},\"type\": \"vlan\",\"vnid\": null}";
+      String connectionPortString = "{\"virtual_circuits\":[" + vrfVcString + "," + vlanVcString + "]}";
+      
+      JSON json = new JSON();
+      Type localVarReturnType = new TypeToken<InterconnectionPort>(){}.getType();
+      JSON.deserialize(connectionPortString, localVarReturnType);
+      System.out.println("no error from VirtualCircuit when deserializing ports");
+
+      // no error from oneOf
+      localVarReturnType = new TypeToken<VirtualCircuit>(){}.getType();
+      JSON.deserialize(vlanVcString, localVarReturnType);
+      JSON.deserialize(vrfVcString, localVarReturnType);
+      System.out.println("no error when deserializing VirtualCircuit oneOf directly");
+
+      try{
+        localVarReturnType = new TypeToken<VrfVirtualCircuit>(){}.getType();
+        JSON.deserialize(vlanVcString, localVarReturnType);
+      } catch (Exception e) {
+        System.out.println("validation error from vrf vc when type is vlan");
+         System.out.println(String.format("Exception message : %s", e.getMessage()));
+         e.printStackTrace();
+      }
+
+      try{
+        localVarReturnType = new TypeToken<VlanVirtualCircuit>(){}.getType();
+        JSON.deserialize(vrfVcString, localVarReturnType);
+      } catch (Exception e) {
+        System.out.println("validation error from vlan vc when type is vrf");
+         System.out.println(String.format("Exception message : %s", e.getMessage()));
+         e.printStackTrace();
+      }
+
+
+      try{
+        localVarReturnType = new TypeToken<VirtualCircuit>(){}.getType();
+        JSON.deserialize(vlanVcString, localVarReturnType);
+        JSON.deserialize(vrfVcString, localVarReturnType);
+      } catch (Exception e) {
+         System.out.println(String.format("Exception message : %s", e.getMessage()));
+         e.printStackTrace();
+      }
+   }
+}

--- a/spec/oas3.config.json
+++ b/spec/oas3.config.json
@@ -7,5 +7,6 @@
    "apiPackage": "com.equinix.openapi.metal.v1.api",
    "hideGenerationTimestamp": true,
    "disallowAdditionalPropertiesIfNotPresent": false,
-   "legacyDiscriminatorBehavior": true
+   "legacyDiscriminatorBehavior": true,
+   "templateDir": "/local/templates"
 }

--- a/templates/libraries/okhttp-gson/pojo.mustache
+++ b/templates/libraries/okhttp-gson/pojo.mustache
@@ -1,0 +1,671 @@
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import {{invokerPackage}}.JSON;
+
+/**
+ * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
+ * @deprecated{{/isDeprecated}}
+ */{{#isDeprecated}}
+@Deprecated{{/isDeprecated}}
+{{#swagger1AnnotationLibrary}}
+{{#description}}
+@ApiModel(description = "{{{.}}}")
+{{/description}}
+{{/swagger1AnnotationLibrary}}
+{{#swagger2AnnotationLibrary}}
+{{#description}}
+@Schema(description = "{{{.}}}")
+{{/description}}
+{{/swagger2AnnotationLibrary}}
+{{#jackson}}
+@JsonPropertyOrder({
+{{#vars}}
+  {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}
+{{/vars}}
+})
+{{#isClassnameSanitized}}
+@JsonTypeName("{{name}}")
+{{/isClassnameSanitized}}
+{{/jackson}}
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
+{{#vendorExtensions.x-class-extra-annotation}}
+{{{vendorExtensions.x-class-extra-annotation}}}
+{{/vendorExtensions.x-class-extra-annotation}}
+public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
+{{#serializableModel}}
+  private static final long serialVersionUID = 1L;
+
+{{/serializableModel}}
+  {{#vars}}
+    {{#isEnum}}
+    {{^isContainer}}
+{{>modelInnerEnum}}
+    {{/isContainer}}
+    {{#isContainer}}
+    {{#mostInnerItems}}
+{{>modelInnerEnum}}
+    {{/mostInnerItems}}
+    {{/isContainer}}
+    {{/isEnum}}
+  {{#gson}}
+  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/gson}}
+  {{#jackson}}
+  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/jackson}}
+  {{#withXml}}
+  {{#isXmlAttribute}}
+  @XmlAttribute(name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+  {{/isXmlAttribute}}
+  {{^isXmlAttribute}}
+    {{^isContainer}}
+  @XmlElement({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    {{/isContainer}}
+    {{#isContainer}}
+  // Is a container wrapped={{isXmlWrapped}}
+      {{#items}}
+  // items.name={{name}} items.baseName={{baseName}} items.xmlName={{xmlName}} items.xmlNamespace={{xmlNamespace}}
+  // items.example={{example}} items.type={{dataType}}
+  @XmlElement({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+      {{/items}}
+      {{#isXmlWrapped}}
+  @XmlElementWrapper({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+      {{/isXmlWrapped}}
+    {{/isContainer}}
+  {{/isXmlAttribute}}
+  {{/withXml}}
+  {{#gson}}
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
+  @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
+  {{/gson}}
+  {{#vendorExtensions.x-field-extra-annotation}}
+  {{{vendorExtensions.x-field-extra-annotation}}}
+  {{/vendorExtensions.x-field-extra-annotation}}
+  {{#vendorExtensions.x-is-jackson-optional-nullable}}
+  {{#isContainer}}
+  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined();
+  {{/isContainer}}
+  {{^isContainer}}
+  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+  {{/isContainer}}
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  {{^vendorExtensions.x-is-jackson-optional-nullable}}
+  {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+
+  {{/vars}}
+  public {{classname}}() {
+    {{#parent}}
+    {{#parcelableModel}}
+    super();
+    {{/parcelableModel}}
+    {{/parent}}
+    {{#gson}}
+    {{#discriminator}}
+    {{^discriminator.isEnum}}
+    this.{{{discriminatorName}}} = this.getClass().getSimpleName();
+    {{/discriminator.isEnum}}
+    {{/discriminator}}
+    {{/gson}}
+  }
+  {{#vendorExtensions.x-has-readonly-properties}}
+  {{^withXml}}
+
+  {{#jsonb}}@JsonbCreator{{/jsonb}}{{#jackson}}@JsonCreator{{/jackson}}
+  public {{classname}}(
+  {{#readOnlyVars}}
+    {{#jsonb}}@JsonbProperty("{{baseName}}"){{/jsonb}}{{#jackson}}@JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}}){{/jackson}} {{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}
+  {{/readOnlyVars}}
+  ) {
+    this();
+  {{#readOnlyVars}}
+    this.{{name}} = {{name}};
+  {{/readOnlyVars}}
+  }
+  {{/withXml}}
+  {{/vendorExtensions.x-has-readonly-properties}}
+  {{#vars}}
+
+  {{^isReadOnly}}
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
+  public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = {{name}};{{/vendorExtensions.x-is-jackson-optional-nullable}}
+    return this;
+  }
+  {{#isArray}}
+
+  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}});
+    }
+    try {
+      this.{{name}}.get().add({{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
+    }
+    this.{{name}}.add({{name}}Item);
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+  {{/isArray}}
+  {{#isMap}}
+
+  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}});
+    }
+    try {
+      this.{{name}}.get().put(key, {{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
+    }
+    this.{{name}}.put(key, {{name}}Item);
+    return this;
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+  {{/isMap}}
+
+  {{/isReadOnly}}
+   /**
+  {{#description}}
+   * {{.}}
+  {{/description}}
+  {{^description}}
+   * Get {{name}}
+  {{/description}}
+  {{#minimum}}
+   * minimum: {{.}}
+  {{/minimum}}
+  {{#maximum}}
+   * maximum: {{.}}
+  {{/maximum}}
+   * @return {{name}}
+   {{#deprecated}}
+   * @deprecated
+   {{/deprecated}}
+  **/
+{{#deprecated}}
+  @Deprecated
+{{/deprecated}}
+{{#required}}
+{{#isNullable}}
+  @{{javaxPackage}}.annotation.Nullable
+{{/isNullable}}
+{{^isNullable}}
+  @{{javaxPackage}}.annotation.Nonnull
+{{/isNullable}}
+{{/required}}
+{{^required}}
+  @{{javaxPackage}}.annotation.Nullable
+{{/required}}
+{{#jsonb}}
+  @JsonbProperty("{{baseName}}")
+{{/jsonb}}
+{{#useBeanValidation}}
+{{>beanValidation}}
+{{/useBeanValidation}}
+{{#swagger1AnnotationLibrary}}
+  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{/swagger1AnnotationLibrary}}
+{{#swagger2AnnotationLibrary}}
+  @Schema({{#example}}example = "{{{.}}}", {{/example}}requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}}, description = "{{{description}}}")
+{{/swagger2AnnotationLibrary}}
+{{#vendorExtensions.x-extra-annotation}}
+  {{{vendorExtensions.x-extra-annotation}}}
+{{/vendorExtensions.x-extra-annotation}}
+{{#vendorExtensions.x-is-jackson-optional-nullable}}
+  {{!unannotated, Jackson would pick this up automatically and add it *in addition* to the _JsonNullable getter field}}
+  @JsonIgnore
+{{/vendorExtensions.x-is-jackson-optional-nullable}}
+{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.x-is-jackson-optional-nullable}}  public {{{datatypeWithEnum}}} {{getter}}() {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    {{#isReadOnly}}{{! A readonly attribute doesn't have setter => jackson will set null directly if explicitly returned by API, so make sure we have an empty JsonNullable}}
+    if ({{name}} == null) {
+      {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+    }
+    {{/isReadOnly}}
+    return {{name}}.orElse(null);
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    return {{name}};
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+
+  {{#vendorExtensions.x-is-jackson-optional-nullable}}
+{{> jackson_annotations}}
+  public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
+    return {{name}};
+  }
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}{{#vendorExtensions.x-is-jackson-optional-nullable}}
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  {{#isReadOnly}}private{{/isReadOnly}}{{^isReadOnly}}public{{/isReadOnly}} void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
+    {{! For getters/setters that have name differing from attribute name, we must include setter (albeit private) for jackson to be able to set the attribute}}
+    this.{{name}} = {{name}};
+  }
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+
+  {{^isReadOnly}}
+{{#vendorExtensions.x-setter-extra-annotation}}  {{{vendorExtensions.x-setter-extra-annotation}}}
+{{/vendorExtensions.x-setter-extra-annotation}}{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}{{#deprecated}}  @Deprecated
+{{/deprecated}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+    this.{{name}} = {{name}};
+    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  }
+  {{/isReadOnly}}
+
+  {{/vars}}
+{{>libraries/okhttp-gson/additional_properties}}
+
+  @Override
+  public boolean equals(Object o) {
+  {{#useReflectionEqualsHashCode}}
+    return EqualsBuilder.reflectionEquals(this, o, false, null, true);
+  {{/useReflectionEqualsHashCode}}
+  {{^useReflectionEqualsHashCode}}
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
+        {{/-last}}{{/vars}}{{#isAdditionalPropertiesTrue}}&&
+        Objects.equals(this.additionalProperties, {{classVarName}}.additionalProperties){{/isAdditionalPropertiesTrue}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
+  {{/useReflectionEqualsHashCode}}
+  }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  @Override
+  public int hashCode() {
+  {{#useReflectionEqualsHashCode}}
+    return HashCodeBuilder.reflectionHashCode(this);
+  {{/useReflectionEqualsHashCode}}
+  {{^useReflectionEqualsHashCode}}
+    return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}}{{#isAdditionalPropertiesTrue}}{{#hasVars}}, {{/hasVars}}{{^hasVars}}{{#parent}}, {{/parent}}{{/hasVars}}additionalProperties{{/isAdditionalPropertiesTrue}});
+  {{/useReflectionEqualsHashCode}}
+  }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+  }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class {{classname}} {\n");
+    {{#parent}}
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    {{/parent}}
+    {{#vars}}
+    sb.append("    {{name}}: ").append(toIndentedString({{name}})).append("\n");
+    {{/vars}}
+{{#isAdditionalPropertiesTrue}}
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
+{{/isAdditionalPropertiesTrue}}
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private{{#jsonb}} static{{/jsonb}} String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+{{#parcelableModel}}
+
+  public void writeToParcel(Parcel out, int flags) {
+{{#model}}
+{{#isArray}}
+    out.writeList(this);
+{{/isArray}}
+{{^isArray}}
+{{#parent}}
+    super.writeToParcel(out, flags);
+{{/parent}}
+{{#vars}}
+    out.writeValue({{name}});
+{{/vars}}
+{{/isArray}}
+{{/model}}
+  }
+
+  {{classname}}(Parcel in) {
+{{#isArray}}
+    in.readTypedList(this, {{arrayModelType}}.CREATOR);
+{{/isArray}}
+{{^isArray}}
+{{#parent}}
+    super(in);
+{{/parent}}
+{{#vars}}
+{{#isPrimitiveType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue(null);
+{{/isPrimitiveType}}
+{{^isPrimitiveType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue({{complexType}}.class.getClassLoader());
+{{/isPrimitiveType}}
+{{/vars}}
+{{/isArray}}
+  }
+
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
+    public {{classname}} createFromParcel(Parcel in) {
+{{#model}}
+{{#isArray}}
+      {{classname}} result = new {{classname}}();
+      result.addAll(in.readArrayList({{arrayModelType}}.class.getClassLoader()));
+      return result;
+{{/isArray}}
+{{^isArray}}
+      return new {{classname}}(in);
+{{/isArray}}
+{{/model}}
+    }
+    public {{classname}}[] newArray(int size) {
+      return new {{classname}}[size];
+    }
+  };
+{{/parcelableModel}}
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    {{#allVars}}
+    openapiFields.add("{{baseName}}");
+    {{/allVars}}
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+    {{#requiredVars}}
+    openapiRequiredFields.add("{{baseName}}");
+    {{/requiredVars}}
+  }
+
+ /**
+  * Validates the JSON Element and throws an exception if issues found
+  *
+  * @param jsonElement JSON Element
+  * @throws IOException if the JSON Element is invalid with respect to {{classname}}
+  */
+  public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      if (jsonElement == null) {
+        if (!{{classname}}.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in {{{classname}}} is not found in the empty JSON string", {{classname}}.openapiRequiredFields.toString()));
+        }
+      }
+      {{^hasChildren}}
+      {{^isAdditionalPropertiesTrue}}
+
+      Set<Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!{{classname}}.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `{{classname}}` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
+        }
+      }
+      {{/isAdditionalPropertiesTrue}}
+      {{#requiredVars}}
+      {{#-first}}
+
+      // check to make sure all required properties/fields are present in the JSON string
+      for (String requiredField : {{classname}}.openapiRequiredFields) {
+        if (jsonElement.getAsJsonObject().get(requiredField) == null) {
+          throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonElement.toString()));
+        }
+      }
+      {{/-first}}
+      {{/requiredVars}}
+      {{/hasChildren}}
+      {{^discriminator}}
+      {{#hasVars}}
+        JsonObject jsonObj = jsonElement.getAsJsonObject();
+      {{/hasVars}}
+      {{#vars}}
+      {{#isArray}}
+      {{#items.isModel}}
+      {{#required}}
+      // ensure the json data is an array
+      if (!jsonObj.get("{{{baseName}}}").isJsonArray()) {
+        throw new IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj.get("{{{baseName}}}").toString()));
+      }
+
+      JsonArray jsonArray{{name}} = jsonObj.getAsJsonArray("{{{baseName}}}");
+      // validate the required field `{{{baseName}}}` (array)
+      for (int i = 0; i < jsonArray{{name}}.size(); i++) {
+        {{{items.dataType}}}.validateJsonElement(jsonArray{{name}}.get(i));
+      };
+      {{/required}}
+      {{^required}}
+      if (jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull()) {
+        JsonArray jsonArray{{name}} = jsonObj.getAsJsonArray("{{{baseName}}}");
+        if (jsonArray{{name}} != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("{{{baseName}}}").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj.get("{{{baseName}}}").toString()));
+          }
+
+          // validate the optional field `{{{baseName}}}` (array)
+          for (int i = 0; i < jsonArray{{name}}.size(); i++) {
+            {{{items.dataType}}}.validateJsonElement(jsonArray{{name}}.get(i));
+          };
+        }
+      }
+      {{/required}}
+      {{/items.isModel}}
+      {{^items.isModel}}
+      {{^required}}
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull() && !jsonObj.get("{{{baseName}}}").isJsonArray()) {
+        throw new IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj.get("{{{baseName}}}").toString()));
+      }
+      {{/required}}
+      {{#required}}
+      // ensure the required json array is present
+      if (jsonObj.get("{{{baseName}}}") == null) {
+        throw new IllegalArgumentException("Expected the field `linkedContent` to be an array in the JSON string but got `null`");
+      } else if (!jsonObj.get("{{{baseName}}}").isJsonArray()) {
+        throw new IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be an array in the JSON string but got `%s`", jsonObj.get("{{{baseName}}}").toString()));
+      }
+      {{/required}}
+      {{/items.isModel}}
+      {{/isArray}}
+      {{^isContainer}}
+      {{#isString}}
+      if ({{#notRequiredOrIsNullable}}(jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull()) && {{/notRequiredOrIsNullable}}!jsonObj.get("{{{baseName}}}").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field `{{{baseName}}}` to be a primitive type in the JSON string but got `%s`", jsonObj.get("{{{baseName}}}").toString()));
+      }
+      {{/isString}}
+      {{#isModel}}
+      {{#required}}
+      // validate the required field `{{{baseName}}}`
+      {{{dataType}}}.validateJsonElement(jsonObj.get("{{{baseName}}}"));
+      {{/required}}
+      {{^required}}
+      // validate the optional field `{{{baseName}}}`
+      if (jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull()) {
+        {{{dataType}}}.validateJsonElement(jsonObj.get("{{{baseName}}}"));
+      }
+      {{/required}}
+      {{/isModel}}
+      {{/isContainer}}
+      {{/vars}}
+      {{/discriminator}}
+      {{#hasChildren}}
+      {{#discriminator}}
+
+      String discriminatorValue = jsonElement.getAsJsonObject().get("{{{propertyBaseName}}}").getAsString();
+      switch (discriminatorValue) {
+      {{#mappedModels}}
+        case "{{mappingName}}":
+          {{modelName}}.validateJsonElement(jsonElement);
+          break;
+      {{/mappedModels}}
+        default:
+          throw new IllegalArgumentException(String.format("The value of the `{{{propertyBaseName}}}` field `%s` does not match any key defined in the discriminator's mapping.", discriminatorValue));
+      }
+      {{/discriminator}}
+      {{/hasChildren}}
+  }
+
+{{^hasChildren}}
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!{{classname}}.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes '{{classname}}' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<{{classname}}> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get({{classname}}.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<{{classname}}>() {
+           @Override
+           public void write(JsonWriter out, {{classname}} value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             {{#isAdditionalPropertiesTrue}}
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
+             {{/isAdditionalPropertiesTrue}}
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public {{classname}} read(JsonReader in) throws IOException {
+             JsonElement jsonElement = elementAdapter.read(in);
+             validateJsonElement(jsonElement);
+             {{#isAdditionalPropertiesTrue}}
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             {{classname}} instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
+             {{/isAdditionalPropertiesTrue}}
+             {{^isAdditionalPropertiesTrue}}
+             return thisAdapter.fromJsonTree(jsonElement);
+             {{/isAdditionalPropertiesTrue}}
+           }
+
+       }.nullSafe();
+    }
+  }
+{{/hasChildren}}
+
+ /**
+  * Create an instance of {{classname}} given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of {{classname}}
+  * @throws IOException if the JSON string is invalid with respect to {{classname}}
+  */
+  public static {{{classname}}} fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, {{{classname}}}.class);
+  }
+
+ /**
+  * Convert an instance of {{classname}} to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+}

--- a/templates/libraries/okhttp-gson/pojo.mustache
+++ b/templates/libraries/okhttp-gson/pojo.mustache
@@ -553,6 +553,30 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
       }
       {{/required}}
       {{/isModel}}
+      {{#isEnum}}
+      {{#required}}
+      // validate the required field `{{{baseName}}}`
+      {{{datatypeWithEnum}}}.validateJsonElement(jsonObj.get("{{{baseName}}}"));
+      {{/required}}
+      {{^required}}
+      // validate the optional field `{{{baseName}}}`
+      if (jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull()) {
+        {{{datatypeWithEnum}}}.validateJsonElement(jsonObj.get("{{{baseName}}}"));
+      }
+      {{/required}}
+      {{/isEnum}}
+      {{#isEnumRef}}
+      {{#required}}
+      // validate the required field `{{{baseName}}}`
+      {{{dataType}}}.validateJsonElement(jsonObj.get("{{{baseName}}}"));
+      {{/required}}
+      {{^required}}
+      // validate the optional field `{{{baseName}}}`
+      if (jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull()) {
+        {{{dataType}}}.validateJsonElement(jsonObj.get("{{{baseName}}}"));
+      }
+      {{/required}}
+      {{/isEnumRef}}
       {{/isContainer}}
       {{/vars}}
       {{/discriminator}}

--- a/templates/modelEnum.mustache
+++ b/templates/modelEnum.mustache
@@ -1,0 +1,117 @@
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+{{/jackson}}
+{{#gson}}
+import java.io.IOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+{{/gson}}
+
+/**
+ * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+ */
+{{#gson}}
+@JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}
+{{#jsonb}}
+@JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
+@JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
+{{/jsonb}}
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#allowableValues}}{{#enumVars}}
+    {{#enumDescription}}
+  /**
+   * {{.}}
+   */
+     {{/enumDescription}}
+  {{#withXml}}
+  @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  {{/withXml}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private {{{dataType}}} value;
+
+  {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+{{#jackson}}
+  @JsonValue
+{{/jackson}}
+  public {{{dataType}}} getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+{{#jackson}}
+  @JsonCreator
+{{/jackson}}
+  public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+    for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+      if (b.value.{{^isString}}equals{{/isString}}{{#isString}}{{#useEnumCaseInsensitive}}equalsIgnoreCase{{/useEnumCaseInsensitive}}{{^useEnumCaseInsensitive}}equals{{/useEnumCaseInsensitive}}{{/isString}}(value)) {
+        return b;
+      }
+    }
+    {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}{{#allowableValues}}{{#enumVars}}{{#-last}}return {{{name}}};{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/enumUnknownDefaultCase}}{{/isNullable}}
+  }
+{{#gson}}
+
+  public static class Adapter extends TypeAdapter<{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}> {
+    @Override
+    public void write(final JsonWriter jsonWriter, final {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} enumeration) throws IOException {
+      jsonWriter.value(enumeration.getValue());
+    }
+
+    @Override
+    public {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
+      {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}next{{{dataType}}}(){{/isInteger}}{{/isNumber}};
+      return {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+    }
+  }
+{{/gson}}
+{{#jsonb}}
+
+  public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {
+    @Override
+    public {{datatypeWithEnum}} deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+      for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        if (String.valueOf(b.value).equals(parser.getString())) {
+          return b;
+        }
+      }
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + parser.getString() + "'");{{/useNullForUnknownEnumValue}}
+    }
+  }
+
+  public static final class Serializer implements JsonbSerializer<{{datatypeWithEnum}}> {
+    @Override
+    public void serialize({{datatypeWithEnum}} obj, JsonGenerator generator, SerializationContext ctx) {
+      generator.write(obj.value);
+    }
+  }
+{{/jsonb}}
+{{#supportUrlQuery}}
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @param prefix prefix of the query string
+   * @return URL query string
+   */
+  public String toUrlQueryString(String prefix) {
+    if (prefix == null) {
+      prefix = "";
+    }
+
+    return String.format("%s=%s", prefix, this.toString());
+  }
+{{/supportUrlQuery}}
+}

--- a/templates/modelEnum.mustache
+++ b/templates/modelEnum.mustache
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 {{#gson}}
 import java.io.IOException;
 import com.google.gson.TypeAdapter;
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -75,6 +76,11 @@ import com.google.gson.stream.JsonWriter;
       {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}next{{{dataType}}}(){{/isInteger}}{{/isNumber}};
       return {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
     }
+  }
+
+  public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+    {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}getAs{{{dataType}}}(){{/isInteger}}{{/isNumber}};
+    {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
   }
 {{/gson}}
 {{#jsonb}}

--- a/templates/modelInnerEnum.mustache
+++ b/templates/modelInnerEnum.mustache
@@ -1,0 +1,95 @@
+  /**
+   * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+   */
+{{#gson}}
+  @JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}
+{{#jsonb}}
+  @JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
+  @JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
+{{/jsonb}}
+{{#withXml}}
+  @XmlType(name="{{datatypeWithEnum}}")
+  @XmlEnum({{dataType}}.class)
+{{/withXml}}
+  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+    {{#allowableValues}}
+      {{#enumVars}}
+    {{#enumDescription}}
+    /**
+     * {{.}}
+     */
+    {{/enumDescription}}
+    {{#withXml}}
+    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    {{/withXml}}
+    {{{name}}}({{{value}}}){{^-last}},
+    {{/-last}}{{#-last}};{{/-last}}
+      {{/enumVars}}
+    {{/allowableValues}}
+
+    private {{{dataType}}} value;
+
+    {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+      this.value = value;
+    }
+
+{{#jackson}}
+    @JsonValue
+{{/jackson}}
+    public {{{dataType}}} getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+{{#jackson}}
+    @JsonCreator
+{{/jackson}}
+    public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+      for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        if (b.value.{{^isString}}equals{{/isString}}{{#isString}}{{#useEnumCaseInsensitive}}equalsIgnoreCase{{/useEnumCaseInsensitive}}{{^useEnumCaseInsensitive}}equals{{/useEnumCaseInsensitive}}{{/isString}}(value)) {
+          return b;
+        }
+      }
+      {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}{{#allowableValues}}{{#enumVars}}{{#-last}}return {{{name}}};{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/enumUnknownDefaultCase}}{{/isNullable}}
+    }
+{{#gson}}
+
+    public static class Adapter extends TypeAdapter<{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
+        {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isFloat}}(float){{/isFloat}} jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}{{#isFloat}}nextDouble{{/isFloat}}{{^isFloat}}next{{{dataType}}}{{/isFloat}}(){{/isInteger}}{{/isNumber}};
+        return {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+      }
+    }
+{{/gson}}
+{{#jsonb}}
+    public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {
+      @Override
+      public {{datatypeWithEnum}} deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+        for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+          if (String.valueOf(b.value).equals(parser.getString())) {
+            return b;
+          }
+        }
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + parser.getString() + "'");{{/useNullForUnknownEnumValue}}
+      }
+    }
+
+    public static final class Serializer implements JsonbSerializer<{{datatypeWithEnum}}> {
+      @Override
+      public void serialize({{datatypeWithEnum}} obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.write(obj.value);
+      }
+    }
+{{/jsonb}}
+  }

--- a/templates/modelInnerEnum.mustache
+++ b/templates/modelInnerEnum.mustache
@@ -71,6 +71,11 @@
         return {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
       }
     }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}getAs{{{dataType}}}(){{/isInteger}}{{/isNumber}};
+      {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+    }
 {{/gson}}
 {{#jsonb}}
     public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {


### PR DESCRIPTION
The Java generator for `openapi-generator` completely skips over enum validation in the `validateJsonElement` function that is generated for each model class.  As a result, enum values are validated inconsistently; if I have a model `X` that has a property that is an enum, the enum values will be validated if I am deserializing a JSON blob in which the top-level object is an instance of `X`, but the enum values will _not_ be validated if I am deserializing a JSON blob that has an instance of `X` nested in it.

```js
// Let's say I have a schema component `X` that has a `this_is_an` property that is a string and a `status` property that is an enum of `"active"` or `"failed"`.
// Given that component, the below is not a valid `X` and would cause an error in metal-java <= v0.10.0
{
   "this_is_an": "X",
   "status": "not-a-status"
}

// The below is an object that has a property, `x_list` that is a list of `X` instances.  The `X` in this case is still not valid, but this would not cause an error in metal-java <= v0.10.0
{
  "x_list": [{
     "this_is_an": "X",
     "status": "not-a-status"
  }]
}
```

This PR introduces custom templates so that we can add enum validation to `validateJsonElement` and ensure that enum values are validated even for nested models.

We needed to modify two templates:
- `libraries/okhttp-gson/pojo.mustache` had to be updated to generate code that validates model properties that are enums
- `modelEnum.mustache` and `modelInnerEnum.mustache` had to be updated to generate a `validateJsonElement` function for all enums

Template changes happen in this commit: ddc37db375e481dfd1b2c317d30886dbc684a419
Code is updated by the bot in this commit: b0f102aa2cfc4083cf3195688fca9964b4a1181e

This PR also includes an `example` that I used to replicate the validation issue and confirm that my tests fixed it; I intended to remove it before merge, since it's really not an example of how the SDK should be used, but I'm open to keeping it.  In the meantime, at least, this PR can be poked at by checking it out locally and running these commands in the project root:

```sh
# if you check out the first commit on this PR, you will need to regenerate the code so the example uses the old code
make generate
# recompile the code so that the example is using the code that was generated above
make build_client
# tell Java where to find the compiled code
export ExampleClassPath="equinix-openapi-metal/target/equinix-openapi-metal-0.10.0.jar:equinix-openapi-metal/target/lib/*"
# run the example (doesn't hit an API, so doesn't need a token)
java -classpath $ExampleClassPath examples/VirtualCircuit.java
```